### PR TITLE
Fix: Random output of score from bdgdiff #318; Cython dependency #321

### DIFF
--- a/.github/workflows/macs2.yml
+++ b/.github/workflows/macs2.yml
@@ -47,11 +47,6 @@ jobs:
     - name: Build sdist
       run: |
         python setup.py sdist
-    - name: Publish distribution to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/macs2.yml
+++ b/.github/workflows/macs2.yml
@@ -46,7 +46,7 @@ jobs:
         cd ..
     - name: Build sdist
       run: |
-        python setup sdist
+        python setup.py sdist
     - name: Publish distribution to Test PyPI
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/MACS2/IO/CallPeakUnit.pyx
+++ b/MACS2/IO/CallPeakUnit.pyx
@@ -1,4 +1,4 @@
-# Time-stamp: <2019-09-20 11:38:30 taoliu>
+# Time-stamp: <2019-09-30 13:05:38 taoliu>
 
 """Module for Calculate Scores.
 
@@ -201,12 +201,13 @@ cdef float median_from_value_length ( np.ndarray value, list length ):
         list tmp
         int32_t l_half, c, tmp_l
         float tmp_v
-    
+
+    c = 0
     tmp = sorted(zip( value, length ))
-    l = sum( length )/2
+    l_half = sum( length )/2
     for (tmp_v, tmp_l) in tmp:
         c += tmp_l
-        if c > l:
+        if c > l_half:
             return tmp_v
 
 cdef float mean_from_value_length ( np.ndarray value, list length ):
@@ -215,7 +216,7 @@ cdef float mean_from_value_length ( np.ndarray value, list length ):
     """
     cdef:
         list tmp
-        int32_t tmp_l
+        int32_t tmp_l, l
         float tmp_v, sum_v
 
     sum_v = 0

--- a/MACS2/IO/ScoreTrack.pyx
+++ b/MACS2/IO/ScoreTrack.pyx
@@ -1,4 +1,4 @@
-# Time-stamp: <2019-09-25 16:45:58 taoliu>
+# Time-stamp: <2019-09-30 13:02:11 taoliu>
 
 """Module for Feature IO classes.
 
@@ -16,8 +16,6 @@ cimport numpy as np
 from copy import copy
 
 from cpython cimport bool
-
-#from scipy.stats import chi2 
 
 from MACS2.Signal import maxima, enforce_valleys, enforce_peakyness
 
@@ -49,7 +47,7 @@ LOG10_E = 0.43429448190325176
 
 pscore_dict = dict()
 
-cdef inline double get_pscore ( int observed, double expectation ):
+cdef double get_pscore ( int observed, double expectation ):
     """Get p-value score from Poisson test. First check existing
     table, if failed, call poisson_cdf function, then store the result
     in table.
@@ -67,7 +65,7 @@ cdef inline double get_pscore ( int observed, double expectation ):
 
 asym_logLR_dict = dict()
 
-cdef inline double logLR_asym ( double x, double y ):
+cdef double logLR_asym ( double x, double y ):
     """Calculate log10 Likelihood between H1 ( enriched ) and H0 (
     chromatin bias ). Set minus sign for depletion.
     
@@ -91,7 +89,7 @@ cdef inline double logLR_asym ( double x, double y ):
 
 sym_logLR_dict = dict()
 
-cdef inline double logLR_sym ( double x, double y ):
+cdef double logLR_sym ( double x, double y ):
     """Calculate log10 Likelihood between H1 ( enriched ) and H0 (
     another enriched ). Set minus sign for H0>H1.
     
@@ -113,12 +111,12 @@ cdef inline double logLR_sym ( double x, double y ):
         sym_logLR_dict[ ( x, y ) ] = s
         return s
     
-cdef inline double get_logFE ( float x, float y ):
+cdef double get_logFE ( float x, float y ):
     """ return 100* log10 fold enrichment with +1 pseudocount.
     """
     return log10( x/y )
 
