### PR TITLE
add missing BEDPE to OptParser validator

### DIFF
--- a/MACS2/OptValidator.py
+++ b/MACS2/OptValidator.py
@@ -362,6 +362,8 @@ def opt_validate_filterdup ( options ):
         options.parser = ELANDResultParser
     elif options.format == "BED":
         options.parser = BEDParser
+    elif options.format == "BEDPE":
+        options.parser = BEDPEParser
     elif options.format == "ELANDMULTI":
         options.parser = ELANDMultiParser
     elif options.format == "ELANDEXPORT":


### PR DESCRIPTION
Hi!
We were trying to run MACS on a BEDPE file. It appeared, though, that the "BEDPE"  option was missing for the "-f" flag, so I added it.

Let me know if that's not what you intended! 
Thanks,
Michael
