### PR TITLE
add option to specify tempdir from commandline

### DIFF
--- a/MACS2/callpeak_cmd.py
+++ b/MACS2/callpeak_cmd.py
@@ -23,6 +23,7 @@ import os
 import sys
 import logging
 from time import strftime
+import tempfile
 
 # ------------------------------------
 # own python modules
@@ -63,7 +64,9 @@ def run( args ):
     options.PE_MODE = options.format in ('BAMPE',)
     if options.PE_MODE: tag = 'fragment' # call things fragments not tags
     else: tag = 'tag'
-    
+
+    tempfile.tempdir = options.tempdir
+
     #1 Read tag files
     info("#1 read %s files...", tag)
     if options.PE_MODE: (treat, control) = load_frag_files_options (options)

--- a/bin/macs2
+++ b/bin/macs2
@@ -23,6 +23,7 @@ the distribution).
 import os
 import sys
 import argparse as ap
+import tempfile
 
 # ------------------------------------
 # own python modules
@@ -252,6 +253,8 @@ def add_callpeak_parser( subparsers ):
                                  help = "When set, random sampling method will scale down the bigger sample. By default, MACS uses linear scaling. Warning: This option will make your result unstable and irreproducible since each time, random reads would be selected. Consider to use 'randsample' script instead. <not implmented>If used together with --SPMR, 1 million unique reads will be randomly picked.</not implemented> Caution: due to the implementation, the final number of selected reads may not be as you expected! DEFAULT: False" )
     group_callpeak.add_argument( "--seed", dest = "seed", type = int, default = -1, 
                                  help = "Set the random seed while down sampling data. Must be a non-negative integer in order to be effective. DEFAULT: not set" )
+    group_callpeak.add_argument( "--tempdir", dest="tempdir", default=tempfile.gettempdir(),
+                                help = "Optional directory to store temp files. DEFAULT: %(default)s")
     group_callpeak.add_argument( "--nolambda", dest = "nolambda", action = "store_true",
                                  help = "If True, MACS will use fixed background lambda as local lambda for every peak region. Normally, MACS calculates a dynamic local lambda to reflect the local bias due to potential chromatin structure. ",
                                  default = False )


### PR DESCRIPTION
I was getting an intermittent EOFile errors when running `macs2 callpeak` on our cluster.

I think it was caused by `/tmp` being full on a shared node when trying to [create pileup tempfiles in `IO.CallPeakUnit`](https://github.com/taoliu/MACS/blob/master/MACS2/IO/CallPeakUnit.pyx#L465).

Anyway, this PR lets you specify the tempdir from the commandline. In my case specifying a different tempdir seems to have fixed the problem.