### PR TITLE
Close file descriptors for temporary files after creating them with mkstemp().

### DIFF
--- a/MACS2/IO/CallPeakUnit.pyx
+++ b/MACS2/IO/CallPeakUnit.pyx
@@ -467,9 +467,13 @@ cdef class CallerFromAlignments:
                 f.close()
                 return
             except IOError:
-                self.pileup_data_files[ chrom ] = mkstemp()[1]                
+                temp_fd, temp_filename = mkstemp()
+                os.close(temp_fd)
+                self.pileup_data_files[ chrom ] = temp_filename
         else:
-            self.pileup_data_files[ chrom ] = mkstemp()[1]
+            temp_fd, temp_filename = mkstemp()
+            os.close(temp_fd)
+            self.pileup_data_files[ chrom ] = temp_filename
 
         # reset or clean existing self.chr_pos_treat_ctrl
         if self.chr_pos_treat_ctrl:     # not a beautiful way to clean


### PR DESCRIPTION
Close file descriptors for temporary files after creating them with mkstemp()
to avoid leaking file descriptors and running out of file descriptors or
hitting the limit or the number of file descriptors that you are allowed to
open, which can happen when you have a lot of chromosomes or scaffolds in
your input files.