-cdef inline float get_subtraction ( float x, float y):
+cdef float get_subtraction ( float x, float y):
     """ return subtraction.
     """
     return x - y
@@ -130,12 +128,13 @@ cdef float median_from_value_length ( np.ndarray value, list length ):
         list tmp
         int32_t l_half, c, tmp_l
         float tmp_v
-    
+
+    c = 0
     tmp = sorted(zip( value, length ))
-    l = sum( length )/2
+    l_half = sum( length )/2
     for (tmp_v, tmp_l) in tmp:
         c += tmp_l
-        if c > l:
+        if c > l_half:
             return tmp_v
 
 cdef float mean_from_value_length ( np.ndarray value, list length ):
@@ -143,9 +142,10 @@ cdef float mean_from_value_length ( np.ndarray value, list length ):
     """
     cdef:
         list tmp
-        int32_t tmp_l
+        int32_t tmp_l, l
         float tmp_v, sum_v
 
+    sum_v = 0
     tmp = zip( value, length )
     l = sum( length )
 
@@ -153,7 +153,6 @@ cdef float mean_from_value_length ( np.ndarray value, list length ):
         sum_v += tmp_v * tmp_l
 
     return sum_v / l
-
 
 # ------------------------------------
 # Classes
@@ -1817,9 +1816,11 @@ cdef class TwoConditionScores:
         """
         cdef:
             int32_t tmp_s, tmp_e
-            int32_t l = 0
+            int32_t l
             float tmp_v, sum_v
 
+        sum_v = 0
+        l = 0
         for (tmp_s, tmp_e, tmp_v) in peakcontent:
             sum_v += tmp_v * ( tmp_e - tmp_s )
             l +=  tmp_e - tmp_s

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Time-stamp: <2019-09-20 15:08:11 taoliu>
+# Time-stamp: <2019-09-30 13:38:06 taoliu>
 
 """Description: 
 
@@ -57,6 +57,7 @@ def main():
                        Extension("MACS2.hashtable", ["MACS2/hashtable.pyx"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=extra_c_args),
                        Extension("MACS2.Statistics", ["MACS2/Statistics.pyx"], libraries=["m"], include_dirs=["MACS2/",numpy_get_include()], extra_compile_args=extra_c_args),
                        ]
+        ext_modules = cythonize(ext_modules, language_level=2)
     else:
         ext_modules = [Extension("MACS2.Prob", ["MACS2/Prob.c"], libraries=["m"], include_dirs=numpy_include_dir, extra_compile_args=extra_c_args ),
                        Extension("MACS2.IO.Parser",["MACS2/IO/Parser.c"], include_dirs=numpy_include_dir, extra_compile_args=extra_c_args),
@@ -79,7 +80,7 @@ def main():
         long_description = fh.read()
         
     setup(name="MACS2",
-          version="2.1.3.3",
+          version="2.1.4",
           description="Model Based Analysis for ChIP-Seq data",
           long_description = long_description,
           long_description_content_type="text/markdown",
@@ -88,7 +89,6 @@ def main():
           url='http://github.com/taoliu/MACS/',
           package_dir={'MACS2' : 'MACS2'},
           packages=['MACS2', 'MACS2.IO'],
-          #package_data={'MACS2': ['data/*.dat']},          
           scripts=['bin/macs2',
                    ],
           classifiers=[
@@ -105,10 +105,9 @@ def main():
               ],
           install_requires=[
               'numpy>=1.15',
-              'cython>=0.25',
               ],
           cmdclass = command_classes,
-          ext_modules = cythonize(ext_modules, language_level="2")
+          ext_modules = ext_modules
           )
 
 if __name__ == '__main__':


### PR DESCRIPTION
The following issues are fixed:

1. #318 Random score in bdgdiff output. It turns out the sum_v is not initialized as 0 before adding. Potential bugs are fixed in other functions  in ScoreTrack and CallPeakUnit codes.
2. #321 Cython dependency is removed. And place 'cythonzie' call to the correct position.
3. A typo is fixed in Github Actions script. 