### PR TITLE
test using Python3.8 dev (currently 3.8.1rc1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.8"
   - "3.7"
   - "3.6"
+  - "3.8-dev"
 install:
   - pip install --upgrade pip
   - pip install --upgrade -r requirements.txt


### PR DESCRIPTION
In Debian we see test failures using Python 3.8.1rc1; perhaps we can replicate them on Travis as well

https://buildd.debian.org/status/fetch.php?pkg=macs&arch=amd64&ver=2.2.6-1&stamp=1576596789&raw=0