### PR TITLE
Add i386: Intel 32-bit case to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,19 @@ python:
   - "3.7"
   - "3.6"  
   - "3.8-dev"
+matrix:
+  include:
+    # i386: Intel 32-bit
+    - name: i386
+      language: minimal
+      install: |
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes &&
+          docker build --rm --build-arg BASE_IMAGE="i386/ubuntu:bionic" -t macs -f test/Dockerfile .
+      script: |
+        docker run --rm -t macs bash -cx "pytest --runxfail && cd test && ./cmdlinetest macs2"
+  allow_failures:
+    - name: i386
+  fast_finish: true
 install:
   - pip install --upgrade pip
   - pip install --upgrade -r requirements.txt

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,29 @@
+ARG BASE_IMAGE=ubuntu:bionic
+FROM ${BASE_IMAGE}
+
+ENV TEST_USER macs
+
+RUN uname -a
+RUN apt-get update -qq && \
+  apt-get install -yq \
+  python3 \
+  python3-pip \
+  python3-setuptools \
+  python3-wheel
+
+RUN useradd -m "${TEST_USER}"
+WORKDIR /build
+COPY . .
+RUN chown -R "${TEST_USER}:${TEST_USER}" /build
+
+USER "${TEST_USER}"
+RUN env | grep ^PATH
+ENV PATH "/home/${TEST_USER}/.local/bin:${PATH}"
+
+RUN python3 --version
+RUN pip3 --version
+
+RUN pip3 install --user --upgrade -r requirements.txt
+RUN pip3 install --user .
+
+RUN pytest --version


### PR DESCRIPTION
Hello.

This PR is related to https://github.com/taoliu/MACS/issues/359  .
It's to add Intel 32-bit (i386) case to Travis CI.

Here is [my forked repository's Travis log](https://travis-ci.org/junaruga/MACS/builds/654689875).
There is one test failure.

https://travis-ci.org/junaruga/MACS/jobs/654689880#L1144

```
 checking macs2_run_callpeak_narrow/run_callpeak_narrow0.log...
...
 ... error/warning found!
```

The Intel 32-bit case is executed on "ubuntu" bionic i386 specific binary docker container image with QEMU on Travis x86_64 using [multiarch/qemu-user-static](https://github.com/multiarch/qemu-user-static).

You can debug on your local environment like this, if you are using Linux as your host environment.

```
docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
docker build --rm --build-arg BASE_IMAGE="i386/ubuntu:bionic" -t macs -f test/Dockerfile .

docker run --rm -it macs bash
```
