### PR TITLE
Feat chisqtest for combining pvalues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,14 +9,8 @@ test/*.wig
 test/*.bed
 
 test/log
-
-test/NA_peaks.encodePeak
-
-test/CTCF_1M.bed.gz
-
-test/NA_model.r
-
-test/NA_peaks.xls
+test/test*_run_*
+test/__pycache__
 
 .DS_Store
 
@@ -33,3 +27,6 @@ test/NOSPMR.ppois.bdg_ppois.bdg
 MACS2.egg-info
 MACS2/IO/*.c
 MACS2/*.c
+
+.pytest_cache
+.cache

--- a/bin/macs2
+++ b/bin/macs2
@@ -471,7 +471,7 @@ def add_cmbreps_parser( subparsers ):
     argparser_cmbreps = subparsers.add_parser( "cmbreps",
                                                help = "Combine BEDGraphs of scores from replicates. Note: All regions on the same chromosome in the bedGraph file should be continuous so only bedGraph files from MACS2 are accpetable." )
     argparser_cmbreps.add_argument( "-i", dest = "ifile", type = str, required = True, nargs = "+",
-                                    help = "MACS score in bedGraph for each replicate. Require exactly two files such as '-i A B'. REQUIRED" )
+                                    help = "MACS score in bedGraph for each replicate. Require at least 2 files such as '-i A B C D'. REQUIRED" )
     # argparser_cmbreps.add_argument( "-w", dest = "weights", type = float, nargs = "*",
     #                                 help = "Weight for each replicate. Default is 1.0 for each. When given, require same number of parameters as IFILE." )    
     argparser_cmbreps.add_argument( "-m", "--method", dest = "method", type = str,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy>=1.15
 cython>=0.25
 pytest>=4.6
-scipy>=1.1.0

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ def main():
               ],
           install_requires=[
               'numpy>=1.15',
-              'scipy>=1.1.0',
               ],
           cmdclass = command_classes,
           ext_modules = ext_modules

--- a/setup_w_cython.py
+++ b/setup_w_cython.py
@@ -113,7 +113,6 @@ def main():
           install_requires=[
               'numpy>=1.15',
               'cython>=0.25',
-              'scipy>=1.1.0',
               ],
           cmdclass = command_classes,
           ext_modules = cythonize(ext_modules, language_level="2")

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# integrative subcmds testing
+
 if [ $# -lt 1 ];then
-    echo "Run all tests for MACS2. Need 1 parameter for a tag name! A unique string combining date, time and MACS2 version is recommended. ./test.sh <TAG>"
+    echo "Run all tests for subcommands of MACS2. Need 1 parameter for a tag name! A unique string combining date, time and MACS2 version is recommended. ./test.sh <TAG>"
     exit
 fi
 
@@ -129,3 +131,11 @@ macs2 bdgdiff --t1 ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_treat_pileup.
 
 macs2 bdgdiff --t1 ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_treat_pileup.bdg --c1 ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_control_lambda.bdg --t2 ${TAG}_run_callpeak_narrow_revert/run_callpeak_narrow_revert_treat_pileup.bdg --c2 ${TAG}_run_callpeak_narrow_revert/run_callpeak_narrow_revert_control_lambda.bdg -o cond1.bed cond2.bed common.bed --outdir ${TAG}_run_bdgdiff &> ${TAG}_run_bdgdiff/run_bdgdiff_w_o_file.log
 
+# cmbreps
+echo "cmbreps"
+
+mkdir ${TAG}_run_cmbreps
+
+macs2 cmbreps -i ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_treat_pileup.bdg ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_control_lambda.bdg ${TAG}_run_bdgcmp/run_bdgcmp_ppois.bdg -m max -o ${TAG}_cmbreps_max.bdg --outdir ${TAG}_run_cmbreps &> ${TAG}_run_cmbreps/run_cmbreps_max.log
+macs2 cmbreps -i ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_treat_pileup.bdg ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_control_lambda.bdg ${TAG}_run_bdgcmp/run_bdgcmp_ppois.bdg -m mean -o ${TAG}_cmbreps_mean.bdg --outdir ${TAG}_run_cmbreps &> ${TAG}_run_cmbreps/run_cmbreps_mean.log
+macs2 cmbreps -i ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_treat_pileup.bdg ${TAG}_run_callpeak_narrow/run_callpeak_narrow0_control_lambda.bdg ${TAG}_run_bdgcmp/run_bdgcmp_ppois.bdg -m fisher -o ${TAG}_cmbreps_fisher.bdg --outdir ${TAG}_run_cmbreps &> ${TAG}_run_cmbreps/run_cmbreps_fisher.log

--- a/test/test_BedGraph.py
+++ b/test/test_BedGraph.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Time-stamp: <2019-08-09 12:47:51 taoliu>
+# Time-stamp: <2019-08-21 16:43:16 taoliu>
 
 import unittest
 
@@ -26,38 +26,52 @@ class Test_bedGraphTrackI_add_loc(unittest.TestCase):
 class Test_bedGraphTrackI_overlie(unittest.TestCase):
 
     def setUp(self):
-        self.test_cslregions1 = [("chrY",0,70,0.00),
-                              ("chrY",70,80,0.07),
-                              ("chrY",80,150,0.00),
-                              ("chrY",150,160,0.07),
-                              ("chrY",160,190,0.00)]
-        self.test_cdregions2 = [("chrY",0,85,0.00),
-                             ("chrY",85,90,0.75),
-                             ("chrY",90,155,0.00),
-                             ("chrY",155,165,0.75),
-                             ("chrY",165,200,0.00)]
-        self.test_overlie_result = [("chrY",0,70,0.0),
-                                    ("chrY",70,80,0.07),
-                                    ("chrY",80,85,0.0),
-                                    ("chrY",85,90,0.75),
-                                    ("chrY",90,150,0.0),
-                                    ("chrY",150,155,0.07),
-                                    ("chrY",155,165,0.75),
-                                    ("chrY",165,190,0.0)]
+        self.test_regions1 = [("chrY",0,70,0.00),
+                              ("chrY",70,80,7.00),
+                              ("chrY",80,150,0.00)]
+        self.test_regions2 = [("chrY",0,85,0.00),
+                              ("chrY",85,90,75.00),
+                              ("chrY",90,155,0.00)]
+        self.test_regions3 = [("chrY",0,75,20.0),
+                              ("chrY",75,90,35.0),
+                              ("chrY",90,150,10.0)]
+        self.test_overlie_max = [("chrY",  0, 75, 20.0), # max
+                                 ("chrY", 75, 85, 35.0),
+                                 ("chrY", 85, 90, 75.0),
+                                 ("chrY", 90,150, 10.0),
+                                 ("chrY",150,155, 0.0)]
+        self.test_overlie_mean = [("chrY",  0, 70, 6.66667), # mean
+                                  ("chrY", 70, 75, 9),
+                                  ("chrY", 75, 80, 14),
+                                  ("chrY", 80, 85, 11.66667),
+                                  ("chrY", 85, 90, 36.66667),
+                                  ("chrY", 90,150, 3.33333),
+                                  ("chrY",150,155, 0.0)]
+        self.test_overlie_fisher = [("chrY",  0, 70, (0,0,20), 92.10340371976183, 1.1074313239555578e-17, 16.9557 ), # fisher
+                                    ("chrY", 70, 75, (7,0,20), 124.33959502167846, 1.9957116587802055e-24, 23.6999 ),
+                                    ("chrY", 75, 80, (7,0,35), 193.41714781149986, 4.773982707347631e-39, 38.3211 ),
+                                    ("chrY", 80, 85, (0,0,35), 161.1809565095832, 3.329003070922764e-32, 31.4777),
+                                    ("chrY", 85, 90, (0,75,35), 506.56872045869005, 3.233076792862357e-106, 105.4904),
+                                    ("chrY", 90,150, (0,0,10), 46.051701859880914, 2.8912075645386016e-08, 7.5389),
+                                    ("chrY",150,155, (0,0,0), 0, 1.0, 0.0)]        
+        
+        self.bdg1 = bedGraphTrackI()
+        self.bdg2 = bedGraphTrackI()
+        self.bdg3 = bedGraphTrackI()
+        for a in self.test_regions1:
+            self.bdg1.safe_add_loc(a[0],a[1],a[2],a[3])
 
-    def assertEqual_float ( self, a, b, roundn = 5 ):
+        for a in self.test_regions2:
+            self.bdg2.safe_add_loc(a[0],a[1],a[2],a[3])
+
+        for a in self.test_regions3:
+            self.bdg3.safe_add_loc(a[0],a[1],a[2],a[3])
+
+    def assertEqual_float ( self, a, b, roundn = 4 ):
         self.assertEqual( round( a, roundn ), round( b, roundn ) )
 
-    def test_overlie(self):
-        bdg1 = bedGraphTrackI()
-        bdg2 = bedGraphTrackI()
-        for a in self.test_cslregions1:
-            bdg1.safe_add_loc(a[0],a[1],a[2],a[3])
-
-        for a in self.test_cdregions2:
-            bdg2.safe_add_loc(a[0],a[1],a[2],a[3])
-
-        bdgb = bdg1.overlie([bdg2])
+    def test_overlie_max(self):
+        bdgb = self.bdg1.overlie([self.bdg2,self.bdg3], func="max")
 
         chrom = "chrY"
         (p,v) = bdgb.get_data_by_chr(chrom)
@@ -65,10 +79,39 @@ class Test_bedGraphTrackI_overlie(unittest.TestCase):
         for i in xrange(len(p)):
             pos = p[i]
             value = v[i]
-            self.assertEqual_float( self.test_overlie_result[i][1], pre )
-            self.assertEqual_float( self.test_overlie_result[i][2], pos )
-            self.assertEqual_float( self.test_overlie_result[i][3], value )            
-            pre = pos        
+            self.assertEqual_float( self.test_overlie_max[i][1], pre )
+            self.assertEqual_float( self.test_overlie_max[i][2], pos )
+            self.assertEqual_float( self.test_overlie_max[i][3], value )            
+            pre = pos
+
+    def test_overlie_mean(self):
+        bdgb = self.bdg1.overlie([self.bdg2,self.bdg3], func="mean")
+
+        chrom = "chrY"
+        (p,v) = bdgb.get_data_by_chr(chrom)
+        pre = 0
+        for i in xrange(len(p)):
+            pos = p[i]
+            value = v[i]
+            self.assertEqual_float( self.test_overlie_mean[i][1], pre )
+            self.assertEqual_float( self.test_overlie_mean[i][2], pos )
+            self.assertEqual_float( self.test_overlie_mean[i][3], value )            
+            pre = pos
+
+    def test_overlie_fisher(self):
+        bdgb = self.bdg1.overlie([self.bdg2,self.bdg3], func="fisher")
+
+        chrom = "chrY"
+        (p,v) = bdgb.get_data_by_chr(chrom)
+        pre = 0
+        for i in xrange(len(p)):
+            pos = p[i]
+            value = v[i]
+            self.assertEqual_float( self.test_overlie_fisher[i][1], pre )
+            self.assertEqual_float( self.test_overlie_fisher[i][2], pos )
+            self.assertEqual_float( self.test_overlie_fisher[i][6], value )            
+            pre = pos                        
+
 
 
 if __name__ == '__main__':

--- a/test/test_Prob.py
+++ b/test/test_Prob.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Time-stamp: <2019-08-09 15:33:31 taoliu>
+# Time-stamp: <2019-08-21 15:36:54 taoliu>
 
 """Module Description: Test functions to calculate probabilities.
 
@@ -83,6 +83,40 @@ class Test_poisson_cdf(unittest.TestCase):
                   round(log10(poisson_cdf(self.n4[0],self.n4[1],True)),4))
         self.assertEqual( result, expect )
 
+class Test_chisq_p_e(unittest.TestCase):
+    """Test chisq pvalue calculation -- assuming df is an even number. We
+    only implemented even number pchisq for upper tail. Because this
+    is the function we need to combine p-values using fisher's method
+
+    """
+    def setUp(self):
+        # x, k, p(upper), -log p upper, -log10 p upper
+        self.c = ((10, 2, 0.006737947, 5, 2.171472),
+                  (100, 2, 1.92875e-22, 50, 21.71472),
+                  (1000, 22, 1.956374e-197, 452.9382, 196.7085),
+                  (10, 4, 0.04042768, 3.208241, 1.393321),
+                  (100, 8, 4.269159e-18, 39.99511, 17.36966),
+                  (1000, 80, 6.889598e-159, 364.181, 158.1618),
+                  (54, 6, 7.377151e-10, 21.02746, 9.132111),
+                  (565, 10, 5.518772e-115, 263.0891, 114.2582 ),
+                  (7765, 12, 0, 3845.965, 1670.2814),
+                 )
+
+    def test_chisq_p(self):
+        expect = map(lambda x:round(x[2],4),self.c)
+        result = map(lambda x:round(chisq_pvalue_e(x[0],x[1]),4),self.c)
+        self.assertEqual( result, expect )
+
+    def test_chisq_logp(self):
+        expect = map(lambda x:round(x[3],4),self.c)
+        result = map(lambda x:round(chisq_logp_e(x[0],x[1]),4),self.c)
+        self.assertEqual( result, expect )
+
+    def test_chisq_log10p(self):
+        expect = map(lambda x:round(x[4],4),self.c)
+        result = map(lambda x:round(chisq_logp_e(x[0],x[1],log10=True),4),self.c)
+        self.assertEqual( result, expect )
+        
 class Test_binomial_cdf(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
The purpose is to remove scipy dependency, and implement our own chi-sq p value functions for combining pvalues with Fisher's method

1. Implemented chi-square p value function (only support even degree of freedom and upper tail p-value for combining pvalues) in Prob.pyx. 
2. Removed scipy dependency from PR #304 . 
3. Redesigned the unit tests for BedGraph overlie functions (for 3 bedgraphs)
4. Implemented unit tests  for chi-square p functions.