### PR TITLE
Fix average fragment length computation for paired-end data

### DIFF
--- a/MACS2/IO/Parser.pyx
+++ b/MACS2/IO/Parser.pyx
@@ -1031,7 +1031,7 @@ cdef class BAMPEParser(BAMParser):
             int *asint
             list references
             dict rlengths
-            float d = 0.0
+            double d = 0.0
             str rawread
             str rawentrylength
             _BAMPEParsed read

--- a/MACS2/IO/Parser.pyx
+++ b/MACS2/IO/Parser.pyx
@@ -1063,7 +1063,7 @@ cdef class BAMPEParser(BAMParser):
                 info(" %d" % (m*1000000))
             add_loc(references[read.ref], read.start, read.start + read.tlen)
         self.n = i
-        self.d = int(d)
+        self.d = int(round(d))
         assert d >= 0, "Something went wrong (mean fragment size was negative)"
         self.fhd.close()
         petrack.set_rlengths( rlengths )


### PR DESCRIPTION
Fixed rounding error when computing average fragment length for paired-end data. Using single-precision float for computing average of large number of integers leads to accumulation of rounding errors. In my case, I have 50 millions of paired end fragments, and MACS computes average fragment length as 183bp, but actually the average length of fragments was 235bp. 