### PR TITLE
Add compatibility check for -Ofast compiler option

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,25 @@ the distribution).
 import os
 import sys
 from setuptools import setup, Extension
+from distutils.command.build_ext import build_ext
+import subprocess
 
-# Use build_ext from Cython if found
-command_classes = {}
+
+# Check compatibility of -Ofast option
+# For GCC, if >= 4.6, use -Ofast, otherwise -O3.
+class build_ext_subclass(build_ext):
+    def build_extensions(self):
+        extra_compile_args = ['-w', '-Ofast']
+        cmd = "echo | %s -E - %s &>/dev/null" % (
+            self.compiler.compiler[0], " ".join(extra_compile_args))
+        try:
+            subprocess.check_call(cmd, shell=True)
+        except:
+            extra_compile_args = ['-w', '-O3']
+        for e in self.extensions:
+            e.extra_compile_args = extra_compile_args
+        build_ext.build_extensions(self)
+
 
 try: 
     from numpy import get_include as numpy_get_include 
@@ -37,23 +53,22 @@ def main():
         sys.stderr.write("CRITICAL: Python version must be 2.7!\n")
         sys.exit(1)
 
-    # User must check GCC, if >= 4.6, use -Ofast, otherwise -O3.
 
-    ext_modules = [Extension("MACS2.Prob", ["MACS2/Prob.c"], libraries=["m"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                   Extension("MACS2.IO.Parser",["MACS2/IO/Parser.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.Pileup", ["MACS2/Pileup.c","MACS2/cPosValCalculation.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                   Extension("MACS2.PeakModel", ["MACS2/PeakModel.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.PeakDetect", ["MACS2/PeakDetect.c"], extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.Signal", ["MACS2/Signal.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.IO.PeakIO", ["MACS2/IO/PeakIO.c"], extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.IO.BedGraphIO", ["MACS2/IO/BedGraphIO.c"], extra_compile_args=["-w","-Ofast"]),                   
-                   Extension("MACS2.IO.FixWidthTrack", ["MACS2/IO/FixWidthTrack.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.IO.PairedEndTrack", ["MACS2/IO/PairedEndTrack.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.IO.BedGraph", ["MACS2/IO/BedGraph.c"], libraries=["m"], extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.IO.ScoreTrack", ["MACS2/IO/ScoreTrack.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                   Extension("MACS2.IO.CallPeakUnit", ["MACS2/IO/CallPeakUnit.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.hashtable", ["MACS2/hashtable.c"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=["-w","-Ofast"]),
-                   Extension("MACS2.Statistics", ["MACS2/Statistics.c", "MACS2/cStatistics.c"], libraries=["m"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=["-w","-Ofast"]),
+    ext_modules = [Extension("MACS2.Prob", ["MACS2/Prob.c"], libraries=["m"], include_dirs=numpy_include_dir ),
+                   Extension("MACS2.IO.Parser",["MACS2/IO/Parser.c"], include_dirs=numpy_include_dir),
+                   Extension("MACS2.Pileup", ["MACS2/Pileup.c","MACS2/cPosValCalculation.c"], include_dirs=numpy_include_dir ),
+                   Extension("MACS2.PeakModel", ["MACS2/PeakModel.c"], include_dirs=numpy_include_dir),
+                   Extension("MACS2.PeakDetect", ["MACS2/PeakDetect.c"]),
+                   Extension("MACS2.Signal", ["MACS2/Signal.c"], include_dirs=numpy_include_dir),
+                   Extension("MACS2.IO.PeakIO", ["MACS2/IO/PeakIO.c"]),
+                   Extension("MACS2.IO.BedGraphIO", ["MACS2/IO/BedGraphIO.c"]),                   
+                   Extension("MACS2.IO.FixWidthTrack", ["MACS2/IO/FixWidthTrack.c"], include_dirs=numpy_include_dir),
+                   Extension("MACS2.IO.PairedEndTrack", ["MACS2/IO/PairedEndTrack.c"], include_dirs=numpy_include_dir),
+                   Extension("MACS2.IO.BedGraph", ["MACS2/IO/BedGraph.c"], libraries=["m"]),
+                   Extension("MACS2.IO.ScoreTrack", ["MACS2/IO/ScoreTrack.c"], include_dirs=numpy_include_dir ),
+                   Extension("MACS2.IO.CallPeakUnit", ["MACS2/IO/CallPeakUnit.c"], include_dirs=numpy_include_dir),
+                   Extension("MACS2.hashtable", ["MACS2/hashtable.c"], include_dirs=["MACS2/",numpy_get_include()]),
+                   Extension("MACS2.Statistics", ["MACS2/Statistics.c", "MACS2/cStatistics.c"], libraries=["m"], include_dirs=["MACS2/",numpy_get_include()]),
                    ]
     
     setup(name="MACS2",
@@ -82,7 +97,7 @@ def main():
               'numpy>=1.6',
               #'scipy',
               ],
-          cmdclass = command_classes,
+          cmdclass={'build_ext': build_ext_subclass},
           ext_modules = ext_modules
           )
 

--- a/setup_w_cython.py
+++ b/setup_w_cython.py
@@ -22,6 +22,8 @@ the distribution).
 import os
 import sys
 from setuptools import setup, Extension
+import subprocess
+
 
 # Use build_ext from Cython if found
 command_classes = {}
@@ -29,8 +31,28 @@ try:
     import Cython.Distutils
     command_classes['build_ext'] = Cython.Distutils.build_ext
     has_cython = True
+
 except:
+    import distutils
     has_cython = False
+    command_classes['build_ext'] = distutils.build_ext
+
+
+# Check compatibility of -Ofast option
+# For GCC, if >= 4.6, use -Ofast, otherwise -O3.
+class build_ext_subclass(command_classes['build_ext']):
+    def build_extensions(self):
+        extra_compile_args = ['-w', '-Ofast']
+        cmd = "echo | %s -E - %s &>/dev/null" % (
+            self.compiler.compiler[0], " ".join(extra_compile_args))
+        try:
+            subprocess.check_call(cmd, shell=True)
+        except:
+            extra_compile_args = ['-w', '-O3']
+        for e in self.extensions:
+            e.extra_compile_args = extra_compile_args
+        command_classes['build_ext'].build_extensions(self)
+
 
 try: 
     from numpy import get_include as numpy_get_include 
@@ -45,38 +67,38 @@ def main():
         sys.exit(1)
 
     if has_cython:
-        ext_modules = [Extension("MACS2.Prob", ["MACS2/Prob.pyx"], libraries=["m"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                       Extension("MACS2.IO.Parser",["MACS2/IO/Parser.pyx"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.Pileup", ["MACS2/Pileup.pyx","MACS2/cPosValCalculation.pxd","MACS2/cPosValCalculation.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                       Extension("MACS2.PeakModel", ["MACS2/PeakModel.pyx"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.PeakDetect", ["MACS2/PeakDetect.pyx"], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.Signal", ["MACS2/Signal.pyx"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.PeakIO", ["MACS2/IO/PeakIO.pyx"], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.BedGraphIO", ["MACS2/IO/BedGraphIO.pyx"], extra_compile_args=["-w","-Ofast"]),                   
-                       Extension("MACS2.IO.FixWidthTrack", ["MACS2/IO/FixWidthTrack.pyx"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.PairedEndTrack", ["MACS2/IO/PairedEndTrack.pyx"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.BedGraph", ["MACS2/IO/BedGraph.pyx"], libraries=["m"], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.ScoreTrack", ["MACS2/IO/ScoreTrack.pyx"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                       Extension("MACS2.IO.CallPeakUnit", ["MACS2/IO/CallPeakUnit.pyx"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.hashtable", ["MACS2/hashtable.pyx"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.Statistics", ["MACS2/Statistics.pyx", "MACS2/cStatistics.c"], libraries=["m"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=["-w","-Ofast"]),
+        ext_modules = [Extension("MACS2.Prob", ["MACS2/Prob.pyx"], libraries=["m"], include_dirs=numpy_include_dir ),
+                       Extension("MACS2.IO.Parser",["MACS2/IO/Parser.pyx"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.Pileup", ["MACS2/Pileup.pyx","MACS2/cPosValCalculation.pxd","MACS2/cPosValCalculation.c"], include_dirs=numpy_include_dir ),
+                       Extension("MACS2.PeakModel", ["MACS2/PeakModel.pyx"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.PeakDetect", ["MACS2/PeakDetect.pyx"]),
+                       Extension("MACS2.Signal", ["MACS2/Signal.pyx"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.IO.PeakIO", ["MACS2/IO/PeakIO.pyx"]),
+                       Extension("MACS2.IO.BedGraphIO", ["MACS2/IO/BedGraphIO.pyx"]),                   
+                       Extension("MACS2.IO.FixWidthTrack", ["MACS2/IO/FixWidthTrack.pyx"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.IO.PairedEndTrack", ["MACS2/IO/PairedEndTrack.pyx"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.IO.BedGraph", ["MACS2/IO/BedGraph.pyx"], libraries=["m"]),
+                       Extension("MACS2.IO.ScoreTrack", ["MACS2/IO/ScoreTrack.pyx"], include_dirs=numpy_include_dir ),
+                       Extension("MACS2.IO.CallPeakUnit", ["MACS2/IO/CallPeakUnit.pyx"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.hashtable", ["MACS2/hashtable.pyx"], include_dirs=["MACS2/",numpy_get_include()]),
+                       Extension("MACS2.Statistics", ["MACS2/Statistics.pyx", "MACS2/cStatistics.c"], libraries=["m"], include_dirs=["MACS2/",numpy_get_include()]),
                        ]
     else:
-        ext_modules = [Extension("MACS2.Prob", ["MACS2/Prob.c"], libraries=["m"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                       Extension("MACS2.IO.Parser",["MACS2/IO/Parser.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.Pileup", ["MACS2/Pileup.c","MACS2/cPosValCalculation.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                       Extension("MACS2.PeakModel", ["MACS2/PeakModel.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.PeakDetect", ["MACS2/PeakDetect.c"], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.Signal", ["MACS2/Signal.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.PeakIO", ["MACS2/IO/PeakIO.c"], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.BedGraphIO", ["MACS2/IO/BedGraphIO.c"], extra_compile_args=["-w","-Ofast"]),                   
-                       Extension("MACS2.IO.FixWidthTrack", ["MACS2/IO/FixWidthTrack.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.PairedEndTrack", ["MACS2/IO/PairedEndTrack.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.BedGraph", ["MACS2/IO/BedGraph.c"], libraries=["m"], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.IO.ScoreTrack", ["MACS2/IO/ScoreTrack.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"] ),
-                       Extension("MACS2.IO.CallPeakUnit", ["MACS2/IO/CallPeakUnit.c"], include_dirs=numpy_include_dir, extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.hashtable", ["MACS2/hashtable.c"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=["-w","-Ofast"]),
-                       Extension("MACS2.Statistics", ["MACS2/Statistics.c", "MACS2/cStatistics.c"], libraries=["m"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=["-w","-Ofast"]),
+        ext_modules = [Extension("MACS2.Prob", ["MACS2/Prob.c"], libraries=["m"], include_dirs=numpy_include_dir ),
+                       Extension("MACS2.IO.Parser",["MACS2/IO/Parser.c"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.Pileup", ["MACS2/Pileup.c","MACS2/cPosValCalculation.c"], include_dirs=numpy_include_dir ),
+                       Extension("MACS2.PeakModel", ["MACS2/PeakModel.c"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.PeakDetect", ["MACS2/PeakDetect.c"]),
+                       Extension("MACS2.Signal", ["MACS2/Signal.c"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.IO.PeakIO", ["MACS2/IO/PeakIO.c"]),
+                       Extension("MACS2.IO.BedGraphIO", ["MACS2/IO/BedGraphIO.c"]),                   
+                       Extension("MACS2.IO.FixWidthTrack", ["MACS2/IO/FixWidthTrack.c"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.IO.PairedEndTrack", ["MACS2/IO/PairedEndTrack.c"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.IO.BedGraph", ["MACS2/IO/BedGraph.c"], libraries=["m"]),
+                       Extension("MACS2.IO.ScoreTrack", ["MACS2/IO/ScoreTrack.c"], include_dirs=numpy_include_dir ),
+                       Extension("MACS2.IO.CallPeakUnit", ["MACS2/IO/CallPeakUnit.c"], include_dirs=numpy_include_dir),
+                       Extension("MACS2.hashtable", ["MACS2/hashtable.c"], include_dirs=["MACS2/",numpy_get_include()]),
+                       Extension("MACS2.Statistics", ["MACS2/Statistics.c", "MACS2/cStatistics.c"], libraries=["m"], include_dirs=["MACS2/",numpy_get_include()]),
                        ]
 
     setup(name="MACS2",
@@ -106,7 +128,8 @@ def main():
               'cython>=0.18',
               #'scipy',
               ],
-          cmdclass = command_classes,
+          # cmdclass = command_classes,
+          cmdclass={'build_ext': build_ext_subclass},
           ext_modules = ext_modules
           )
 


### PR DESCRIPTION
Check that the -Ofast option works, and if not, resort to the older -O3
option. Addresses issues #75 and #91.