### PR TITLE
Fixed --name behavior

### DIFF
--- a/bin/macs2
+++ b/bin/macs2
@@ -53,6 +53,17 @@ def main():
 
     if subcommand == "callpeak":
         # General call peak
+        # Check if the base directory of the --name argument exits.  This
+        # prevents MACS peak calling and then failing to write the output when
+        # the --name argument is used.
+        if args.name:
+            name_dir = os.path.dirname(args.name)
+            if not os.path.exists(name_dir):
+                try:
+                    os.makedirs(name_dir)
+                except:
+                    sys.exit("Base directory %s of --name argument could not be created. Terminating program." % name_dir)
+
         from MACS2.callpeak_cmd import run
         run( args )
     #elif subcommand == "diffpeak":


### PR DESCRIPTION
If a non existent base directory is provided to the --name argument,  MACS2 callpeak fails writing output after peak calling. New version does not start peak calling if the --name base directory does not exist.

For example, if --name "/non/existing/directory/sample1" is provided, then MACS will call the peaks, then fail to write output under "/non/existing/directory/" and exit without saving any results. This is quite frustrating when large samples are run.