### PR TITLE
Fix: setup script will correctly check and install numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def main():
     cwd = os.path.abspath(os.path.dirname(__file__))
 
     # install required numpy
-    p = subprocess.call(['pip','install', f'numpy{numpy_requires}'],cwd=cwd)
+    p = subprocess.call([sys.executable, "-m", 'pip', 'install', f'numpy{numpy_requires}'],cwd=cwd)
     if p != 0:
         # Could be due to a too old pip version and build isolation, check that
         try:

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,40 @@ the distribution).
 """
 
 import sys
+import os
 from setuptools import setup, Extension
+from distutils.version import LooseVersion
+import subprocess
 
-from numpy import get_include as numpy_get_include
-numpy_include_dir = [numpy_get_include()]
+numpy_requires = '>=1.17'
+install_requires = [f"numpy>={numpy_requires}",]
 
 def main():
     if float(sys.version[:3])<3.6:
         sys.stderr.write("CRITICAL: Python version must >= 3.6!\n")
         sys.exit(1)
 
+    cwd = os.path.abspath(os.path.dirname(__file__))
+
+    # install required numpy
+    p = subprocess.call(['pip','install', f'numpy{numpy_requires}'],cwd=cwd)
+    if p != 0:
+        # Could be due to a too old pip version and build isolation, check that
+        try:
+            # Note, pip may not be installed or not have been used
+            import pip
+            if LooseVersion(pip.__version__) < LooseVersion('18.0.0'):
+                raise RuntimeError("Installing requirements failed. Possibly due "
+                                   "to `pip` being too old, found version {}, "
+                                   "needed is >= 18.0.0.".format(pip.__version__))
+            else:
+                raise RuntimeError("Installing requirements failed!")
+        except ImportError:
+            raise RuntimeError("Installing requirement failed! `pip` has to be installed!")
+        
+    from numpy import get_include as numpy_get_include
+    numpy_include_dir = [numpy_get_include()]
+        
     # I intend to use -Ofast, however if gcc version < 4.6, this option is unavailable so...
     extra_c_args = ["-w","-O3","-ffast-math","-g0"] # for C, -Ofast implies -O3 and -ffast-math
 
@@ -69,7 +93,9 @@ def main():
               'Programming Language :: Python :: 3.8',              
               'Programming Language :: Cython',
               ],
-          install_requires=['numpy>=1.17'],          
+          install_requires=install_requires,
+          setup_requires=install_requires,          
+          python_requires='>=3.6',
           ext_modules = ext_modules
           )
 


### PR DESCRIPTION
Because in our setup script, the paths to NumPy header files are necessary, we need to make sure 'numpy'  being installed already. Now setup script will check and install NumPy according to the dependency requirement before trying to retrieve the paths. This fix is for issue #364.

