### PR TITLE
The cutoff-analysis of CallPeakUnit has the same behavior as bdgpeakc…

### DIFF
--- a/MACS2/IO/CallPeakUnit.c
+++ b/MACS2/IO/CallPeakUnit.c
@@ -1145,7 +1145,7 @@ struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___pre_com
   __pyx_t_5numpy_int32_t min_length;
 };
 
-/* "MACS2/IO/CallPeakUnit.pyx":896
+/* "MACS2/IO/CallPeakUnit.pyx":898
  *         return
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,             # <<<<<<<<<<<<<<
@@ -1160,7 +1160,7 @@ struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_peak
   PyBoolObject *cutoff_analysis;
 };
 
-/* "MACS2/IO/CallPeakUnit.pyx":1100
+/* "MACS2/IO/CallPeakUnit.pyx":1102
  *         return
  * 
  *     cdef bool __close_peak_wo_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -1172,7 +1172,7 @@ struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___close_p
   PyObject *score_cutoff_s;
 };
 
-/* "MACS2/IO/CallPeakUnit.pyx":1161
+/* "MACS2/IO/CallPeakUnit.pyx":1163
  *             return True
  * 
  *     cdef bool __close_peak_with_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -1185,7 +1185,7 @@ struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___close_p
   __pyx_t_5numpy_float32_t min_valley;
 };
 
-/* "MACS2/IO/CallPeakUnit.pyx":1461
+/* "MACS2/IO/CallPeakUnit.pyx":1463
  *         return True
  * 
  *     cpdef call_broadpeaks (self, list scoring_function_symbols, list lvl1_cutoff_s, list lvl2_cutoff_s, int32_t min_length=200, int32_t lvl1_max_gap=50, int32_t lvl2_max_gap=400, bool cutoff_analysis = False):             # <<<<<<<<<<<<<<
@@ -1200,7 +1200,7 @@ struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_broa
   PyBoolObject *cutoff_analysis;
 };
 
-/* "MACS2/IO/CallPeakUnit.pyx":1740
+/* "MACS2/IO/CallPeakUnit.pyx":1742
  *         return
  * 
  *     cdef bool __close_peak_for_broad_region (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -1212,7 +1212,7 @@ struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___close_p
   PyObject *score_cutoff_s;
 };
 
-/* "MACS2/IO/CallPeakUnit.pyx":1838
+/* "MACS2/IO/CallPeakUnit.pyx":1840
  *         return bpeaks
  * 
  *     cpdef refine_peak_from_tags_distribution ( self, peaks, int32_t window_size = 100, float32_t cutoff = 5 ):             # <<<<<<<<<<<<<<
@@ -12835,15 +12835,15 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___pre_compu
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":878
- * 
+  /* "MACS2/IO/CallPeakUnit.pyx":879
  *         # write pvalue and total length of predicted peaks
+ *         # this is the output from cutoff-analysis
  *         fhd = open( self.cutoff_analysis_filename, "w" )             # <<<<<<<<<<<<<<
  *         fhd.write( "pscore\tqscore\tnpeaks\tlpeaks\tavelpeak\n" )
  *         x = []
  */
-  __Pyx_TraceLine(878,0,__PYX_ERR(0, 878, __pyx_L1_error))
-  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 878, __pyx_L1_error)
+  __Pyx_TraceLine(879,0,__PYX_ERR(0, 879, __pyx_L1_error))
+  __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 879, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_INCREF(__pyx_v_self->cutoff_analysis_filename);
   __Pyx_GIVEREF(__pyx_v_self->cutoff_analysis_filename);
@@ -12851,21 +12851,21 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___pre_compu
   __Pyx_INCREF(__pyx_n_u_w);
   __Pyx_GIVEREF(__pyx_n_u_w);
   PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_n_u_w);
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_open, __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 878, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_builtin_open, __pyx_t_3, NULL); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 879, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_fhd = __pyx_t_4;
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":879
- *         # write pvalue and total length of predicted peaks
+  /* "MACS2/IO/CallPeakUnit.pyx":880
+ *         # this is the output from cutoff-analysis
  *         fhd = open( self.cutoff_analysis_filename, "w" )
  *         fhd.write( "pscore\tqscore\tnpeaks\tlpeaks\tavelpeak\n" )             # <<<<<<<<<<<<<<
  *         x = []
  *         y = []
  */
-  __Pyx_TraceLine(879,0,__PYX_ERR(0, 879, __pyx_L1_error))
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_fhd, __pyx_n_s_write); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 879, __pyx_L1_error)
+  __Pyx_TraceLine(880,0,__PYX_ERR(0, 880, __pyx_L1_error))
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_fhd, __pyx_n_s_write); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 880, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_t_2 = NULL;
   if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_3))) {
@@ -12879,257 +12879,289 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___pre_compu
   }
   __pyx_t_4 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_2, __pyx_kp_u_pscore_qscore_npeaks_lpeaks_avel) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_kp_u_pscore_qscore_npeaks_lpeaks_avel);
   __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 879, __pyx_L1_error)
+  if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 880, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":880
+  /* "MACS2/IO/CallPeakUnit.pyx":881
  *         fhd = open( self.cutoff_analysis_filename, "w" )
  *         fhd.write( "pscore\tqscore\tnpeaks\tlpeaks\tavelpeak\n" )
  *         x = []             # <<<<<<<<<<<<<<
  *         y = []
  *         for cutoff in tmplist:
  */
-  __Pyx_TraceLine(880,0,__PYX_ERR(0, 880, __pyx_L1_error))
-  __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 880, __pyx_L1_error)
+  __Pyx_TraceLine(881,0,__PYX_ERR(0, 881, __pyx_L1_error))
+  __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 881, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_v_x = ((PyObject*)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":881
+  /* "MACS2/IO/CallPeakUnit.pyx":882
  *         fhd.write( "pscore\tqscore\tnpeaks\tlpeaks\tavelpeak\n" )
  *         x = []
  *         y = []             # <<<<<<<<<<<<<<
  *         for cutoff in tmplist:
- *             fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
+ *             if self.pvalue_npeaks[ cutoff ] > 0:
  */
-  __Pyx_TraceLine(881,0,__PYX_ERR(0, 881, __pyx_L1_error))
-  __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 881, __pyx_L1_error)
+  __Pyx_TraceLine(882,0,__PYX_ERR(0, 882, __pyx_L1_error))
+  __pyx_t_4 = PyList_New(0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 882, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_v_y = ((PyObject*)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":882
+  /* "MACS2/IO/CallPeakUnit.pyx":883
  *         x = []
  *         y = []
  *         for cutoff in tmplist:             # <<<<<<<<<<<<<<
- *             fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
- *             x.append( cutoff )
+ *             if self.pvalue_npeaks[ cutoff ] > 0:
+ *                 fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
  */
-  __Pyx_TraceLine(882,0,__PYX_ERR(0, 882, __pyx_L1_error))
+  __Pyx_TraceLine(883,0,__PYX_ERR(0, 883, __pyx_L1_error))
   __pyx_t_4 = __pyx_v_tmplist; __Pyx_INCREF(__pyx_t_4); __pyx_t_5 = 0;
   for (;;) {
     if (__pyx_t_5 >= PyList_GET_SIZE(__pyx_t_4)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_4, __pyx_t_5); __Pyx_INCREF(__pyx_t_3); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 882, __pyx_L1_error)
+    __pyx_t_3 = PyList_GET_ITEM(__pyx_t_4, __pyx_t_5); __Pyx_INCREF(__pyx_t_3); __pyx_t_5++; if (unlikely(0 < 0)) __PYX_ERR(0, 883, __pyx_L1_error)
     #else
-    __pyx_t_3 = PySequence_ITEM(__pyx_t_4, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 882, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(__pyx_t_4, __pyx_t_5); __pyx_t_5++; if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 883, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     #endif
-    __pyx_t_23 = __pyx_PyFloat_AsFloat(__pyx_t_3); if (unlikely((__pyx_t_23 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 882, __pyx_L1_error)
+    __pyx_t_23 = __pyx_PyFloat_AsFloat(__pyx_t_3); if (unlikely((__pyx_t_23 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 883, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_v_cutoff = __pyx_t_23;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":883
+    /* "MACS2/IO/CallPeakUnit.pyx":884
  *         y = []
  *         for cutoff in tmplist:
- *             fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )             # <<<<<<<<<<<<<<
- *             x.append( cutoff )
- *             y.append( self.pvalue_length[ cutoff ] )
- */
-    __Pyx_TraceLine(883,0,__PYX_ERR(0, 883, __pyx_L1_error))
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_fhd, __pyx_n_s_write); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_1 = PyTuple_New(10); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_7 = 0;
-    __pyx_t_24 = 127;
-    __pyx_t_25 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_25);
-    __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_kp_u_2f); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
-    __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
-    __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
-    __Pyx_GIVEREF(__pyx_t_26);
-    PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_26);
-    __pyx_t_26 = 0;
-    __Pyx_INCREF(__pyx_kp_u__9);
-    __pyx_t_7 += 1;
-    __Pyx_GIVEREF(__pyx_kp_u__9);
-    PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_kp_u__9);
-    if (unlikely(__pyx_v_self->pqtable == Py_None)) {
-      PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 883, __pyx_L1_error)
-    }
-    __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_25);
-    __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
-    __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_kp_u_2f); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
-    __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
-    __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
-    __Pyx_GIVEREF(__pyx_t_26);
-    PyTuple_SET_ITEM(__pyx_t_1, 2, __pyx_t_26);
-    __pyx_t_26 = 0;
-    __Pyx_INCREF(__pyx_kp_u__9);
-    __pyx_t_7 += 1;
-    __Pyx_GIVEREF(__pyx_kp_u__9);
-    PyTuple_SET_ITEM(__pyx_t_1, 3, __pyx_kp_u__9);
-    if (unlikely(__pyx_v_self->pvalue_npeaks == Py_None)) {
-      PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 883, __pyx_L1_error)
-    }
-    __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_npeaks, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_25);
-    __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
-    __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_n_u_d); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
-    __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
-    __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
-    __Pyx_GIVEREF(__pyx_t_26);
-    PyTuple_SET_ITEM(__pyx_t_1, 4, __pyx_t_26);
-    __pyx_t_26 = 0;
-    __Pyx_INCREF(__pyx_kp_u__9);
-    __pyx_t_7 += 1;
-    __Pyx_GIVEREF(__pyx_kp_u__9);
-    PyTuple_SET_ITEM(__pyx_t_1, 5, __pyx_kp_u__9);
-    if (unlikely(__pyx_v_self->pvalue_length == Py_None)) {
-      PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 883, __pyx_L1_error)
-    }
-    __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_length, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_25);
-    __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
-    __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_n_u_d); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
-    __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
-    __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
-    __Pyx_GIVEREF(__pyx_t_26);
-    PyTuple_SET_ITEM(__pyx_t_1, 6, __pyx_t_26);
-    __pyx_t_26 = 0;
-    __Pyx_INCREF(__pyx_kp_u__9);
-    __pyx_t_7 += 1;
-    __Pyx_GIVEREF(__pyx_kp_u__9);
-    PyTuple_SET_ITEM(__pyx_t_1, 7, __pyx_kp_u__9);
-    if (unlikely(__pyx_v_self->pvalue_length == Py_None)) {
-      PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 883, __pyx_L1_error)
-    }
-    __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_length, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_25);
-    __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
-    if (unlikely(__pyx_v_self->pvalue_npeaks == Py_None)) {
-      PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 883, __pyx_L1_error)
-    }
-    __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __pyx_t_27 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_npeaks, __pyx_t_26); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_27);
-    __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
-    __pyx_t_26 = __Pyx_PyNumber_Divide(__pyx_t_25, __pyx_t_27); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_26);
-    __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
-    __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
-    __pyx_t_27 = __Pyx_PyObject_Format(__pyx_t_26, __pyx_kp_u_2f); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_27);
-    __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
-    __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_27) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_27) : __pyx_t_24;
-    __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_27);
-    __Pyx_GIVEREF(__pyx_t_27);
-    PyTuple_SET_ITEM(__pyx_t_1, 8, __pyx_t_27);
-    __pyx_t_27 = 0;
-    __Pyx_INCREF(__pyx_kp_u__10);
-    __pyx_t_7 += 1;
-    __Pyx_GIVEREF(__pyx_kp_u__10);
-    PyTuple_SET_ITEM(__pyx_t_1, 9, __pyx_kp_u__10);
-    __pyx_t_27 = __Pyx_PyUnicode_Join(__pyx_t_1, 10, __pyx_t_7, __pyx_t_24); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_27);
-    __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_1 = NULL;
-    if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
-      __pyx_t_1 = PyMethod_GET_SELF(__pyx_t_2);
-      if (likely(__pyx_t_1)) {
-        PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_2);
-        __Pyx_INCREF(__pyx_t_1);
-        __Pyx_INCREF(function);
-        __Pyx_DECREF_SET(__pyx_t_2, function);
-      }
-    }
-    __pyx_t_3 = (__pyx_t_1) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_1, __pyx_t_27) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_27);
-    __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
-    if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 883, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_3);
-    __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-
-    /* "MACS2/IO/CallPeakUnit.pyx":884
- *         for cutoff in tmplist:
- *             fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
- *             x.append( cutoff )             # <<<<<<<<<<<<<<
- *             y.append( self.pvalue_length[ cutoff ] )
- *         fhd.close()
+ *             if self.pvalue_npeaks[ cutoff ] > 0:             # <<<<<<<<<<<<<<
+ *                 fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
+ *                 x.append( cutoff )
  */
     __Pyx_TraceLine(884,0,__PYX_ERR(0, 884, __pyx_L1_error))
+    if (unlikely(__pyx_v_self->pvalue_npeaks == Py_None)) {
+      PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
+      __PYX_ERR(0, 884, __pyx_L1_error)
+    }
     __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 884, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_17 = __Pyx_PyList_Append(__pyx_v_x, __pyx_t_3); if (unlikely(__pyx_t_17 == ((int)-1))) __PYX_ERR(0, 884, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_npeaks, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 884, __pyx_L1_error)
+    __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+    __pyx_t_3 = PyObject_RichCompare(__pyx_t_2, __pyx_int_0, Py_GT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 884, __pyx_L1_error)
+    __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+    __pyx_t_13 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 884, __pyx_L1_error)
+    __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+    if (__pyx_t_13) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":885
- *             fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
- *             x.append( cutoff )
- *             y.append( self.pvalue_length[ cutoff ] )             # <<<<<<<<<<<<<<
+      /* "MACS2/IO/CallPeakUnit.pyx":885
+ *         for cutoff in tmplist:
+ *             if self.pvalue_npeaks[ cutoff ] > 0:
+ *                 fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )             # <<<<<<<<<<<<<<
+ *                 x.append( cutoff )
+ *                 y.append( self.pvalue_length[ cutoff ] )
+ */
+      __Pyx_TraceLine(885,0,__PYX_ERR(0, 885, __pyx_L1_error))
+      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_fhd, __pyx_n_s_write); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_2);
+      __pyx_t_1 = PyTuple_New(10); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_1);
+      __pyx_t_7 = 0;
+      __pyx_t_24 = 127;
+      __pyx_t_25 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_25);
+      __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_kp_u_2f); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
+      __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
+      __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
+      __Pyx_GIVEREF(__pyx_t_26);
+      PyTuple_SET_ITEM(__pyx_t_1, 0, __pyx_t_26);
+      __pyx_t_26 = 0;
+      __Pyx_INCREF(__pyx_kp_u__9);
+      __pyx_t_7 += 1;
+      __Pyx_GIVEREF(__pyx_kp_u__9);
+      PyTuple_SET_ITEM(__pyx_t_1, 1, __pyx_kp_u__9);
+      if (unlikely(__pyx_v_self->pqtable == Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
+        __PYX_ERR(0, 885, __pyx_L1_error)
+      }
+      __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_25);
+      __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
+      __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_kp_u_2f); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
+      __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
+      __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
+      __Pyx_GIVEREF(__pyx_t_26);
+      PyTuple_SET_ITEM(__pyx_t_1, 2, __pyx_t_26);
+      __pyx_t_26 = 0;
+      __Pyx_INCREF(__pyx_kp_u__9);
+      __pyx_t_7 += 1;
+      __Pyx_GIVEREF(__pyx_kp_u__9);
+      PyTuple_SET_ITEM(__pyx_t_1, 3, __pyx_kp_u__9);
+      if (unlikely(__pyx_v_self->pvalue_npeaks == Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
+        __PYX_ERR(0, 885, __pyx_L1_error)
+      }
+      __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_npeaks, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_25);
+      __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
+      __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_n_u_d); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
+      __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
+      __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
+      __Pyx_GIVEREF(__pyx_t_26);
+      PyTuple_SET_ITEM(__pyx_t_1, 4, __pyx_t_26);
+      __pyx_t_26 = 0;
+      __Pyx_INCREF(__pyx_kp_u__9);
+      __pyx_t_7 += 1;
+      __Pyx_GIVEREF(__pyx_kp_u__9);
+      PyTuple_SET_ITEM(__pyx_t_1, 5, __pyx_kp_u__9);
+      if (unlikely(__pyx_v_self->pvalue_length == Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
+        __PYX_ERR(0, 885, __pyx_L1_error)
+      }
+      __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_length, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_25);
+      __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
+      __pyx_t_26 = __Pyx_PyObject_Format(__pyx_t_25, __pyx_n_u_d); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
+      __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_26) : __pyx_t_24;
+      __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_26);
+      __Pyx_GIVEREF(__pyx_t_26);
+      PyTuple_SET_ITEM(__pyx_t_1, 6, __pyx_t_26);
+      __pyx_t_26 = 0;
+      __Pyx_INCREF(__pyx_kp_u__9);
+      __pyx_t_7 += 1;
+      __Pyx_GIVEREF(__pyx_kp_u__9);
+      PyTuple_SET_ITEM(__pyx_t_1, 7, __pyx_kp_u__9);
+      if (unlikely(__pyx_v_self->pvalue_length == Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
+        __PYX_ERR(0, 885, __pyx_L1_error)
+      }
+      __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __pyx_t_25 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_length, __pyx_t_26); if (unlikely(!__pyx_t_25)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_25);
+      __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
+      if (unlikely(__pyx_v_self->pvalue_npeaks == Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
+        __PYX_ERR(0, 885, __pyx_L1_error)
+      }
+      __pyx_t_26 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __pyx_t_27 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_npeaks, __pyx_t_26); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_27);
+      __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
+      __pyx_t_26 = __Pyx_PyNumber_Divide(__pyx_t_25, __pyx_t_27); if (unlikely(!__pyx_t_26)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_26);
+      __Pyx_DECREF(__pyx_t_25); __pyx_t_25 = 0;
+      __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
+      __pyx_t_27 = __Pyx_PyObject_Format(__pyx_t_26, __pyx_kp_u_2f); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_27);
+      __Pyx_DECREF(__pyx_t_26); __pyx_t_26 = 0;
+      __pyx_t_24 = (__Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_27) > __pyx_t_24) ? __Pyx_PyUnicode_MAX_CHAR_VALUE(__pyx_t_27) : __pyx_t_24;
+      __pyx_t_7 += __Pyx_PyUnicode_GET_LENGTH(__pyx_t_27);
+      __Pyx_GIVEREF(__pyx_t_27);
+      PyTuple_SET_ITEM(__pyx_t_1, 8, __pyx_t_27);
+      __pyx_t_27 = 0;
+      __Pyx_INCREF(__pyx_kp_u__10);
+      __pyx_t_7 += 1;
+      __Pyx_GIVEREF(__pyx_kp_u__10);
+      PyTuple_SET_ITEM(__pyx_t_1, 9, __pyx_kp_u__10);
+      __pyx_t_27 = __Pyx_PyUnicode_Join(__pyx_t_1, 10, __pyx_t_7, __pyx_t_24); if (unlikely(!__pyx_t_27)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_27);
+      __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
+      __pyx_t_1 = NULL;
+      if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
+        __pyx_t_1 = PyMethod_GET_SELF(__pyx_t_2);
+        if (likely(__pyx_t_1)) {
+          PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_2);
+          __Pyx_INCREF(__pyx_t_1);
+          __Pyx_INCREF(function);
+          __Pyx_DECREF_SET(__pyx_t_2, function);
+        }
+      }
+      __pyx_t_3 = (__pyx_t_1) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_1, __pyx_t_27) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_27);
+      __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
+      __Pyx_DECREF(__pyx_t_27); __pyx_t_27 = 0;
+      if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 885, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_3);
+      __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+
+      /* "MACS2/IO/CallPeakUnit.pyx":886
+ *             if self.pvalue_npeaks[ cutoff ] > 0:
+ *                 fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
+ *                 x.append( cutoff )             # <<<<<<<<<<<<<<
+ *                 y.append( self.pvalue_length[ cutoff ] )
+ *         fhd.close()
+ */
+      __Pyx_TraceLine(886,0,__PYX_ERR(0, 886, __pyx_L1_error))
+      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 886, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_3);
+      __pyx_t_17 = __Pyx_PyList_Append(__pyx_v_x, __pyx_t_3); if (unlikely(__pyx_t_17 == ((int)-1))) __PYX_ERR(0, 886, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+
+      /* "MACS2/IO/CallPeakUnit.pyx":887
+ *                 fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
+ *                 x.append( cutoff )
+ *                 y.append( self.pvalue_length[ cutoff ] )             # <<<<<<<<<<<<<<
  *         fhd.close()
  *         logging.info( "#3 Analysis of cutoff vs num of peaks or total length has been saved in %s" % self.cutoff_analysis_filename )
  */
-    __Pyx_TraceLine(885,0,__PYX_ERR(0, 885, __pyx_L1_error))
-    if (unlikely(__pyx_v_self->pvalue_length == Py_None)) {
-      PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 885, __pyx_L1_error)
-    }
-    __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 885, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_2 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_length, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 885, __pyx_L1_error)
-    __Pyx_GOTREF(__pyx_t_2);
-    __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_17 = __Pyx_PyList_Append(__pyx_v_y, __pyx_t_2); if (unlikely(__pyx_t_17 == ((int)-1))) __PYX_ERR(0, 885, __pyx_L1_error)
-    __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+      __Pyx_TraceLine(887,0,__PYX_ERR(0, 887, __pyx_L1_error))
+      if (unlikely(__pyx_v_self->pvalue_length == Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
+        __PYX_ERR(0, 887, __pyx_L1_error)
+      }
+      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 887, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_3);
+      __pyx_t_2 = __Pyx_PyDict_GetItem(__pyx_v_self->pvalue_length, __pyx_t_3); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 887, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_2);
+      __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+      __pyx_t_17 = __Pyx_PyList_Append(__pyx_v_y, __pyx_t_2); if (unlikely(__pyx_t_17 == ((int)-1))) __PYX_ERR(0, 887, __pyx_L1_error)
+      __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":882
+      /* "MACS2/IO/CallPeakUnit.pyx":884
+ *         y = []
+ *         for cutoff in tmplist:
+ *             if self.pvalue_npeaks[ cutoff ] > 0:             # <<<<<<<<<<<<<<
+ *                 fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
+ *                 x.append( cutoff )
+ */
+    }
+
+    /* "MACS2/IO/CallPeakUnit.pyx":883
  *         x = []
  *         y = []
  *         for cutoff in tmplist:             # <<<<<<<<<<<<<<
- *             fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
- *             x.append( cutoff )
+ *             if self.pvalue_npeaks[ cutoff ] > 0:
+ *                 fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
  */
-    __Pyx_TraceLine(882,0,__PYX_ERR(0, 882, __pyx_L1_error))
+    __Pyx_TraceLine(883,0,__PYX_ERR(0, 883, __pyx_L1_error))
   }
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":886
- *             x.append( cutoff )
- *             y.append( self.pvalue_length[ cutoff ] )
+  /* "MACS2/IO/CallPeakUnit.pyx":888
+ *                 x.append( cutoff )
+ *                 y.append( self.pvalue_length[ cutoff ] )
  *         fhd.close()             # <<<<<<<<<<<<<<
  *         logging.info( "#3 Analysis of cutoff vs num of peaks or total length has been saved in %s" % self.cutoff_analysis_filename )
  *         #logging.info( "#3 Suggest a cutoff..." )
  */
-  __Pyx_TraceLine(886,0,__PYX_ERR(0, 886, __pyx_L1_error))
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_fhd, __pyx_n_s_close); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 886, __pyx_L1_error)
+  __Pyx_TraceLine(888,0,__PYX_ERR(0, 888, __pyx_L1_error))
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_fhd, __pyx_n_s_close); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 888, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_3 = NULL;
   if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -13143,25 +13175,25 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___pre_compu
   }
   __pyx_t_4 = (__pyx_t_3) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_3) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 886, __pyx_L1_error)
+  if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 888, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":887
- *             y.append( self.pvalue_length[ cutoff ] )
+  /* "MACS2/IO/CallPeakUnit.pyx":889
+ *                 y.append( self.pvalue_length[ cutoff ] )
  *         fhd.close()
  *         logging.info( "#3 Analysis of cutoff vs num of peaks or total length has been saved in %s" % self.cutoff_analysis_filename )             # <<<<<<<<<<<<<<
  *         #logging.info( "#3 Suggest a cutoff..." )
  *         #optimal_cutoff, optimal_length = find_optimal_cutoff( x, y )
  */
-  __Pyx_TraceLine(887,0,__PYX_ERR(0, 887, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 887, __pyx_L1_error)
+  __Pyx_TraceLine(889,0,__PYX_ERR(0, 889, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 889, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 887, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 889, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  __pyx_t_2 = PyUnicode_Format(__pyx_kp_u_3_Analysis_of_cutoff_vs_num_of, __pyx_v_self->cutoff_analysis_filename); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 887, __pyx_L1_error)
+  __pyx_t_2 = PyUnicode_Format(__pyx_kp_u_3_Analysis_of_cutoff_vs_num_of, __pyx_v_self->cutoff_analysis_filename); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 889, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_27 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_3))) {
@@ -13176,19 +13208,19 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___pre_compu
   __pyx_t_4 = (__pyx_t_27) ? __Pyx_PyObject_Call2Args(__pyx_t_3, __pyx_t_27, __pyx_t_2) : __Pyx_PyObject_CallOneArg(__pyx_t_3, __pyx_t_2);
   __Pyx_XDECREF(__pyx_t_27); __pyx_t_27 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 887, __pyx_L1_error)
+  if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 889, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":894
+  /* "MACS2/IO/CallPeakUnit.pyx":896
  *         #print (list(self.pvalue_length.keys()))
  *         #print (list(self.pvalue_npeaks.keys()))
  *         return             # <<<<<<<<<<<<<<
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,
  */
-  __Pyx_TraceLine(894,0,__PYX_ERR(0, 894, __pyx_L1_error))
+  __Pyx_TraceLine(896,0,__PYX_ERR(0, 896, __pyx_L1_error))
   goto __pyx_L0;
 
   /* "MACS2/IO/CallPeakUnit.pyx":736
@@ -13232,7 +13264,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___pre_compu
   __Pyx_RefNannyFinishContext();
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":896
+/* "MACS2/IO/CallPeakUnit.pyx":898
  *         return
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,             # <<<<<<<<<<<<<<
@@ -13245,7 +13277,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
   __pyx_t_5numpy_int32_t __pyx_v_min_length = ((__pyx_t_5numpy_int32_t)0xC8);
   __pyx_t_5numpy_int32_t __pyx_v_max_gap = ((__pyx_t_5numpy_int32_t)50);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":897
+  /* "MACS2/IO/CallPeakUnit.pyx":899
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,
  *                        int32_t max_gap = 50, bool call_summits = False, bool cutoff_analysis = False ):             # <<<<<<<<<<<<<<
@@ -13275,7 +13307,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
   char const *__pyx_t_13;
   Py_ssize_t __pyx_t_14;
   __Pyx_RefNannySetupContext("call_peaks", 0);
-  __Pyx_TraceCall("call_peaks", __pyx_f[0], 896, 0, __PYX_ERR(0, 896, __pyx_L1_error));
+  __Pyx_TraceCall("call_peaks", __pyx_f[0], 898, 0, __PYX_ERR(0, 898, __pyx_L1_error));
   if (__pyx_optional_args) {
     if (__pyx_optional_args->__pyx_n > 0) {
       __pyx_v_min_length = __pyx_optional_args->min_length;
@@ -13291,14 +13323,14 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
     }
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":896
+  /* "MACS2/IO/CallPeakUnit.pyx":898
  *         return
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,             # <<<<<<<<<<<<<<
  *                        int32_t max_gap = 50, bool call_summits = False, bool cutoff_analysis = False ):
  *         """Call peaks for all chromosomes. Return a PeakIO object.
  */
-  __Pyx_TraceLine(896,0,__PYX_ERR(0, 896, __pyx_L1_error))
+  __Pyx_TraceLine(898,0,__PYX_ERR(0, 898, __pyx_L1_error))
   /* Check if called by wrapper */
   if (unlikely(__pyx_skip_dispatch)) ;
   /* Check if overridden in Python */
@@ -13308,13 +13340,13 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
     if (unlikely(!__Pyx_object_dict_version_matches(((PyObject *)__pyx_v_self), __pyx_tp_dict_version, __pyx_obj_dict_version))) {
       PY_UINT64_T __pyx_type_dict_guard = __Pyx_get_tp_dict_version(((PyObject *)__pyx_v_self));
       #endif
-      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_call_peaks); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 896, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_call_peaks); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 898, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       if (!PyCFunction_Check(__pyx_t_1) || (PyCFunction_GET_FUNCTION(__pyx_t_1) != (PyCFunction)(void*)__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_9call_peaks)) {
         __Pyx_XDECREF(__pyx_r);
-        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 896, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 898, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_max_gap); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 896, __pyx_L1_error)
+        __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_max_gap); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 898, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         __Pyx_INCREF(__pyx_t_1);
         __pyx_t_5 = __pyx_t_1; __pyx_t_6 = NULL;
@@ -13332,7 +13364,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
         #if CYTHON_FAST_PYCALL
         if (PyFunction_Check(__pyx_t_5)) {
           PyObject *__pyx_temp[7] = {__pyx_t_6, __pyx_v_scoring_function_symbols, __pyx_v_score_cutoff_s, __pyx_t_3, __pyx_t_4, ((PyObject *)__pyx_v_call_summits), ((PyObject *)__pyx_v_cutoff_analysis)};
-          __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 6+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 896, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 6+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 898, __pyx_L1_error)
           __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -13342,7 +13374,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
         #if CYTHON_FAST_PYCCALL
         if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
           PyObject *__pyx_temp[7] = {__pyx_t_6, __pyx_v_scoring_function_symbols, __pyx_v_score_cutoff_s, __pyx_t_3, __pyx_t_4, ((PyObject *)__pyx_v_call_summits), ((PyObject *)__pyx_v_cutoff_analysis)};
-          __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 6+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 896, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 6+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 898, __pyx_L1_error)
           __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -13350,7 +13382,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
         } else
         #endif
         {
-          __pyx_t_8 = PyTuple_New(6+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 896, __pyx_L1_error)
+          __pyx_t_8 = PyTuple_New(6+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 898, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_8);
           if (__pyx_t_6) {
             __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -13373,7 +13405,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
           PyTuple_SET_ITEM(__pyx_t_8, 5+__pyx_t_7, ((PyObject *)__pyx_v_cutoff_analysis));
           __pyx_t_3 = 0;
           __pyx_t_4 = 0;
-          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 896, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 898, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
         }
@@ -13396,15 +13428,15 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
     #endif
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":911
+  /* "MACS2/IO/CallPeakUnit.pyx":913
  *             bytes tmp_bytes
  * 
  *         peaks = PeakIO()             # <<<<<<<<<<<<<<
  * 
  *         # prepare p-q table
  */
-  __Pyx_TraceLine(911,0,__PYX_ERR(0, 911, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 911, __pyx_L1_error)
+  __Pyx_TraceLine(913,0,__PYX_ERR(0, 913, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 913, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_5 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_2))) {
@@ -13418,35 +13450,35 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
   }
   __pyx_t_1 = (__pyx_t_5) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_5) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 911, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 913, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_peaks = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":914
+  /* "MACS2/IO/CallPeakUnit.pyx":916
  * 
  *         # prepare p-q table
  *         if not self.pqtable:             # <<<<<<<<<<<<<<
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:
  */
-  __Pyx_TraceLine(914,0,__PYX_ERR(0, 914, __pyx_L1_error))
-  __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_v_self->pqtable); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 914, __pyx_L1_error)
+  __Pyx_TraceLine(916,0,__PYX_ERR(0, 916, __pyx_L1_error))
+  __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_v_self->pqtable); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 916, __pyx_L1_error)
   __pyx_t_10 = ((!__pyx_t_9) != 0);
   if (__pyx_t_10) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":915
+    /* "MACS2/IO/CallPeakUnit.pyx":917
  *         # prepare p-q table
  *         if not self.pqtable:
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")             # <<<<<<<<<<<<<<
  *             if cutoff_analysis:
  *                 logging.info("#3 Cutoff vs peaks called will be analyzed!")
  */
-    __Pyx_TraceLine(915,0,__PYX_ERR(0, 915, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 915, __pyx_L1_error)
+    __Pyx_TraceLine(917,0,__PYX_ERR(0, 917, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 917, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 915, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 917, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_2 = NULL;
@@ -13461,33 +13493,33 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
     }
     __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_2, __pyx_kp_u_3_Pre_compute_pvalue_qvalue_tab) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_kp_u_3_Pre_compute_pvalue_qvalue_tab);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 915, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 917, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":916
+    /* "MACS2/IO/CallPeakUnit.pyx":918
  *         if not self.pqtable:
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:             # <<<<<<<<<<<<<<
  *                 logging.info("#3 Cutoff vs peaks called will be analyzed!")
  *                 self.__pre_computes( max_gap = max_gap, min_length = min_length )
  */
-    __Pyx_TraceLine(916,0,__PYX_ERR(0, 916, __pyx_L1_error))
-    __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_cutoff_analysis)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 916, __pyx_L1_error)
+    __Pyx_TraceLine(918,0,__PYX_ERR(0, 918, __pyx_L1_error))
+    __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_cutoff_analysis)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 918, __pyx_L1_error)
     if (__pyx_t_10) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":917
+      /* "MACS2/IO/CallPeakUnit.pyx":919
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:
  *                 logging.info("#3 Cutoff vs peaks called will be analyzed!")             # <<<<<<<<<<<<<<
  *                 self.__pre_computes( max_gap = max_gap, min_length = min_length )
  *             else:
  */
-      __Pyx_TraceLine(917,0,__PYX_ERR(0, 917, __pyx_L1_error))
-      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 917, __pyx_L1_error)
+      __Pyx_TraceLine(919,0,__PYX_ERR(0, 919, __pyx_L1_error))
+      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 919, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 917, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 919, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __pyx_t_5 = NULL;
@@ -13502,25 +13534,25 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
       }
       __pyx_t_1 = (__pyx_t_5) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_5, __pyx_kp_u_3_Cutoff_vs_peaks_called_will_b) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_kp_u_3_Cutoff_vs_peaks_called_will_b);
       __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
-      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 917, __pyx_L1_error)
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 919, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":918
+      /* "MACS2/IO/CallPeakUnit.pyx":920
  *             if cutoff_analysis:
  *                 logging.info("#3 Cutoff vs peaks called will be analyzed!")
  *                 self.__pre_computes( max_gap = max_gap, min_length = min_length )             # <<<<<<<<<<<<<<
  *             else:
  *                 self.__cal_pvalue_qvalue_table()
  */
-      __Pyx_TraceLine(918,0,__PYX_ERR(0, 918, __pyx_L1_error))
+      __Pyx_TraceLine(920,0,__PYX_ERR(0, 920, __pyx_L1_error))
       __pyx_t_11.__pyx_n = 2;
       __pyx_t_11.max_gap = __pyx_v_max_gap;
       __pyx_t_11.min_length = __pyx_v_min_length;
       ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___pre_computes(__pyx_v_self, &__pyx_t_11); 
 
-      /* "MACS2/IO/CallPeakUnit.pyx":916
+      /* "MACS2/IO/CallPeakUnit.pyx":918
  *         if not self.pqtable:
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:             # <<<<<<<<<<<<<<
@@ -13530,20 +13562,20 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
       goto __pyx_L4;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":920
+    /* "MACS2/IO/CallPeakUnit.pyx":922
  *                 self.__pre_computes( max_gap = max_gap, min_length = min_length )
  *             else:
  *                 self.__cal_pvalue_qvalue_table()             # <<<<<<<<<<<<<<
  * 
  * 
  */
-    __Pyx_TraceLine(920,0,__PYX_ERR(0, 920, __pyx_L1_error))
+    __Pyx_TraceLine(922,0,__PYX_ERR(0, 922, __pyx_L1_error))
     /*else*/ {
       ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pvalue_qvalue_table(__pyx_v_self);
     }
     __pyx_L4:;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":914
+    /* "MACS2/IO/CallPeakUnit.pyx":916
  * 
  *         # prepare p-q table
  *         if not self.pqtable:             # <<<<<<<<<<<<<<
@@ -13552,58 +13584,58 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":924
+  /* "MACS2/IO/CallPeakUnit.pyx":926
  * 
  *         # prepare bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
  *             self.bedGraph_treat_f = fopen( self.bedGraph_treat_filename, "w" )
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )
  */
-  __Pyx_TraceLine(924,0,__PYX_ERR(0, 924, __pyx_L1_error))
-  __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 924, __pyx_L1_error)
+  __Pyx_TraceLine(926,0,__PYX_ERR(0, 926, __pyx_L1_error))
+  __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 926, __pyx_L1_error)
   if (__pyx_t_10) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":925
+    /* "MACS2/IO/CallPeakUnit.pyx":927
  *         # prepare bedGraph file
  *         if self.save_bedGraph:
  *             self.bedGraph_treat_f = fopen( self.bedGraph_treat_filename, "w" )             # <<<<<<<<<<<<<<
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )
  * 
  */
-    __Pyx_TraceLine(925,0,__PYX_ERR(0, 925, __pyx_L1_error))
+    __Pyx_TraceLine(927,0,__PYX_ERR(0, 927, __pyx_L1_error))
     if (unlikely(__pyx_v_self->bedGraph_treat_filename == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-      __PYX_ERR(0, 925, __pyx_L1_error)
+      __PYX_ERR(0, 927, __pyx_L1_error)
     }
-    __pyx_t_12 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_treat_filename); if (unlikely((!__pyx_t_12) && PyErr_Occurred())) __PYX_ERR(0, 925, __pyx_L1_error)
+    __pyx_t_12 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_treat_filename); if (unlikely((!__pyx_t_12) && PyErr_Occurred())) __PYX_ERR(0, 927, __pyx_L1_error)
     __pyx_v_self->bedGraph_treat_f = fopen(__pyx_t_12, ((char const *)"w"));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":926
+    /* "MACS2/IO/CallPeakUnit.pyx":928
  *         if self.save_bedGraph:
  *             self.bedGraph_treat_f = fopen( self.bedGraph_treat_filename, "w" )
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )             # <<<<<<<<<<<<<<
  * 
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")
  */
-    __Pyx_TraceLine(926,0,__PYX_ERR(0, 926, __pyx_L1_error))
+    __Pyx_TraceLine(928,0,__PYX_ERR(0, 928, __pyx_L1_error))
     if (unlikely(__pyx_v_self->bedGraph_control_filename == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-      __PYX_ERR(0, 926, __pyx_L1_error)
+      __PYX_ERR(0, 928, __pyx_L1_error)
     }
-    __pyx_t_12 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_control_filename); if (unlikely((!__pyx_t_12) && PyErr_Occurred())) __PYX_ERR(0, 926, __pyx_L1_error)
+    __pyx_t_12 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_control_filename); if (unlikely((!__pyx_t_12) && PyErr_Occurred())) __PYX_ERR(0, 928, __pyx_L1_error)
     __pyx_v_self->bedGraph_ctrl_f = fopen(__pyx_t_12, ((char const *)"w"));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":928
+    /* "MACS2/IO/CallPeakUnit.pyx":930
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )
  * 
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")             # <<<<<<<<<<<<<<
  *             logging.info ("#3   Write bedGraph files for treatment pileup (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_treat_pileup.bdg")
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  */
-    __Pyx_TraceLine(928,0,__PYX_ERR(0, 928, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 928, __pyx_L1_error)
+    __Pyx_TraceLine(930,0,__PYX_ERR(0, 930, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 930, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 928, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 930, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_2 = NULL;
@@ -13618,34 +13650,34 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
     }
     __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_2, __pyx_kp_u_3_In_the_peak_calling_step_the) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_kp_u_3_In_the_peak_calling_step_the);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 928, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 930, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":929
+    /* "MACS2/IO/CallPeakUnit.pyx":931
  * 
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")
  *             logging.info ("#3   Write bedGraph files for treatment pileup (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_treat_pileup.bdg")             # <<<<<<<<<<<<<<
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  * 
  */
-    __Pyx_TraceLine(929,0,__PYX_ERR(0, 929, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 929, __pyx_L1_error)
+    __Pyx_TraceLine(931,0,__PYX_ERR(0, 931, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 931, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 929, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 931, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     if (unlikely(__pyx_v_self->bedGraph_filename_prefix == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%.30s'", "decode");
-      __PYX_ERR(0, 929, __pyx_L1_error)
+      __PYX_ERR(0, 931, __pyx_L1_error)
     }
-    __pyx_t_5 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 929, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 931, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_8 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_trea, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 929, __pyx_L1_error)
+    __pyx_t_8 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_trea, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 931, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    __pyx_t_5 = __Pyx_PyUnicode_Concat(__pyx_t_8, __pyx_kp_u_treat_pileup_bdg); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 929, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyUnicode_Concat(__pyx_t_8, __pyx_kp_u_treat_pileup_bdg); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 931, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     __pyx_t_8 = NULL;
@@ -13661,34 +13693,34 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
     __pyx_t_1 = (__pyx_t_8) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_8, __pyx_t_5) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_5);
     __Pyx_XDECREF(__pyx_t_8); __pyx_t_8 = 0;
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 929, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 931, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":930
+    /* "MACS2/IO/CallPeakUnit.pyx":932
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")
  *             logging.info ("#3   Write bedGraph files for treatment pileup (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_treat_pileup.bdg")
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")             # <<<<<<<<<<<<<<
  * 
  *             if self.save_SPMR:
  */
-    __Pyx_TraceLine(930,0,__PYX_ERR(0, 930, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 930, __pyx_L1_error)
+    __Pyx_TraceLine(932,0,__PYX_ERR(0, 932, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 932, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 930, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 932, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     if (unlikely(__pyx_v_self->bedGraph_filename_prefix == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%.30s'", "decode");
-      __PYX_ERR(0, 930, __pyx_L1_error)
+      __PYX_ERR(0, 932, __pyx_L1_error)
     }
-    __pyx_t_2 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 930, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 932, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_8 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_cont, __pyx_t_2); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 930, __pyx_L1_error)
+    __pyx_t_8 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_cont, __pyx_t_2); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 932, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_2 = __Pyx_PyUnicode_Concat(__pyx_t_8, __pyx_kp_u_control_lambda_bdg); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 930, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyUnicode_Concat(__pyx_t_8, __pyx_kp_u_control_lambda_bdg); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 932, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     __pyx_t_8 = NULL;
@@ -13704,33 +13736,33 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
     __pyx_t_1 = (__pyx_t_8) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_8, __pyx_t_2) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_2);
     __Pyx_XDECREF(__pyx_t_8); __pyx_t_8 = 0;
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 930, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 932, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":932
+    /* "MACS2/IO/CallPeakUnit.pyx":934
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  * 
  *             if self.save_SPMR:             # <<<<<<<<<<<<<<
  *                 logging.info ( "#3   --SPMR is requested, so pileup will be normalized by sequencing depth in million reads." )
  *             elif self.treat_scaling_factor == 1:
  */
-    __Pyx_TraceLine(932,0,__PYX_ERR(0, 932, __pyx_L1_error))
-    __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_SPMR)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 932, __pyx_L1_error)
+    __Pyx_TraceLine(934,0,__PYX_ERR(0, 934, __pyx_L1_error))
+    __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_SPMR)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 934, __pyx_L1_error)
     if (__pyx_t_10) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":933
+      /* "MACS2/IO/CallPeakUnit.pyx":935
  * 
  *             if self.save_SPMR:
  *                 logging.info ( "#3   --SPMR is requested, so pileup will be normalized by sequencing depth in million reads." )             # <<<<<<<<<<<<<<
  *             elif self.treat_scaling_factor == 1:
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in treatment." )
  */
-      __Pyx_TraceLine(933,0,__PYX_ERR(0, 933, __pyx_L1_error))
-      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 933, __pyx_L1_error)
+      __Pyx_TraceLine(935,0,__PYX_ERR(0, 935, __pyx_L1_error))
+      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 935, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 933, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 935, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __pyx_t_5 = NULL;
@@ -13745,12 +13777,12 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
       }
       __pyx_t_1 = (__pyx_t_5) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_5, __pyx_kp_u_3_SPMR_is_requested_so_pileup_w) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_kp_u_3_SPMR_is_requested_so_pileup_w);
       __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
-      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 933, __pyx_L1_error)
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 935, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":932
+      /* "MACS2/IO/CallPeakUnit.pyx":934
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  * 
  *             if self.save_SPMR:             # <<<<<<<<<<<<<<
@@ -13760,28 +13792,28 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":934
+    /* "MACS2/IO/CallPeakUnit.pyx":936
  *             if self.save_SPMR:
  *                 logging.info ( "#3   --SPMR is requested, so pileup will be normalized by sequencing depth in million reads." )
  *             elif self.treat_scaling_factor == 1:             # <<<<<<<<<<<<<<
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in treatment." )
  *             else:
  */
-    __Pyx_TraceLine(934,0,__PYX_ERR(0, 934, __pyx_L1_error))
+    __Pyx_TraceLine(936,0,__PYX_ERR(0, 936, __pyx_L1_error))
     __pyx_t_10 = ((__pyx_v_self->treat_scaling_factor == 1.0) != 0);
     if (__pyx_t_10) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":935
+      /* "MACS2/IO/CallPeakUnit.pyx":937
  *                 logging.info ( "#3   --SPMR is requested, so pileup will be normalized by sequencing depth in million reads." )
  *             elif self.treat_scaling_factor == 1:
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in treatment." )             # <<<<<<<<<<<<<<
  *             else:
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in control." )
  */
-      __Pyx_TraceLine(935,0,__PYX_ERR(0, 935, __pyx_L1_error))
-      __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 935, __pyx_L1_error)
+      __Pyx_TraceLine(937,0,__PYX_ERR(0, 937, __pyx_L1_error))
+      __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 937, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 935, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 937, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = NULL;
@@ -13796,12 +13828,12 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
       }
       __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_2, __pyx_kp_u_3_Pileup_will_be_based_on_seque) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_kp_u_3_Pileup_will_be_based_on_seque);
       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 935, __pyx_L1_error)
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 937, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":934
+      /* "MACS2/IO/CallPeakUnit.pyx":936
  *             if self.save_SPMR:
  *                 logging.info ( "#3   --SPMR is requested, so pileup will be normalized by sequencing depth in million reads." )
  *             elif self.treat_scaling_factor == 1:             # <<<<<<<<<<<<<<
@@ -13811,18 +13843,18 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":937
+    /* "MACS2/IO/CallPeakUnit.pyx":939
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in treatment." )
  *             else:
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in control." )             # <<<<<<<<<<<<<<
  * 
  *             if self.trackline:
  */
-    __Pyx_TraceLine(937,0,__PYX_ERR(0, 937, __pyx_L1_error))
+    __Pyx_TraceLine(939,0,__PYX_ERR(0, 939, __pyx_L1_error))
     /*else*/ {
-      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 937, __pyx_L1_error)
+      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_logging); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 939, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 937, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 939, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __pyx_t_5 = NULL;
@@ -13837,77 +13869,46 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
       }
       __pyx_t_1 = (__pyx_t_5) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_5, __pyx_kp_u_3_Pileup_will_be_based_on_seque_2) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_kp_u_3_Pileup_will_be_based_on_seque_2);
       __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
-      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 937, __pyx_L1_error)
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 939, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     }
     __pyx_L6:;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":939
+    /* "MACS2/IO/CallPeakUnit.pyx":941
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in control." )
  * 
  *             if self.trackline:             # <<<<<<<<<<<<<<
  *                 # this line is REQUIRED by the wiggle format for UCSC browser
  *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  */
-    __Pyx_TraceLine(939,0,__PYX_ERR(0, 939, __pyx_L1_error))
-    __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->trackline)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 939, __pyx_L1_error)
+    __Pyx_TraceLine(941,0,__PYX_ERR(0, 941, __pyx_L1_error))
+    __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->trackline)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 941, __pyx_L1_error)
     if (__pyx_t_10) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":941
+      /* "MACS2/IO/CallPeakUnit.pyx":943
  *             if self.trackline:
  *                 # this line is REQUIRED by the wiggle format for UCSC browser
  *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()             # <<<<<<<<<<<<<<
  *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
  *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  */
-      __Pyx_TraceLine(941,0,__PYX_ERR(0, 941, __pyx_L1_error))
-      __pyx_t_1 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_treatme, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 941, __pyx_L1_error)
+      __Pyx_TraceLine(943,0,__PYX_ERR(0, 943, __pyx_L1_error))
+      __pyx_t_1 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_treatme, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 943, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_2 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_1), NULL, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 941, __pyx_L1_error)
+      __pyx_t_2 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_1), NULL, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 943, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_v_tmp_bytes = ((PyObject*)__pyx_t_2);
       __pyx_t_2 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":942
+      /* "MACS2/IO/CallPeakUnit.pyx":944
  *                 # this line is REQUIRED by the wiggle format for UCSC browser
  *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  *                 fprintf( self.bedGraph_treat_f, tmp_bytes )             # <<<<<<<<<<<<<<
  *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )
- */
-      __Pyx_TraceLine(942,0,__PYX_ERR(0, 942, __pyx_L1_error))
-      if (unlikely(__pyx_v_tmp_bytes == Py_None)) {
-        PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-        __PYX_ERR(0, 942, __pyx_L1_error)
-      }
-      __pyx_t_13 = __Pyx_PyBytes_AsString(__pyx_v_tmp_bytes); if (unlikely((!__pyx_t_13) && PyErr_Occurred())) __PYX_ERR(0, 942, __pyx_L1_error)
-      (void)(fprintf(__pyx_v_self->bedGraph_treat_f, __pyx_t_13));
-
-      /* "MACS2/IO/CallPeakUnit.pyx":943
- *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
- *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
- *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()             # <<<<<<<<<<<<<<
- *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )
- * 
- */
-      __Pyx_TraceLine(943,0,__PYX_ERR(0, 943, __pyx_L1_error))
-      __pyx_t_2 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_control, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 943, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_1 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_2), NULL, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 943, __pyx_L1_error)
-      __Pyx_GOTREF(__pyx_t_1);
-      __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      __Pyx_DECREF_SET(__pyx_v_tmp_bytes, ((PyObject*)__pyx_t_1));
-      __pyx_t_1 = 0;
-
-      /* "MACS2/IO/CallPeakUnit.pyx":944
- *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
- *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
- *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )             # <<<<<<<<<<<<<<
- * 
- *         logging.info("#3 Call peaks for each chromosome...")
  */
       __Pyx_TraceLine(944,0,__PYX_ERR(0, 944, __pyx_L1_error))
       if (unlikely(__pyx_v_tmp_bytes == Py_None)) {
@@ -13915,9 +13916,40 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
         __PYX_ERR(0, 944, __pyx_L1_error)
       }
       __pyx_t_13 = __Pyx_PyBytes_AsString(__pyx_v_tmp_bytes); if (unlikely((!__pyx_t_13) && PyErr_Occurred())) __PYX_ERR(0, 944, __pyx_L1_error)
+      (void)(fprintf(__pyx_v_self->bedGraph_treat_f, __pyx_t_13));
+
+      /* "MACS2/IO/CallPeakUnit.pyx":945
+ *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
+ *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
+ *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()             # <<<<<<<<<<<<<<
+ *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )
+ * 
+ */
+      __Pyx_TraceLine(945,0,__PYX_ERR(0, 945, __pyx_L1_error))
+      __pyx_t_2 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_control, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 945, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_2);
+      __pyx_t_1 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_2), NULL, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 945, __pyx_L1_error)
+      __Pyx_GOTREF(__pyx_t_1);
+      __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
+      __Pyx_DECREF_SET(__pyx_v_tmp_bytes, ((PyObject*)__pyx_t_1));
+      __pyx_t_1 = 0;
+
+      /* "MACS2/IO/CallPeakUnit.pyx":946
+ *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
+ *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
+ *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )             # <<<<<<<<<<<<<<
+ * 
+ *         logging.info("#3 Call peaks for each chromosome...")
+ */
+      __Pyx_TraceLine(946,0,__PYX_ERR(0, 946, __pyx_L1_error))
+      if (unlikely(__pyx_v_tmp_bytes == Py_None)) {
+        PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
+        __PYX_ERR(0, 946, __pyx_L1_error)
+      }
+      __pyx_t_13 = __Pyx_PyBytes_AsString(__pyx_v_tmp_bytes); if (unlikely((!__pyx_t_13) && PyErr_Occurred())) __PYX_ERR(0, 946, __pyx_L1_error)
       (void)(fprintf(__pyx_v_self->bedGraph_ctrl_f, __pyx_t_13));
 
-      /* "MACS2/IO/CallPeakUnit.pyx":939
+      /* "MACS2/IO/CallPeakUnit.pyx":941
  *                 logging.info ( "#3   Pileup will be based on sequencing depth in control." )
  * 
  *             if self.trackline:             # <<<<<<<<<<<<<<
@@ -13926,7 +13958,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
  */
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":924
+    /* "MACS2/IO/CallPeakUnit.pyx":926
  * 
  *         # prepare bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
@@ -13935,17 +13967,17 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":946
+  /* "MACS2/IO/CallPeakUnit.pyx":948
  *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )
  * 
  *         logging.info("#3 Call peaks for each chromosome...")             # <<<<<<<<<<<<<<
  *         for chrom in self.chromosomes:
  *             # treat/control bedGraph will be saved if requested by user.
  */
-  __Pyx_TraceLine(946,0,__PYX_ERR(0, 946, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 946, __pyx_L1_error)
+  __Pyx_TraceLine(948,0,__PYX_ERR(0, 948, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 948, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 946, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 948, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_t_2 = NULL;
@@ -13960,106 +13992,106 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
   }
   __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_2, __pyx_kp_u_3_Call_peaks_for_each_chromosom) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_kp_u_3_Call_peaks_for_each_chromosom);
   __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 946, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 948, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":947
+  /* "MACS2/IO/CallPeakUnit.pyx":949
  * 
  *         logging.info("#3 Call peaks for each chromosome...")
  *         for chrom in self.chromosomes:             # <<<<<<<<<<<<<<
  *             # treat/control bedGraph will be saved if requested by user.
  *             self.__chrom_call_peak_using_certain_criteria ( peaks, chrom, scoring_function_symbols, score_cutoff_s, min_length, max_gap, call_summits, self.save_bedGraph )
  */
-  __Pyx_TraceLine(947,0,__PYX_ERR(0, 947, __pyx_L1_error))
+  __Pyx_TraceLine(949,0,__PYX_ERR(0, 949, __pyx_L1_error))
   if (unlikely(__pyx_v_self->chromosomes == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 947, __pyx_L1_error)
+    __PYX_ERR(0, 949, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->chromosomes; __Pyx_INCREF(__pyx_t_1); __pyx_t_14 = 0;
   for (;;) {
     if (__pyx_t_14 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_5 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_14); __Pyx_INCREF(__pyx_t_5); __pyx_t_14++; if (unlikely(0 < 0)) __PYX_ERR(0, 947, __pyx_L1_error)
+    __pyx_t_5 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_14); __Pyx_INCREF(__pyx_t_5); __pyx_t_14++; if (unlikely(0 < 0)) __PYX_ERR(0, 949, __pyx_L1_error)
     #else
-    __pyx_t_5 = PySequence_ITEM(__pyx_t_1, __pyx_t_14); __pyx_t_14++; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 947, __pyx_L1_error)
+    __pyx_t_5 = PySequence_ITEM(__pyx_t_1, __pyx_t_14); __pyx_t_14++; if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 949, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     #endif
-    if (!(likely(PyBytes_CheckExact(__pyx_t_5))||((__pyx_t_5) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_5)->tp_name), 0))) __PYX_ERR(0, 947, __pyx_L1_error)
+    if (!(likely(PyBytes_CheckExact(__pyx_t_5))||((__pyx_t_5) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_5)->tp_name), 0))) __PYX_ERR(0, 949, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_chrom, ((PyObject*)__pyx_t_5));
     __pyx_t_5 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":949
+    /* "MACS2/IO/CallPeakUnit.pyx":951
  *         for chrom in self.chromosomes:
  *             # treat/control bedGraph will be saved if requested by user.
  *             self.__chrom_call_peak_using_certain_criteria ( peaks, chrom, scoring_function_symbols, score_cutoff_s, min_length, max_gap, call_summits, self.save_bedGraph )             # <<<<<<<<<<<<<<
  *             #print chrom, ":", ttime() - t0
  * 
  */
-    __Pyx_TraceLine(949,0,__PYX_ERR(0, 949, __pyx_L1_error))
+    __Pyx_TraceLine(951,0,__PYX_ERR(0, 951, __pyx_L1_error))
     __pyx_t_5 = ((PyObject *)__pyx_v_self->save_bedGraph);
     __Pyx_INCREF(__pyx_t_5);
     ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___chrom_call_peak_using_certain_criteria(__pyx_v_self, __pyx_v_peaks, __pyx_v_chrom, __pyx_v_scoring_function_symbols, __pyx_v_score_cutoff_s, __pyx_v_min_length, __pyx_v_max_gap, __pyx_v_call_summits, ((PyBoolObject *)__pyx_t_5));
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":947
+    /* "MACS2/IO/CallPeakUnit.pyx":949
  * 
  *         logging.info("#3 Call peaks for each chromosome...")
  *         for chrom in self.chromosomes:             # <<<<<<<<<<<<<<
  *             # treat/control bedGraph will be saved if requested by user.
  *             self.__chrom_call_peak_using_certain_criteria ( peaks, chrom, scoring_function_symbols, score_cutoff_s, min_length, max_gap, call_summits, self.save_bedGraph )
  */
-    __Pyx_TraceLine(947,0,__PYX_ERR(0, 947, __pyx_L1_error))
+    __Pyx_TraceLine(949,0,__PYX_ERR(0, 949, __pyx_L1_error))
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":953
+  /* "MACS2/IO/CallPeakUnit.pyx":955
  * 
  *         # close bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
  *             fclose(self.bedGraph_treat_f)
  *             fclose(self.bedGraph_ctrl_f)
  */
-  __Pyx_TraceLine(953,0,__PYX_ERR(0, 953, __pyx_L1_error))
-  __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 953, __pyx_L1_error)
+  __Pyx_TraceLine(955,0,__PYX_ERR(0, 955, __pyx_L1_error))
+  __pyx_t_10 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 955, __pyx_L1_error)
   if (__pyx_t_10) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":954
+    /* "MACS2/IO/CallPeakUnit.pyx":956
  *         # close bedGraph file
  *         if self.save_bedGraph:
  *             fclose(self.bedGraph_treat_f)             # <<<<<<<<<<<<<<
  *             fclose(self.bedGraph_ctrl_f)
  *             self.save_bedGraph = False
  */
-    __Pyx_TraceLine(954,0,__PYX_ERR(0, 954, __pyx_L1_error))
+    __Pyx_TraceLine(956,0,__PYX_ERR(0, 956, __pyx_L1_error))
     (void)(fclose(__pyx_v_self->bedGraph_treat_f));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":955
+    /* "MACS2/IO/CallPeakUnit.pyx":957
  *         if self.save_bedGraph:
  *             fclose(self.bedGraph_treat_f)
  *             fclose(self.bedGraph_ctrl_f)             # <<<<<<<<<<<<<<
  *             self.save_bedGraph = False
  * 
  */
-    __Pyx_TraceLine(955,0,__PYX_ERR(0, 955, __pyx_L1_error))
+    __Pyx_TraceLine(957,0,__PYX_ERR(0, 957, __pyx_L1_error))
     (void)(fclose(__pyx_v_self->bedGraph_ctrl_f));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":956
+    /* "MACS2/IO/CallPeakUnit.pyx":958
  *             fclose(self.bedGraph_treat_f)
  *             fclose(self.bedGraph_ctrl_f)
  *             self.save_bedGraph = False             # <<<<<<<<<<<<<<
  * 
  *         #print "time to build peak regions: %f" % self.test_time
  */
-    __Pyx_TraceLine(956,0,__PYX_ERR(0, 956, __pyx_L1_error))
+    __Pyx_TraceLine(958,0,__PYX_ERR(0, 958, __pyx_L1_error))
     __Pyx_INCREF(Py_False);
     __Pyx_GIVEREF(Py_False);
     __Pyx_GOTREF(__pyx_v_self->save_bedGraph);
     __Pyx_DECREF(((PyObject *)__pyx_v_self->save_bedGraph));
     __pyx_v_self->save_bedGraph = ((PyBoolObject *)Py_False);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":953
+    /* "MACS2/IO/CallPeakUnit.pyx":955
  * 
  *         # close bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
@@ -14068,20 +14100,20 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_p
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":960
+  /* "MACS2/IO/CallPeakUnit.pyx":962
  *         #print "time to build peak regions: %f" % self.test_time
  * 
  *         return peaks             # <<<<<<<<<<<<<<
  * 
  *     cdef void __chrom_call_peak_using_certain_criteria ( self, peaks, bytes chrom, list scoring_function_s, list score_cutoff_s, int32_t min_length,
  */
-  __Pyx_TraceLine(960,0,__PYX_ERR(0, 960, __pyx_L1_error))
+  __Pyx_TraceLine(962,0,__PYX_ERR(0, 962, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(__pyx_v_peaks);
   __pyx_r = __pyx_v_peaks;
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":896
+  /* "MACS2/IO/CallPeakUnit.pyx":898
  *         return
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,             # <<<<<<<<<<<<<<
@@ -14127,7 +14159,7 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_9call
     static PyObject **__pyx_pyargnames[] = {&__pyx_n_s_scoring_function_symbols,&__pyx_n_s_score_cutoff_s,&__pyx_n_s_min_length,&__pyx_n_s_max_gap,&__pyx_n_s_call_summits,&__pyx_n_s_cutoff_analysis,0};
     PyObject* values[6] = {0,0,0,0,0,0};
 
-    /* "MACS2/IO/CallPeakUnit.pyx":897
+    /* "MACS2/IO/CallPeakUnit.pyx":899
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,
  *                        int32_t max_gap = 50, bool call_summits = False, bool cutoff_analysis = False ):             # <<<<<<<<<<<<<<
@@ -14164,7 +14196,7 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_9call
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_score_cutoff_s)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("call_peaks", 0, 2, 6, 1); __PYX_ERR(0, 896, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("call_peaks", 0, 2, 6, 1); __PYX_ERR(0, 898, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
@@ -14192,7 +14224,7 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_9call
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "call_peaks") < 0)) __PYX_ERR(0, 896, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "call_peaks") < 0)) __PYX_ERR(0, 898, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -14213,12 +14245,12 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_9call
     __pyx_v_scoring_function_symbols = ((PyObject*)values[0]);
     __pyx_v_score_cutoff_s = ((PyObject*)values[1]);
     if (values[2]) {
-      __pyx_v_min_length = __Pyx_PyInt_As_npy_int32(values[2]); if (unlikely((__pyx_v_min_length == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 896, __pyx_L3_error)
+      __pyx_v_min_length = __Pyx_PyInt_As_npy_int32(values[2]); if (unlikely((__pyx_v_min_length == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 898, __pyx_L3_error)
     } else {
       __pyx_v_min_length = ((__pyx_t_5numpy_int32_t)0xC8);
     }
     if (values[3]) {
-      __pyx_v_max_gap = __Pyx_PyInt_As_npy_int32(values[3]); if (unlikely((__pyx_v_max_gap == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 897, __pyx_L3_error)
+      __pyx_v_max_gap = __Pyx_PyInt_As_npy_int32(values[3]); if (unlikely((__pyx_v_max_gap == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 899, __pyx_L3_error)
     } else {
       __pyx_v_max_gap = ((__pyx_t_5numpy_int32_t)50);
     }
@@ -14227,19 +14259,19 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_9call
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("call_peaks", 0, 2, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 896, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("call_peaks", 0, 2, 6, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 898, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("MACS2.IO.CallPeakUnit.CallerFromAlignments.call_peaks", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_scoring_function_symbols), (&PyList_Type), 1, "scoring_function_symbols", 1))) __PYX_ERR(0, 896, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_score_cutoff_s), (&PyList_Type), 1, "score_cutoff_s", 1))) __PYX_ERR(0, 896, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_call_summits), __pyx_ptype_7cpython_4bool_bool, 1, "call_summits", 0))) __PYX_ERR(0, 897, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_cutoff_analysis), __pyx_ptype_7cpython_4bool_bool, 1, "cutoff_analysis", 0))) __PYX_ERR(0, 897, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_scoring_function_symbols), (&PyList_Type), 1, "scoring_function_symbols", 1))) __PYX_ERR(0, 898, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_score_cutoff_s), (&PyList_Type), 1, "score_cutoff_s", 1))) __PYX_ERR(0, 898, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_call_summits), __pyx_ptype_7cpython_4bool_bool, 1, "call_summits", 0))) __PYX_ERR(0, 899, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_cutoff_analysis), __pyx_ptype_7cpython_4bool_bool, 1, "cutoff_analysis", 0))) __PYX_ERR(0, 899, __pyx_L1_error)
   __pyx_r = __pyx_pf_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_8call_peaks(((struct __pyx_obj_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self), __pyx_v_scoring_function_symbols, __pyx_v_score_cutoff_s, __pyx_v_min_length, __pyx_v_max_gap, __pyx_v_call_summits, __pyx_v_cutoff_analysis);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":896
+  /* "MACS2/IO/CallPeakUnit.pyx":898
  *         return
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,             # <<<<<<<<<<<<<<
@@ -14263,14 +14295,14 @@ static PyObject *__pyx_pf_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_8call
   PyObject *__pyx_t_1 = NULL;
   struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_peaks __pyx_t_2;
   __Pyx_RefNannySetupContext("call_peaks", 0);
-  __Pyx_TraceCall("call_peaks (wrapper)", __pyx_f[0], 896, 0, __PYX_ERR(0, 896, __pyx_L1_error));
+  __Pyx_TraceCall("call_peaks (wrapper)", __pyx_f[0], 898, 0, __PYX_ERR(0, 898, __pyx_L1_error));
   __Pyx_XDECREF(__pyx_r);
   __pyx_t_2.__pyx_n = 4;
   __pyx_t_2.min_length = __pyx_v_min_length;
   __pyx_t_2.max_gap = __pyx_v_max_gap;
   __pyx_t_2.call_summits = __pyx_v_call_summits;
   __pyx_t_2.cutoff_analysis = __pyx_v_cutoff_analysis;
-  __pyx_t_1 = __pyx_vtabptr_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments->call_peaks(__pyx_v_self, __pyx_v_scoring_function_symbols, __pyx_v_score_cutoff_s, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 896, __pyx_L1_error)
+  __pyx_t_1 = __pyx_vtabptr_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments->call_peaks(__pyx_v_self, __pyx_v_scoring_function_symbols, __pyx_v_score_cutoff_s, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 898, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -14288,7 +14320,7 @@ static PyObject *__pyx_pf_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_8call
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":962
+/* "MACS2/IO/CallPeakUnit.pyx":964
  *         return peaks
  * 
  *     cdef void __chrom_call_peak_using_certain_criteria ( self, peaks, bytes chrom, list scoring_function_s, list score_cutoff_s, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -14358,7 +14390,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___close_peak_with_subpeaks __pyx_t_22;
   struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___close_peak_wo_subpeaks __pyx_t_23;
   __Pyx_RefNannySetupContext("__chrom_call_peak_using_certain_criteria", 0);
-  __Pyx_TraceCall("__chrom_call_peak_using_certain_criteria", __pyx_f[0], 962, 0, __PYX_ERR(0, 962, __pyx_L1_error));
+  __Pyx_TraceCall("__chrom_call_peak_using_certain_criteria", __pyx_f[0], 964, 0, __PYX_ERR(0, 964, __pyx_L1_error));
   __pyx_pybuffer_above_cutoff_endpos.pybuffer.buf = NULL;
   __pyx_pybuffer_above_cutoff_endpos.refcount = 0;
   __pyx_pybuffernd_above_cutoff_endpos.data = NULL;
@@ -14384,66 +14416,66 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __pyx_pybuffernd_ctrl_array.data = NULL;
   __pyx_pybuffernd_ctrl_array.rcbuffer = &__pyx_pybuffer_ctrl_array;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":998
+  /* "MACS2/IO/CallPeakUnit.pyx":1000
  * 
  * 
  *         assert len(scoring_function_s) == len(score_cutoff_s), "number of functions and cutoffs should be the same!"             # <<<<<<<<<<<<<<
  * 
  *         peak_content = []           # to store points above cutoff
  */
-  __Pyx_TraceLine(998,0,__PYX_ERR(0, 998, __pyx_L1_error))
+  __Pyx_TraceLine(1000,0,__PYX_ERR(0, 1000, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(__pyx_v_scoring_function_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 998, __pyx_L1_error)
+      __PYX_ERR(0, 1000, __pyx_L1_error)
     }
-    __pyx_t_1 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 998, __pyx_L1_error)
+    __pyx_t_1 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1000, __pyx_L1_error)
     if (unlikely(__pyx_v_score_cutoff_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 998, __pyx_L1_error)
+      __PYX_ERR(0, 1000, __pyx_L1_error)
     }
-    __pyx_t_2 = PyList_GET_SIZE(__pyx_v_score_cutoff_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 998, __pyx_L1_error)
+    __pyx_t_2 = PyList_GET_SIZE(__pyx_v_score_cutoff_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1000, __pyx_L1_error)
     if (unlikely(!((__pyx_t_1 == __pyx_t_2) != 0))) {
       PyErr_SetObject(PyExc_AssertionError, __pyx_kp_u_number_of_functions_and_cutoffs);
-      __PYX_ERR(0, 998, __pyx_L1_error)
+      __PYX_ERR(0, 1000, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1000
+  /* "MACS2/IO/CallPeakUnit.pyx":1002
  *         assert len(scoring_function_s) == len(score_cutoff_s), "number of functions and cutoffs should be the same!"
  * 
  *         peak_content = []           # to store points above cutoff             # <<<<<<<<<<<<<<
  * 
  *         # first, build pileup, self.chr_pos_treat_ctrl
  */
-  __Pyx_TraceLine(1000,0,__PYX_ERR(0, 1000, __pyx_L1_error))
-  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1000, __pyx_L1_error)
+  __Pyx_TraceLine(1002,0,__PYX_ERR(0, 1002, __pyx_L1_error))
+  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1002, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_v_peak_content = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1004
+  /* "MACS2/IO/CallPeakUnit.pyx":1006
  *         # first, build pileup, self.chr_pos_treat_ctrl
  *         # this step will be speeped up if pqtable is pre-computed.
  *         self.__pileup_treat_ctrl_a_chromosome( chrom )             # <<<<<<<<<<<<<<
  *         [pos_array, treat_array, ctrl_array] = self.chr_pos_treat_ctrl
  * 
  */
-  __Pyx_TraceLine(1004,0,__PYX_ERR(0, 1004, __pyx_L1_error))
-  __pyx_t_3 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___pileup_treat_ctrl_a_chromosome(__pyx_v_self, __pyx_v_chrom); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1004, __pyx_L1_error)
+  __Pyx_TraceLine(1006,0,__PYX_ERR(0, 1006, __pyx_L1_error))
+  __pyx_t_3 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___pileup_treat_ctrl_a_chromosome(__pyx_v_self, __pyx_v_chrom); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1006, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1005
+  /* "MACS2/IO/CallPeakUnit.pyx":1007
  *         # this step will be speeped up if pqtable is pre-computed.
  *         self.__pileup_treat_ctrl_a_chromosome( chrom )
  *         [pos_array, treat_array, ctrl_array] = self.chr_pos_treat_ctrl             # <<<<<<<<<<<<<<
  * 
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  */
-  __Pyx_TraceLine(1005,0,__PYX_ERR(0, 1005, __pyx_L1_error))
+  __Pyx_TraceLine(1007,0,__PYX_ERR(0, 1007, __pyx_L1_error))
   __pyx_t_3 = __pyx_v_self->chr_pos_treat_ctrl;
   __Pyx_INCREF(__pyx_t_3);
   if (likely(__pyx_t_3 != Py_None)) {
@@ -14452,7 +14484,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     if (unlikely(size != 3)) {
       if (size > 3) __Pyx_RaiseTooManyValuesError(3);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 1005, __pyx_L1_error)
+      __PYX_ERR(0, 1007, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     __pyx_t_4 = PyList_GET_ITEM(sequence, 0); 
@@ -14462,20 +14494,20 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     __Pyx_INCREF(__pyx_t_5);
     __Pyx_INCREF(__pyx_t_6);
     #else
-    __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1005, __pyx_L1_error)
+    __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1007, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1005, __pyx_L1_error)
+    __pyx_t_5 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1007, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_6 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1005, __pyx_L1_error)
+    __pyx_t_6 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1007, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     #endif
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   } else {
-    __Pyx_RaiseNoneNotIterableError(); __PYX_ERR(0, 1005, __pyx_L1_error)
+    __Pyx_RaiseNoneNotIterableError(); __PYX_ERR(0, 1007, __pyx_L1_error)
   }
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1005, __pyx_L1_error)
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1005, __pyx_L1_error)
-  if (!(likely(((__pyx_t_6) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1005, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1007, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1007, __pyx_L1_error)
+  if (!(likely(((__pyx_t_6) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1007, __pyx_L1_error)
   __pyx_t_7 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -14492,7 +14524,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_9 = __pyx_t_10 = __pyx_t_11 = 0;
     }
     __pyx_pybuffernd_pos_array.diminfo[0].strides = __pyx_pybuffernd_pos_array.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_pos_array.diminfo[0].shape = __pyx_pybuffernd_pos_array.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1005, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1007, __pyx_L1_error)
   }
   __pyx_t_7 = 0;
   __pyx_v_pos_array = ((PyArrayObject *)__pyx_t_4);
@@ -14513,7 +14545,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_11 = __pyx_t_10 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_treat_array.diminfo[0].strides = __pyx_pybuffernd_treat_array.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_treat_array.diminfo[0].shape = __pyx_pybuffernd_treat_array.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1005, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1007, __pyx_L1_error)
   }
   __pyx_t_12 = 0;
   __pyx_v_treat_array = ((PyArrayObject *)__pyx_t_5);
@@ -14534,36 +14566,36 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_9 = __pyx_t_10 = __pyx_t_11 = 0;
     }
     __pyx_pybuffernd_ctrl_array.diminfo[0].strides = __pyx_pybuffernd_ctrl_array.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_ctrl_array.diminfo[0].shape = __pyx_pybuffernd_ctrl_array.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1005, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1007, __pyx_L1_error)
   }
   __pyx_t_12 = 0;
   __pyx_v_ctrl_array = ((PyArrayObject *)__pyx_t_6);
   __pyx_t_6 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1008
+  /* "MACS2/IO/CallPeakUnit.pyx":1010
  * 
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  *         if save_bedGraph:             # <<<<<<<<<<<<<<
  *             self.__write_bedGraph_for_a_chromosome ( chrom )
  * 
  */
-  __Pyx_TraceLine(1008,0,__PYX_ERR(0, 1008, __pyx_L1_error))
-  __pyx_t_13 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_save_bedGraph)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1008, __pyx_L1_error)
+  __Pyx_TraceLine(1010,0,__PYX_ERR(0, 1010, __pyx_L1_error))
+  __pyx_t_13 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_save_bedGraph)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1010, __pyx_L1_error)
   if (__pyx_t_13) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1009
+    /* "MACS2/IO/CallPeakUnit.pyx":1011
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  *         if save_bedGraph:
  *             self.__write_bedGraph_for_a_chromosome ( chrom )             # <<<<<<<<<<<<<<
  * 
  *         # keep all types of scores needed
  */
-    __Pyx_TraceLine(1009,0,__PYX_ERR(0, 1009, __pyx_L1_error))
-    __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___write_bedGraph_for_a_chromosome(__pyx_v_self, __pyx_v_chrom)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1009, __pyx_L1_error)
+    __Pyx_TraceLine(1011,0,__PYX_ERR(0, 1011, __pyx_L1_error))
+    __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___write_bedGraph_for_a_chromosome(__pyx_v_self, __pyx_v_chrom)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1011, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1008
+    /* "MACS2/IO/CallPeakUnit.pyx":1010
  * 
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  *         if save_bedGraph:             # <<<<<<<<<<<<<<
@@ -14572,80 +14604,80 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1013
+  /* "MACS2/IO/CallPeakUnit.pyx":1015
  *         # keep all types of scores needed
  *         #t0 = ttime()
  *         score_array_s = []             # <<<<<<<<<<<<<<
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]
  */
-  __Pyx_TraceLine(1013,0,__PYX_ERR(0, 1013, __pyx_L1_error))
-  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1013, __pyx_L1_error)
+  __Pyx_TraceLine(1015,0,__PYX_ERR(0, 1015, __pyx_L1_error))
+  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1015, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_v_score_array_s = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1014
+  /* "MACS2/IO/CallPeakUnit.pyx":1016
  *         #t0 = ttime()
  *         score_array_s = []
  *         for i in range(len(scoring_function_s)):             # <<<<<<<<<<<<<<
  *             s = scoring_function_s[i]
  *             if s == 'p':
  */
-  __Pyx_TraceLine(1014,0,__PYX_ERR(0, 1014, __pyx_L1_error))
+  __Pyx_TraceLine(1016,0,__PYX_ERR(0, 1016, __pyx_L1_error))
   if (unlikely(__pyx_v_scoring_function_s == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 1014, __pyx_L1_error)
+    __PYX_ERR(0, 1016, __pyx_L1_error)
   }
-  __pyx_t_2 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1014, __pyx_L1_error)
+  __pyx_t_2 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1016, __pyx_L1_error)
   __pyx_t_1 = __pyx_t_2;
   for (__pyx_t_14 = 0; __pyx_t_14 < __pyx_t_1; __pyx_t_14+=1) {
     __pyx_v_i = __pyx_t_14;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1015
+    /* "MACS2/IO/CallPeakUnit.pyx":1017
  *         score_array_s = []
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]             # <<<<<<<<<<<<<<
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  */
-    __Pyx_TraceLine(1015,0,__PYX_ERR(0, 1015, __pyx_L1_error))
+    __Pyx_TraceLine(1017,0,__PYX_ERR(0, 1017, __pyx_L1_error))
     if (unlikely(__pyx_v_scoring_function_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1015, __pyx_L1_error)
+      __PYX_ERR(0, 1017, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_scoring_function_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1015, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_scoring_function_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1017, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    if (!(likely(PyUnicode_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "unicode", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 1015, __pyx_L1_error)
+    if (!(likely(PyUnicode_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "unicode", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 1017, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_s, ((PyObject*)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1016
+    /* "MACS2/IO/CallPeakUnit.pyx":1018
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]
  *             if s == 'p':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':
  */
-    __Pyx_TraceLine(1016,0,__PYX_ERR(0, 1016, __pyx_L1_error))
-    __pyx_t_13 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_p, Py_EQ)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1016, __pyx_L1_error)
+    __Pyx_TraceLine(1018,0,__PYX_ERR(0, 1018, __pyx_L1_error))
+    __pyx_t_13 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_p, Py_EQ)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1018, __pyx_L1_error)
     __pyx_t_15 = (__pyx_t_13 != 0);
     if (__pyx_t_15) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1017
+      /* "MACS2/IO/CallPeakUnit.pyx":1019
  *             s = scoring_function_s[i]
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  */
-      __Pyx_TraceLine(1017,0,__PYX_ERR(0, 1017, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1017, __pyx_L1_error)
+      __Pyx_TraceLine(1019,0,__PYX_ERR(0, 1019, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1019, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1017, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1019, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1016
+      /* "MACS2/IO/CallPeakUnit.pyx":1018
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]
  *             if s == 'p':             # <<<<<<<<<<<<<<
@@ -14655,32 +14687,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1018
+    /* "MACS2/IO/CallPeakUnit.pyx":1020
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':
  */
-    __Pyx_TraceLine(1018,0,__PYX_ERR(0, 1018, __pyx_L1_error))
-    __pyx_t_15 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_q, Py_EQ)); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 1018, __pyx_L1_error)
+    __Pyx_TraceLine(1020,0,__PYX_ERR(0, 1020, __pyx_L1_error))
+    __pyx_t_15 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_q, Py_EQ)); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 1020, __pyx_L1_error)
     __pyx_t_13 = (__pyx_t_15 != 0);
     if (__pyx_t_13) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1019
+      /* "MACS2/IO/CallPeakUnit.pyx":1021
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  */
-      __Pyx_TraceLine(1019,0,__PYX_ERR(0, 1019, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_qscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1019, __pyx_L1_error)
+      __Pyx_TraceLine(1021,0,__PYX_ERR(0, 1021, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_qscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1021, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1019, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1021, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1018
+      /* "MACS2/IO/CallPeakUnit.pyx":1020
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':             # <<<<<<<<<<<<<<
@@ -14690,32 +14722,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1020
+    /* "MACS2/IO/CallPeakUnit.pyx":1022
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':
  */
-    __Pyx_TraceLine(1020,0,__PYX_ERR(0, 1020, __pyx_L1_error))
-    __pyx_t_13 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_f, Py_EQ)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1020, __pyx_L1_error)
+    __Pyx_TraceLine(1022,0,__PYX_ERR(0, 1022, __pyx_L1_error))
+    __pyx_t_13 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_f, Py_EQ)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1022, __pyx_L1_error)
     __pyx_t_15 = (__pyx_t_13 != 0);
     if (__pyx_t_15) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1021
+      /* "MACS2/IO/CallPeakUnit.pyx":1023
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  *             elif s == 's':
  *                 score_array_s.append( self.__cal_subtraction( treat_array, ctrl_array ) )
  */
-      __Pyx_TraceLine(1021,0,__PYX_ERR(0, 1021, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_FE(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1021, __pyx_L1_error)
+      __Pyx_TraceLine(1023,0,__PYX_ERR(0, 1023, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_FE(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1023, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1021, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1023, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1020
+      /* "MACS2/IO/CallPeakUnit.pyx":1022
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':             # <<<<<<<<<<<<<<
@@ -14725,32 +14757,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1022
+    /* "MACS2/IO/CallPeakUnit.pyx":1024
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_subtraction( treat_array, ctrl_array ) )
  * 
  */
-    __Pyx_TraceLine(1022,0,__PYX_ERR(0, 1022, __pyx_L1_error))
-    __pyx_t_15 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_s, Py_EQ)); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 1022, __pyx_L1_error)
+    __Pyx_TraceLine(1024,0,__PYX_ERR(0, 1024, __pyx_L1_error))
+    __pyx_t_15 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_s, Py_EQ)); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 1024, __pyx_L1_error)
     __pyx_t_13 = (__pyx_t_15 != 0);
     if (__pyx_t_13) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1023
+      /* "MACS2/IO/CallPeakUnit.pyx":1025
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':
  *                 score_array_s.append( self.__cal_subtraction( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  * 
  *         #self.test_time += ttime() - t0
  */
-      __Pyx_TraceLine(1023,0,__PYX_ERR(0, 1023, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_subtraction(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1023, __pyx_L1_error)
+      __Pyx_TraceLine(1025,0,__PYX_ERR(0, 1025, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_subtraction(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1025, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1023, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1025, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1022
+      /* "MACS2/IO/CallPeakUnit.pyx":1024
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':             # <<<<<<<<<<<<<<
@@ -14761,20 +14793,20 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     __pyx_L6:;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1030
+  /* "MACS2/IO/CallPeakUnit.pyx":1032
  *         #t0 = ttime()
  *         # get the regions with scores above cutoffs
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,score_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?             # <<<<<<<<<<<<<<
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  */
-  __Pyx_TraceLine(1030,0,__PYX_ERR(0, 1030, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1030, __pyx_L1_error)
+  __Pyx_TraceLine(1032,0,__PYX_ERR(0, 1032, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1032, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_nonzero); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1030, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_nonzero); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1032, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = ((PyObject *)__pyx_f_5MACS2_2IO_12CallPeakUnit_apply_multiple_cutoffs(__pyx_v_score_array_s, __pyx_v_score_cutoff_s)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1030, __pyx_L1_error)
+  __pyx_t_6 = ((PyObject *)__pyx_f_5MACS2_2IO_12CallPeakUnit_apply_multiple_cutoffs(__pyx_v_score_array_s, __pyx_v_score_cutoff_s)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1032, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_t_4 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -14789,48 +14821,48 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __pyx_t_3 = (__pyx_t_4) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_4, __pyx_t_6) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_6);
   __Pyx_XDECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1030, __pyx_L1_error)
+  if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1032, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1030, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1032, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1030, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1032, __pyx_L1_error)
   __pyx_v_above_cutoff = ((PyArrayObject *)__pyx_t_5);
   __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1031
+  /* "MACS2/IO/CallPeakUnit.pyx":1033
  *         # get the regions with scores above cutoffs
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,score_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices             # <<<<<<<<<<<<<<
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  */
-  __Pyx_TraceLine(1031,0,__PYX_ERR(0, 1031, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1031, __pyx_L1_error)
+  __Pyx_TraceLine(1033,0,__PYX_ERR(0, 1033, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1033, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_arange); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1031, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_arange); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1033, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_pos_array->dimensions[0])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1031, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_pos_array->dimensions[0])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1033, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1031, __pyx_L1_error)
+  __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1033, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_GIVEREF(__pyx_t_5);
   PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5);
   __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1031, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1033, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1031, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_6, __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1031, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1033, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_6, __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1033, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_GetItem(__pyx_t_4, ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1031, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetItem(__pyx_t_4, ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1033, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1031, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1033, __pyx_L1_error)
   __pyx_t_7 = ((PyArrayObject *)__pyx_t_5);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -14847,23 +14879,23 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_11 = __pyx_t_10 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_above_cutoff_index_array.diminfo[0].strides = __pyx_pybuffernd_above_cutoff_index_array.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_above_cutoff_index_array.diminfo[0].shape = __pyx_pybuffernd_above_cutoff_index_array.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1031, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1033, __pyx_L1_error)
   }
   __pyx_t_7 = 0;
   __pyx_v_above_cutoff_index_array = ((PyArrayObject *)__pyx_t_5);
   __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1032
+  /* "MACS2/IO/CallPeakUnit.pyx":1034
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,score_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff             # <<<<<<<<<<<<<<
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  */
-  __Pyx_TraceLine(1032,0,__PYX_ERR(0, 1032, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1032, __pyx_L1_error)
+  __Pyx_TraceLine(1034,0,__PYX_ERR(0, 1034, __pyx_L1_error))
+  __pyx_t_5 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1034, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1032, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1034, __pyx_L1_error)
   __pyx_t_7 = ((PyArrayObject *)__pyx_t_5);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -14880,26 +14912,26 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_9 = __pyx_t_10 = __pyx_t_11 = 0;
     }
     __pyx_pybuffernd_above_cutoff_endpos.diminfo[0].strides = __pyx_pybuffernd_above_cutoff_endpos.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_above_cutoff_endpos.diminfo[0].shape = __pyx_pybuffernd_above_cutoff_endpos.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1032, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1034, __pyx_L1_error)
   }
   __pyx_t_7 = 0;
   __pyx_v_above_cutoff_endpos = ((PyArrayObject *)__pyx_t_5);
   __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1033
+  /* "MACS2/IO/CallPeakUnit.pyx":1035
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff             # <<<<<<<<<<<<<<
  * 
  *         if above_cutoff.size == 0:
  */
-  __Pyx_TraceLine(1033,0,__PYX_ERR(0, 1033, __pyx_L1_error))
-  __pyx_t_5 = PyNumber_Subtract(((PyObject *)__pyx_v_above_cutoff), __pyx_int_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1033, __pyx_L1_error)
+  __Pyx_TraceLine(1035,0,__PYX_ERR(0, 1035, __pyx_L1_error))
+  __pyx_t_5 = PyNumber_Subtract(((PyObject *)__pyx_v_above_cutoff), __pyx_int_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1035, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1033, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1035, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1033, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1035, __pyx_L1_error)
   __pyx_t_7 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -14916,40 +14948,40 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_11 = __pyx_t_10 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_above_cutoff_startpos.diminfo[0].strides = __pyx_pybuffernd_above_cutoff_startpos.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_above_cutoff_startpos.diminfo[0].shape = __pyx_pybuffernd_above_cutoff_startpos.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1033, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1035, __pyx_L1_error)
   }
   __pyx_t_7 = 0;
   __pyx_v_above_cutoff_startpos = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1035
+  /* "MACS2/IO/CallPeakUnit.pyx":1037
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  *         if above_cutoff.size == 0:             # <<<<<<<<<<<<<<
  *             # nothing above cutoff
  *             return
  */
-  __Pyx_TraceLine(1035,0,__PYX_ERR(0, 1035, __pyx_L1_error))
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff), __pyx_n_s_size); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1035, __pyx_L1_error)
+  __Pyx_TraceLine(1037,0,__PYX_ERR(0, 1037, __pyx_L1_error))
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff), __pyx_n_s_size); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1037, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyInt_EqObjC(__pyx_t_4, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1035, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_EqObjC(__pyx_t_4, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1037, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_13 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1035, __pyx_L1_error)
+  __pyx_t_13 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1037, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   if (__pyx_t_13) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1037
+    /* "MACS2/IO/CallPeakUnit.pyx":1039
  *         if above_cutoff.size == 0:
  *             # nothing above cutoff
  *             return             # <<<<<<<<<<<<<<
  * 
  *         if above_cutoff[0] == 0:
  */
-    __Pyx_TraceLine(1037,0,__PYX_ERR(0, 1037, __pyx_L1_error))
+    __Pyx_TraceLine(1039,0,__PYX_ERR(0, 1039, __pyx_L1_error))
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1035
+    /* "MACS2/IO/CallPeakUnit.pyx":1037
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  *         if above_cutoff.size == 0:             # <<<<<<<<<<<<<<
@@ -14958,31 +14990,31 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1039
+  /* "MACS2/IO/CallPeakUnit.pyx":1041
  *             return
  * 
  *         if above_cutoff[0] == 0:             # <<<<<<<<<<<<<<
  *             # first element > cutoff, fix the first point as 0. otherwise it would be the last item in data[chrom]['pos']
  *             above_cutoff_startpos[0] = 0
  */
-  __Pyx_TraceLine(1039,0,__PYX_ERR(0, 1039, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_above_cutoff), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1039, __pyx_L1_error)
+  __Pyx_TraceLine(1041,0,__PYX_ERR(0, 1041, __pyx_L1_error))
+  __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_above_cutoff), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1041, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_5, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1039, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_5, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1041, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_13 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1039, __pyx_L1_error)
+  __pyx_t_13 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1041, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   if (__pyx_t_13) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1041
+    /* "MACS2/IO/CallPeakUnit.pyx":1043
  *         if above_cutoff[0] == 0:
  *             # first element > cutoff, fix the first point as 0. otherwise it would be the last item in data[chrom]['pos']
  *             above_cutoff_startpos[0] = 0             # <<<<<<<<<<<<<<
  * 
  *         #print "apply cutoff -- chrom:",chrom,"  time:", ttime() - t0
  */
-    __Pyx_TraceLine(1041,0,__PYX_ERR(0, 1041, __pyx_L1_error))
+    __Pyx_TraceLine(1043,0,__PYX_ERR(0, 1043, __pyx_L1_error))
     __pyx_t_17 = 0;
     __pyx_t_8 = -1;
     if (__pyx_t_17 < 0) {
@@ -14991,11 +15023,11 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     } else if (unlikely(__pyx_t_17 >= __pyx_pybuffernd_above_cutoff_startpos.diminfo[0].shape)) __pyx_t_8 = 0;
     if (unlikely(__pyx_t_8 != -1)) {
       __Pyx_RaiseBufferIndexError(__pyx_t_8);
-      __PYX_ERR(0, 1041, __pyx_L1_error)
+      __PYX_ERR(0, 1043, __pyx_L1_error)
     }
     *__Pyx_BufPtrStrided1d(__pyx_t_5numpy_int32_t *, __pyx_pybuffernd_above_cutoff_startpos.rcbuffer->pybuffer.buf, __pyx_t_17, __pyx_pybuffernd_above_cutoff_startpos.diminfo[0].strides) = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1039
+    /* "MACS2/IO/CallPeakUnit.pyx":1041
  *             return
  * 
  *         if above_cutoff[0] == 0:             # <<<<<<<<<<<<<<
@@ -15004,125 +15036,125 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1048
+  /* "MACS2/IO/CallPeakUnit.pyx":1050
  * 
  *         # first bit of region above cutoff
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data             # <<<<<<<<<<<<<<
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  */
-  __Pyx_TraceLine(1048,0,__PYX_ERR(0, 1048, __pyx_L1_error))
+  __Pyx_TraceLine(1050,0,__PYX_ERR(0, 1050, __pyx_L1_error))
   __pyx_v_acs_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_startpos->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1049
+  /* "MACS2/IO/CallPeakUnit.pyx":1051
  *         # first bit of region above cutoff
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data             # <<<<<<<<<<<<<<
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  */
-  __Pyx_TraceLine(1049,0,__PYX_ERR(0, 1049, __pyx_L1_error))
+  __Pyx_TraceLine(1051,0,__PYX_ERR(0, 1051, __pyx_L1_error))
   __pyx_v_ace_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_endpos->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1050
+  /* "MACS2/IO/CallPeakUnit.pyx":1052
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data             # <<<<<<<<<<<<<<
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  */
-  __Pyx_TraceLine(1050,0,__PYX_ERR(0, 1050, __pyx_L1_error))
+  __Pyx_TraceLine(1052,0,__PYX_ERR(0, 1052, __pyx_L1_error))
   __pyx_v_acia_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_index_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1051
+  /* "MACS2/IO/CallPeakUnit.pyx":1053
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data             # <<<<<<<<<<<<<<
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  */
-  __Pyx_TraceLine(1051,0,__PYX_ERR(0, 1051, __pyx_L1_error))
+  __Pyx_TraceLine(1053,0,__PYX_ERR(0, 1053, __pyx_L1_error))
   __pyx_v_treat_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_treat_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1052
+  /* "MACS2/IO/CallPeakUnit.pyx":1054
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data             # <<<<<<<<<<<<<<
  * 
  *         ts = acs_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1052,0,__PYX_ERR(0, 1052, __pyx_L1_error))
+  __Pyx_TraceLine(1054,0,__PYX_ERR(0, 1054, __pyx_L1_error))
   __pyx_v_ctrl_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_ctrl_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1054
+  /* "MACS2/IO/CallPeakUnit.pyx":1056
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  *         ts = acs_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1054,0,__PYX_ERR(0, 1054, __pyx_L1_error))
+  __Pyx_TraceLine(1056,0,__PYX_ERR(0, 1056, __pyx_L1_error))
   __pyx_v_ts = (__pyx_v_acs_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1055
+  /* "MACS2/IO/CallPeakUnit.pyx":1057
  * 
  *         ts = acs_ptr[ 0 ]
  *         te = ace_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]
  */
-  __Pyx_TraceLine(1055,0,__PYX_ERR(0, 1055, __pyx_L1_error))
+  __Pyx_TraceLine(1057,0,__PYX_ERR(0, 1057, __pyx_L1_error))
   __pyx_v_te = (__pyx_v_ace_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1056
+  /* "MACS2/IO/CallPeakUnit.pyx":1058
  *         ts = acs_ptr[ 0 ]
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         tp = treat_array_ptr[ ti ]
  *         cp = ctrl_array_ptr[ ti ]
  */
-  __Pyx_TraceLine(1056,0,__PYX_ERR(0, 1056, __pyx_L1_error))
+  __Pyx_TraceLine(1058,0,__PYX_ERR(0, 1058, __pyx_L1_error))
   __pyx_v_ti = (__pyx_v_acia_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1057
+  /* "MACS2/IO/CallPeakUnit.pyx":1059
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *         cp = ctrl_array_ptr[ ti ]
  * 
  */
-  __Pyx_TraceLine(1057,0,__PYX_ERR(0, 1057, __pyx_L1_error))
+  __Pyx_TraceLine(1059,0,__PYX_ERR(0, 1059, __pyx_L1_error))
   __pyx_v_tp = (__pyx_v_treat_array_ptr[__pyx_v_ti]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1058
+  /* "MACS2/IO/CallPeakUnit.pyx":1060
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]
  *         cp = ctrl_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  * 
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  */
-  __Pyx_TraceLine(1058,0,__PYX_ERR(0, 1058, __pyx_L1_error))
+  __Pyx_TraceLine(1060,0,__PYX_ERR(0, 1060, __pyx_L1_error))
   __pyx_v_cp = (__pyx_v_ctrl_array_ptr[__pyx_v_ti]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1060
+  /* "MACS2/IO/CallPeakUnit.pyx":1062
  *         cp = ctrl_array_ptr[ ti ]
  * 
  *         peak_content.append( ( ts, te, tp, cp, ti ) )             # <<<<<<<<<<<<<<
  *         lastp = te
  *         acs_ptr += 1
  */
-  __Pyx_TraceLine(1060,0,__PYX_ERR(0, 1060, __pyx_L1_error))
-  __pyx_t_4 = __Pyx_PyInt_From_npy_int64(__pyx_v_ts); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1060, __pyx_L1_error)
+  __Pyx_TraceLine(1062,0,__PYX_ERR(0, 1062, __pyx_L1_error))
+  __pyx_t_4 = __Pyx_PyInt_From_npy_int64(__pyx_v_ts); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1062, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyInt_From_npy_int64(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1060, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_From_npy_int64(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1062, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = PyFloat_FromDouble(__pyx_v_tp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1060, __pyx_L1_error)
+  __pyx_t_6 = PyFloat_FromDouble(__pyx_v_tp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1062, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cp); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1060, __pyx_L1_error)
+  __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cp); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1062, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_18 = __Pyx_PyInt_From_npy_int64(__pyx_v_ti); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1060, __pyx_L1_error)
+  __pyx_t_18 = __Pyx_PyInt_From_npy_int64(__pyx_v_ti); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1062, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_18);
-  __pyx_t_19 = PyTuple_New(5); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 1060, __pyx_L1_error)
+  __pyx_t_19 = PyTuple_New(5); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 1062, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_19);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_19, 0, __pyx_t_4);
@@ -15139,182 +15171,182 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __pyx_t_6 = 0;
   __pyx_t_3 = 0;
   __pyx_t_18 = 0;
-  __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_19); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1060, __pyx_L1_error)
+  __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_19); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1062, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_19); __pyx_t_19 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1061
+  /* "MACS2/IO/CallPeakUnit.pyx":1063
  * 
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  *         lastp = te             # <<<<<<<<<<<<<<
  *         acs_ptr += 1
  *         ace_ptr += 1
  */
-  __Pyx_TraceLine(1061,0,__PYX_ERR(0, 1061, __pyx_L1_error))
+  __Pyx_TraceLine(1063,0,__PYX_ERR(0, 1063, __pyx_L1_error))
   __pyx_v_lastp = __pyx_v_te;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1062
+  /* "MACS2/IO/CallPeakUnit.pyx":1064
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  *         lastp = te
  *         acs_ptr += 1             # <<<<<<<<<<<<<<
  *         ace_ptr += 1
  *         acia_ptr+= 1
  */
-  __Pyx_TraceLine(1062,0,__PYX_ERR(0, 1062, __pyx_L1_error))
+  __Pyx_TraceLine(1064,0,__PYX_ERR(0, 1064, __pyx_L1_error))
   __pyx_v_acs_ptr = (__pyx_v_acs_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1063
+  /* "MACS2/IO/CallPeakUnit.pyx":1065
  *         lastp = te
  *         acs_ptr += 1
  *         ace_ptr += 1             # <<<<<<<<<<<<<<
  *         acia_ptr+= 1
  * 
  */
-  __Pyx_TraceLine(1063,0,__PYX_ERR(0, 1063, __pyx_L1_error))
+  __Pyx_TraceLine(1065,0,__PYX_ERR(0, 1065, __pyx_L1_error))
   __pyx_v_ace_ptr = (__pyx_v_ace_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1064
+  /* "MACS2/IO/CallPeakUnit.pyx":1066
  *         acs_ptr += 1
  *         ace_ptr += 1
  *         acia_ptr+= 1             # <<<<<<<<<<<<<<
  * 
  *         for i in range( 1, above_cutoff_startpos.shape[0] ):
  */
-  __Pyx_TraceLine(1064,0,__PYX_ERR(0, 1064, __pyx_L1_error))
+  __Pyx_TraceLine(1066,0,__PYX_ERR(0, 1066, __pyx_L1_error))
   __pyx_v_acia_ptr = (__pyx_v_acia_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1066
+  /* "MACS2/IO/CallPeakUnit.pyx":1068
  *         acia_ptr+= 1
  * 
  *         for i in range( 1, above_cutoff_startpos.shape[0] ):             # <<<<<<<<<<<<<<
  *             ts = acs_ptr[ 0 ]
  *             te = ace_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1066,0,__PYX_ERR(0, 1066, __pyx_L1_error))
+  __Pyx_TraceLine(1068,0,__PYX_ERR(0, 1068, __pyx_L1_error))
   __pyx_t_20 = (__pyx_v_above_cutoff_startpos->dimensions[0]);
   __pyx_t_21 = __pyx_t_20;
   for (__pyx_t_14 = 1; __pyx_t_14 < __pyx_t_21; __pyx_t_14+=1) {
     __pyx_v_i = __pyx_t_14;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1067
+    /* "MACS2/IO/CallPeakUnit.pyx":1069
  * 
  *         for i in range( 1, above_cutoff_startpos.shape[0] ):
  *             ts = acs_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *             te = ace_ptr[ 0 ]
  *             ti = acia_ptr[ 0 ]
  */
-    __Pyx_TraceLine(1067,0,__PYX_ERR(0, 1067, __pyx_L1_error))
+    __Pyx_TraceLine(1069,0,__PYX_ERR(0, 1069, __pyx_L1_error))
     __pyx_v_ts = (__pyx_v_acs_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1068
+    /* "MACS2/IO/CallPeakUnit.pyx":1070
  *         for i in range( 1, above_cutoff_startpos.shape[0] ):
  *             ts = acs_ptr[ 0 ]
  *             te = ace_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *             ti = acia_ptr[ 0 ]
  *             acs_ptr += 1
  */
-    __Pyx_TraceLine(1068,0,__PYX_ERR(0, 1068, __pyx_L1_error))
+    __Pyx_TraceLine(1070,0,__PYX_ERR(0, 1070, __pyx_L1_error))
     __pyx_v_te = (__pyx_v_ace_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1069
+    /* "MACS2/IO/CallPeakUnit.pyx":1071
  *             ts = acs_ptr[ 0 ]
  *             te = ace_ptr[ 0 ]
  *             ti = acia_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *             acs_ptr += 1
  *             ace_ptr += 1
  */
-    __Pyx_TraceLine(1069,0,__PYX_ERR(0, 1069, __pyx_L1_error))
+    __Pyx_TraceLine(1071,0,__PYX_ERR(0, 1071, __pyx_L1_error))
     __pyx_v_ti = (__pyx_v_acia_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1070
+    /* "MACS2/IO/CallPeakUnit.pyx":1072
  *             te = ace_ptr[ 0 ]
  *             ti = acia_ptr[ 0 ]
  *             acs_ptr += 1             # <<<<<<<<<<<<<<
  *             ace_ptr += 1
  *             acia_ptr+= 1
  */
-    __Pyx_TraceLine(1070,0,__PYX_ERR(0, 1070, __pyx_L1_error))
+    __Pyx_TraceLine(1072,0,__PYX_ERR(0, 1072, __pyx_L1_error))
     __pyx_v_acs_ptr = (__pyx_v_acs_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1071
+    /* "MACS2/IO/CallPeakUnit.pyx":1073
  *             ti = acia_ptr[ 0 ]
  *             acs_ptr += 1
  *             ace_ptr += 1             # <<<<<<<<<<<<<<
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ]
  */
-    __Pyx_TraceLine(1071,0,__PYX_ERR(0, 1071, __pyx_L1_error))
+    __Pyx_TraceLine(1073,0,__PYX_ERR(0, 1073, __pyx_L1_error))
     __pyx_v_ace_ptr = (__pyx_v_ace_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1072
+    /* "MACS2/IO/CallPeakUnit.pyx":1074
  *             acs_ptr += 1
  *             ace_ptr += 1
  *             acia_ptr+= 1             # <<<<<<<<<<<<<<
  *             tp = treat_array_ptr[ ti ]
  *             cp = ctrl_array_ptr[ ti ]
  */
-    __Pyx_TraceLine(1072,0,__PYX_ERR(0, 1072, __pyx_L1_error))
+    __Pyx_TraceLine(1074,0,__PYX_ERR(0, 1074, __pyx_L1_error))
     __pyx_v_acia_ptr = (__pyx_v_acia_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1073
+    /* "MACS2/IO/CallPeakUnit.pyx":1075
  *             ace_ptr += 1
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp
  */
-    __Pyx_TraceLine(1073,0,__PYX_ERR(0, 1073, __pyx_L1_error))
+    __Pyx_TraceLine(1075,0,__PYX_ERR(0, 1075, __pyx_L1_error))
     __pyx_v_tp = (__pyx_v_treat_array_ptr[__pyx_v_ti]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1074
+    /* "MACS2/IO/CallPeakUnit.pyx":1076
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ]
  *             cp = ctrl_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *             tl = ts - lastp
  *             if tl <= max_gap:
  */
-    __Pyx_TraceLine(1074,0,__PYX_ERR(0, 1074, __pyx_L1_error))
+    __Pyx_TraceLine(1076,0,__PYX_ERR(0, 1076, __pyx_L1_error))
     __pyx_v_cp = (__pyx_v_ctrl_array_ptr[__pyx_v_ti]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1075
+    /* "MACS2/IO/CallPeakUnit.pyx":1077
  *             tp = treat_array_ptr[ ti ]
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp             # <<<<<<<<<<<<<<
  *             if tl <= max_gap:
  *                 # append.
  */
-    __Pyx_TraceLine(1075,0,__PYX_ERR(0, 1075, __pyx_L1_error))
+    __Pyx_TraceLine(1077,0,__PYX_ERR(0, 1077, __pyx_L1_error))
     __pyx_v_tl = (__pyx_v_ts - __pyx_v_lastp);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1076
+    /* "MACS2/IO/CallPeakUnit.pyx":1078
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp
  *             if tl <= max_gap:             # <<<<<<<<<<<<<<
  *                 # append.
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )
  */
-    __Pyx_TraceLine(1076,0,__PYX_ERR(0, 1076, __pyx_L1_error))
+    __Pyx_TraceLine(1078,0,__PYX_ERR(0, 1078, __pyx_L1_error))
     __pyx_t_13 = ((__pyx_v_tl <= __pyx_v_max_gap) != 0);
     if (__pyx_t_13) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1078
+      /* "MACS2/IO/CallPeakUnit.pyx":1080
  *             if tl <= max_gap:
  *                 # append.
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )             # <<<<<<<<<<<<<<
  *                 lastp = te #above_cutoff_endpos[i]
  *             else:
  */
-      __Pyx_TraceLine(1078,0,__PYX_ERR(0, 1078, __pyx_L1_error))
-      __pyx_t_19 = __Pyx_PyInt_From_npy_int64(__pyx_v_ts); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 1078, __pyx_L1_error)
+      __Pyx_TraceLine(1080,0,__PYX_ERR(0, 1080, __pyx_L1_error))
+      __pyx_t_19 = __Pyx_PyInt_From_npy_int64(__pyx_v_ts); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 1080, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_19);
-      __pyx_t_18 = __Pyx_PyInt_From_npy_int64(__pyx_v_te); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1078, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyInt_From_npy_int64(__pyx_v_te); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1080, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_18);
-      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_tp); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1078, __pyx_L1_error)
+      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_tp); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1080, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_6 = PyFloat_FromDouble(__pyx_v_cp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1078, __pyx_L1_error)
+      __pyx_t_6 = PyFloat_FromDouble(__pyx_v_cp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1080, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_5 = __Pyx_PyInt_From_npy_int64(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1078, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyInt_From_npy_int64(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1080, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_4 = PyTuple_New(5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1078, __pyx_L1_error)
+      __pyx_t_4 = PyTuple_New(5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1080, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_GIVEREF(__pyx_t_19);
       PyTuple_SET_ITEM(__pyx_t_4, 0, __pyx_t_19);
@@ -15331,20 +15363,20 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_3 = 0;
       __pyx_t_6 = 0;
       __pyx_t_5 = 0;
-      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_4); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1078, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_4); if (unlikely(__pyx_t_16 == ((int)-1))) __PYX_ERR(0, 1080, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1079
+      /* "MACS2/IO/CallPeakUnit.pyx":1081
  *                 # append.
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )
  *                 lastp = te #above_cutoff_endpos[i]             # <<<<<<<<<<<<<<
  *             else:
  *                 # close
  */
-      __Pyx_TraceLine(1079,0,__PYX_ERR(0, 1079, __pyx_L1_error))
+      __Pyx_TraceLine(1081,0,__PYX_ERR(0, 1081, __pyx_L1_error))
       __pyx_v_lastp = __pyx_v_te;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1076
+      /* "MACS2/IO/CallPeakUnit.pyx":1078
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp
  *             if tl <= max_gap:             # <<<<<<<<<<<<<<
@@ -15354,33 +15386,33 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L11;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1082
+    /* "MACS2/IO/CallPeakUnit.pyx":1084
  *             else:
  *                 # close
  *                 if call_summits:             # <<<<<<<<<<<<<<
  *                     self.__close_peak_with_subpeaks (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  *                 else:
  */
-    __Pyx_TraceLine(1082,0,__PYX_ERR(0, 1082, __pyx_L1_error))
+    __Pyx_TraceLine(1084,0,__PYX_ERR(0, 1084, __pyx_L1_error))
     /*else*/ {
-      __pyx_t_13 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_call_summits)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1082, __pyx_L1_error)
+      __pyx_t_13 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_call_summits)); if (unlikely(__pyx_t_13 < 0)) __PYX_ERR(0, 1084, __pyx_L1_error)
       if (__pyx_t_13) {
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1083
+        /* "MACS2/IO/CallPeakUnit.pyx":1085
  *                 # close
  *                 if call_summits:
  *                     self.__close_peak_with_subpeaks (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'             # <<<<<<<<<<<<<<
  *                 else:
  *                     self.__close_peak_wo_subpeaks   (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  */
-        __Pyx_TraceLine(1083,0,__PYX_ERR(0, 1083, __pyx_L1_error))
+        __Pyx_TraceLine(1085,0,__PYX_ERR(0, 1085, __pyx_L1_error))
         __pyx_t_22.__pyx_n = 1;
         __pyx_t_22.score_cutoff_s = __pyx_v_score_cutoff_s;
-        __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_with_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_22)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1083, __pyx_L1_error)
+        __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_with_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_22)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1085, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1082
+        /* "MACS2/IO/CallPeakUnit.pyx":1084
  *             else:
  *                 # close
  *                 if call_summits:             # <<<<<<<<<<<<<<
@@ -15390,42 +15422,42 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
         goto __pyx_L12;
       }
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1085
+      /* "MACS2/IO/CallPeakUnit.pyx":1087
  *                     self.__close_peak_with_subpeaks (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  *                 else:
  *                     self.__close_peak_wo_subpeaks   (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'             # <<<<<<<<<<<<<<
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]
  *                 lastp = te #above_cutoff_endpos[i]
  */
-      __Pyx_TraceLine(1085,0,__PYX_ERR(0, 1085, __pyx_L1_error))
+      __Pyx_TraceLine(1087,0,__PYX_ERR(0, 1087, __pyx_L1_error))
       /*else*/ {
         __pyx_t_23.__pyx_n = 1;
         __pyx_t_23.score_cutoff_s = __pyx_v_score_cutoff_s;
-        __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_23)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1085, __pyx_L1_error)
+        __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_23)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1087, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       }
       __pyx_L12:;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1086
+      /* "MACS2/IO/CallPeakUnit.pyx":1088
  *                 else:
  *                     self.__close_peak_wo_subpeaks   (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]             # <<<<<<<<<<<<<<
  *                 lastp = te #above_cutoff_endpos[i]
  *         # save the last peak
  */
-      __Pyx_TraceLine(1086,0,__PYX_ERR(0, 1086, __pyx_L1_error))
-      __pyx_t_4 = __Pyx_PyInt_From_npy_int64(__pyx_v_ts); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1086, __pyx_L1_error)
+      __Pyx_TraceLine(1088,0,__PYX_ERR(0, 1088, __pyx_L1_error))
+      __pyx_t_4 = __Pyx_PyInt_From_npy_int64(__pyx_v_ts); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1088, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
-      __pyx_t_5 = __Pyx_PyInt_From_npy_int64(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1086, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyInt_From_npy_int64(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1088, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_6 = PyFloat_FromDouble(__pyx_v_tp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1086, __pyx_L1_error)
+      __pyx_t_6 = PyFloat_FromDouble(__pyx_v_tp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1088, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cp); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1086, __pyx_L1_error)
+      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_cp); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1088, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_18 = __Pyx_PyInt_From_npy_int64(__pyx_v_ti); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1086, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyInt_From_npy_int64(__pyx_v_ti); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1088, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_18);
-      __pyx_t_19 = PyTuple_New(5); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 1086, __pyx_L1_error)
+      __pyx_t_19 = PyTuple_New(5); if (unlikely(!__pyx_t_19)) __PYX_ERR(0, 1088, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_19);
       __Pyx_GIVEREF(__pyx_t_4);
       PyTuple_SET_ITEM(__pyx_t_19, 0, __pyx_t_4);
@@ -15442,7 +15474,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __pyx_t_6 = 0;
       __pyx_t_3 = 0;
       __pyx_t_18 = 0;
-      __pyx_t_18 = PyList_New(1); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1086, __pyx_L1_error)
+      __pyx_t_18 = PyList_New(1); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1088, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_18);
       __Pyx_GIVEREF(__pyx_t_19);
       PyList_SET_ITEM(__pyx_t_18, 0, __pyx_t_19);
@@ -15450,42 +15482,42 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __Pyx_DECREF_SET(__pyx_v_peak_content, ((PyObject*)__pyx_t_18));
       __pyx_t_18 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1087
+      /* "MACS2/IO/CallPeakUnit.pyx":1089
  *                     self.__close_peak_wo_subpeaks   (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]
  *                 lastp = te #above_cutoff_endpos[i]             # <<<<<<<<<<<<<<
  *         # save the last peak
  *         if not peak_content:
  */
-      __Pyx_TraceLine(1087,0,__PYX_ERR(0, 1087, __pyx_L1_error))
+      __Pyx_TraceLine(1089,0,__PYX_ERR(0, 1089, __pyx_L1_error))
       __pyx_v_lastp = __pyx_v_te;
     }
     __pyx_L11:;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1089
+  /* "MACS2/IO/CallPeakUnit.pyx":1091
  *                 lastp = te #above_cutoff_endpos[i]
  *         # save the last peak
  *         if not peak_content:             # <<<<<<<<<<<<<<
  *             return
  *         else:
  */
-  __Pyx_TraceLine(1089,0,__PYX_ERR(0, 1089, __pyx_L1_error))
+  __Pyx_TraceLine(1091,0,__PYX_ERR(0, 1091, __pyx_L1_error))
   __pyx_t_13 = (PyList_GET_SIZE(__pyx_v_peak_content) != 0);
   __pyx_t_15 = ((!__pyx_t_13) != 0);
   if (__pyx_t_15) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1090
+    /* "MACS2/IO/CallPeakUnit.pyx":1092
  *         # save the last peak
  *         if not peak_content:
  *             return             # <<<<<<<<<<<<<<
  *         else:
  *             if call_summits:
  */
-    __Pyx_TraceLine(1090,0,__PYX_ERR(0, 1090, __pyx_L1_error))
+    __Pyx_TraceLine(1092,0,__PYX_ERR(0, 1092, __pyx_L1_error))
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1089
+    /* "MACS2/IO/CallPeakUnit.pyx":1091
  *                 lastp = te #above_cutoff_endpos[i]
  *         # save the last peak
  *         if not peak_content:             # <<<<<<<<<<<<<<
@@ -15494,33 +15526,33 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1092
+  /* "MACS2/IO/CallPeakUnit.pyx":1094
  *             return
  *         else:
  *             if call_summits:             # <<<<<<<<<<<<<<
  *                 self.__close_peak_with_subpeaks (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  *             else:
  */
-  __Pyx_TraceLine(1092,0,__PYX_ERR(0, 1092, __pyx_L1_error))
+  __Pyx_TraceLine(1094,0,__PYX_ERR(0, 1094, __pyx_L1_error))
   /*else*/ {
-    __pyx_t_15 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_call_summits)); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 1092, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_call_summits)); if (unlikely(__pyx_t_15 < 0)) __PYX_ERR(0, 1094, __pyx_L1_error)
     if (__pyx_t_15) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1093
+      /* "MACS2/IO/CallPeakUnit.pyx":1095
  *         else:
  *             if call_summits:
  *                 self.__close_peak_with_subpeaks (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'             # <<<<<<<<<<<<<<
  *             else:
  *                 self.__close_peak_wo_subpeaks   (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  */
-      __Pyx_TraceLine(1093,0,__PYX_ERR(0, 1093, __pyx_L1_error))
+      __Pyx_TraceLine(1095,0,__PYX_ERR(0, 1095, __pyx_L1_error))
       __pyx_t_22.__pyx_n = 1;
       __pyx_t_22.score_cutoff_s = __pyx_v_score_cutoff_s;
-      __pyx_t_18 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_with_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_22)); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1093, __pyx_L1_error)
+      __pyx_t_18 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_with_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_22)); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1095, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_18);
       __Pyx_DECREF(__pyx_t_18); __pyx_t_18 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1092
+      /* "MACS2/IO/CallPeakUnit.pyx":1094
  *             return
  *         else:
  *             if call_summits:             # <<<<<<<<<<<<<<
@@ -15530,35 +15562,35 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L14;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1095
+    /* "MACS2/IO/CallPeakUnit.pyx":1097
  *                 self.__close_peak_with_subpeaks (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'
  *             else:
  *                 self.__close_peak_wo_subpeaks   (peak_content, peaks, min_length, chrom, min_length, score_array_s, score_cutoff_s = score_cutoff_s ) # smooth length is min_length, i.e. fragment size 'd'             # <<<<<<<<<<<<<<
  * 
  *         #print "close peaks -- chrom:",chrom,"  time:", ttime() - t0
  */
-    __Pyx_TraceLine(1095,0,__PYX_ERR(0, 1095, __pyx_L1_error))
+    __Pyx_TraceLine(1097,0,__PYX_ERR(0, 1097, __pyx_L1_error))
     /*else*/ {
       __pyx_t_23.__pyx_n = 1;
       __pyx_t_23.score_cutoff_s = __pyx_v_score_cutoff_s;
-      __pyx_t_18 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_23)); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1095, __pyx_L1_error)
+      __pyx_t_18 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_min_length, __pyx_v_score_array_s, &__pyx_t_23)); if (unlikely(!__pyx_t_18)) __PYX_ERR(0, 1097, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_18);
       __Pyx_DECREF(__pyx_t_18); __pyx_t_18 = 0;
     }
     __pyx_L14:;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1098
+  /* "MACS2/IO/CallPeakUnit.pyx":1100
  * 
  *         #print "close peaks -- chrom:",chrom,"  time:", ttime() - t0
  *         return             # <<<<<<<<<<<<<<
  * 
  *     cdef bool __close_peak_wo_subpeaks (self, list peak_content, peaks, int32_t min_length,
  */
-  __Pyx_TraceLine(1098,0,__PYX_ERR(0, 1098, __pyx_L1_error))
+  __Pyx_TraceLine(1100,0,__PYX_ERR(0, 1100, __pyx_L1_error))
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":962
+  /* "MACS2/IO/CallPeakUnit.pyx":964
  *         return peaks
  * 
  *     cdef void __chrom_call_peak_using_certain_criteria ( self, peaks, bytes chrom, list scoring_function_s, list score_cutoff_s, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -15609,7 +15641,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __Pyx_RefNannyFinishContext();
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1100
+/* "MACS2/IO/CallPeakUnit.pyx":1102
  *         return
  * 
  *     cdef bool __close_peak_wo_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -15661,126 +15693,126 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   int __pyx_t_19;
   int __pyx_t_20;
   __Pyx_RefNannySetupContext("__close_peak_wo_subpeaks", 0);
-  __Pyx_TraceCall("__close_peak_wo_subpeaks", __pyx_f[0], 1100, 0, __PYX_ERR(0, 1100, __pyx_L1_error));
+  __Pyx_TraceCall("__close_peak_wo_subpeaks", __pyx_f[0], 1102, 0, __PYX_ERR(0, 1102, __pyx_L1_error));
   if (__pyx_optional_args) {
     if (__pyx_optional_args->__pyx_n > 0) {
       __pyx_v_score_cutoff_s = __pyx_optional_args->score_cutoff_s;
     }
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1115
+  /* "MACS2/IO/CallPeakUnit.pyx":1117
  *             int32_t tlist_scores_p
  * 
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]             # <<<<<<<<<<<<<<
  *         if peak_length >= min_length: # if the peak is too small, reject it
  *             tsummit = []
  */
-  __Pyx_TraceLine(1115,0,__PYX_ERR(0, 1115, __pyx_L1_error))
+  __Pyx_TraceLine(1117,0,__PYX_ERR(0, 1117, __pyx_L1_error))
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1115, __pyx_L1_error)
+    __PYX_ERR(0, 1117, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1115, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1117, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1115, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1117, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1115, __pyx_L1_error)
+    __PYX_ERR(0, 1117, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1115, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1117, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1115, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1117, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = PyNumber_Subtract(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1115, __pyx_L1_error)
+  __pyx_t_1 = PyNumber_Subtract(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1117, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_peak_length = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1116
+  /* "MACS2/IO/CallPeakUnit.pyx":1118
  * 
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]
  *         if peak_length >= min_length: # if the peak is too small, reject it             # <<<<<<<<<<<<<<
  *             tsummit = []
  *             summit_pos   = 0
  */
-  __Pyx_TraceLine(1116,0,__PYX_ERR(0, 1116, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1116, __pyx_L1_error)
+  __Pyx_TraceLine(1118,0,__PYX_ERR(0, 1118, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1118, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyObject_RichCompare(__pyx_v_peak_length, __pyx_t_1, Py_GE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1116, __pyx_L1_error)
+  __pyx_t_3 = PyObject_RichCompare(__pyx_v_peak_length, __pyx_t_1, Py_GE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1118, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1116, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1118, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1117
+    /* "MACS2/IO/CallPeakUnit.pyx":1119
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]
  *         if peak_length >= min_length: # if the peak is too small, reject it
  *             tsummit = []             # <<<<<<<<<<<<<<
  *             summit_pos   = 0
  *             summit_value = 0
  */
-    __Pyx_TraceLine(1117,0,__PYX_ERR(0, 1117, __pyx_L1_error))
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1117, __pyx_L1_error)
+    __Pyx_TraceLine(1119,0,__PYX_ERR(0, 1119, __pyx_L1_error))
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1119, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_v_tsummit = ((PyObject*)__pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1118
+    /* "MACS2/IO/CallPeakUnit.pyx":1120
  *         if peak_length >= min_length: # if the peak is too small, reject it
  *             tsummit = []
  *             summit_pos   = 0             # <<<<<<<<<<<<<<
  *             summit_value = 0
  *             for i in range(len(peak_content)):
  */
-    __Pyx_TraceLine(1118,0,__PYX_ERR(0, 1118, __pyx_L1_error))
+    __Pyx_TraceLine(1120,0,__PYX_ERR(0, 1120, __pyx_L1_error))
     __pyx_v_summit_pos = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1119
+    /* "MACS2/IO/CallPeakUnit.pyx":1121
  *             tsummit = []
  *             summit_pos   = 0
  *             summit_value = 0             # <<<<<<<<<<<<<<
  *             for i in range(len(peak_content)):
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  */
-    __Pyx_TraceLine(1119,0,__PYX_ERR(0, 1119, __pyx_L1_error))
+    __Pyx_TraceLine(1121,0,__PYX_ERR(0, 1121, __pyx_L1_error))
     __Pyx_INCREF(__pyx_int_0);
     __pyx_v_summit_value = __pyx_int_0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1120
+    /* "MACS2/IO/CallPeakUnit.pyx":1122
  *             summit_pos   = 0
  *             summit_value = 0
  *             for i in range(len(peak_content)):             # <<<<<<<<<<<<<<
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *                 tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  */
-    __Pyx_TraceLine(1120,0,__PYX_ERR(0, 1120, __pyx_L1_error))
+    __Pyx_TraceLine(1122,0,__PYX_ERR(0, 1122, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1120, __pyx_L1_error)
+      __PYX_ERR(0, 1122, __pyx_L1_error)
     }
-    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_peak_content); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1120, __pyx_L1_error)
+    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_peak_content); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1122, __pyx_L1_error)
     __pyx_t_6 = __pyx_t_5;
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_i = __pyx_t_7;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1121
+      /* "MACS2/IO/CallPeakUnit.pyx":1123
  *             summit_value = 0
  *             for i in range(len(peak_content)):
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]             # <<<<<<<<<<<<<<
  *                 tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *                 if not summit_value or summit_value < tscore:
  */
-      __Pyx_TraceLine(1121,0,__PYX_ERR(0, 1121, __pyx_L1_error))
+      __Pyx_TraceLine(1123,0,__PYX_ERR(0, 1123, __pyx_L1_error))
       if (unlikely(__pyx_v_peak_content == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1121, __pyx_L1_error)
+        __PYX_ERR(0, 1123, __pyx_L1_error)
       }
-      __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1121, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1123, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       if ((likely(PyTuple_CheckExact(__pyx_t_3))) || (PyList_CheckExact(__pyx_t_3))) {
         PyObject* sequence = __pyx_t_3;
@@ -15788,7 +15820,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         if (unlikely(size != 5)) {
           if (size > 5) __Pyx_RaiseTooManyValuesError(5);
           else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-          __PYX_ERR(0, 1121, __pyx_L1_error)
+          __PYX_ERR(0, 1123, __pyx_L1_error)
         }
         #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
         if (likely(PyTuple_CheckExact(sequence))) {
@@ -15814,7 +15846,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
           Py_ssize_t i;
           PyObject** temps[5] = {&__pyx_t_1,&__pyx_t_2,&__pyx_t_8,&__pyx_t_9,&__pyx_t_10};
           for (i=0; i < 5; i++) {
-            PyObject* item = PySequence_ITEM(sequence, i); if (unlikely(!item)) __PYX_ERR(0, 1121, __pyx_L1_error)
+            PyObject* item = PySequence_ITEM(sequence, i); if (unlikely(!item)) __PYX_ERR(0, 1123, __pyx_L1_error)
             __Pyx_GOTREF(item);
             *(temps[i]) = item;
           }
@@ -15824,7 +15856,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       } else {
         Py_ssize_t index = -1;
         PyObject** temps[5] = {&__pyx_t_1,&__pyx_t_2,&__pyx_t_8,&__pyx_t_9,&__pyx_t_10};
-        __pyx_t_11 = PyObject_GetIter(__pyx_t_3); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 1121, __pyx_L1_error)
+        __pyx_t_11 = PyObject_GetIter(__pyx_t_3); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 1123, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_11);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __pyx_t_12 = Py_TYPE(__pyx_t_11)->tp_iternext;
@@ -15833,7 +15865,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
           __Pyx_GOTREF(item);
           *(temps[index]) = item;
         }
-        if (__Pyx_IternextUnpackEndCheck(__pyx_t_12(__pyx_t_11), 5) < 0) __PYX_ERR(0, 1121, __pyx_L1_error)
+        if (__Pyx_IternextUnpackEndCheck(__pyx_t_12(__pyx_t_11), 5) < 0) __PYX_ERR(0, 1123, __pyx_L1_error)
         __pyx_t_12 = NULL;
         __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
         goto __pyx_L7_unpacking_done;
@@ -15841,18 +15873,18 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
         __pyx_t_12 = NULL;
         if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-        __PYX_ERR(0, 1121, __pyx_L1_error)
+        __PYX_ERR(0, 1123, __pyx_L1_error)
         __pyx_L7_unpacking_done:;
       }
-      __pyx_t_13 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_13 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1121, __pyx_L1_error)
+      __pyx_t_13 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_13 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1123, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-      __pyx_t_14 = __Pyx_PyInt_As_npy_int32(__pyx_t_2); if (unlikely((__pyx_t_14 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1121, __pyx_L1_error)
+      __pyx_t_14 = __Pyx_PyInt_As_npy_int32(__pyx_t_2); if (unlikely((__pyx_t_14 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1123, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      __pyx_t_15 = __pyx_PyFloat_AsDouble(__pyx_t_8); if (unlikely((__pyx_t_15 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1121, __pyx_L1_error)
+      __pyx_t_15 = __pyx_PyFloat_AsDouble(__pyx_t_8); if (unlikely((__pyx_t_15 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1123, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-      __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_9); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1121, __pyx_L1_error)
+      __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_9); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1123, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-      __pyx_t_17 = __Pyx_PyInt_As_npy_int32(__pyx_t_10); if (unlikely((__pyx_t_17 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1121, __pyx_L1_error)
+      __pyx_t_17 = __Pyx_PyInt_As_npy_int32(__pyx_t_10); if (unlikely((__pyx_t_17 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1123, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
       __pyx_v_tstart = __pyx_t_13;
       __pyx_v_tend = __pyx_t_14;
@@ -15860,52 +15892,52 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_v_tctrl_p = __pyx_t_16;
       __pyx_v_tlist_scores_p = __pyx_t_17;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1122
+      /* "MACS2/IO/CallPeakUnit.pyx":1124
  *             for i in range(len(peak_content)):
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *                 tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit             # <<<<<<<<<<<<<<
  *                 if not summit_value or summit_value < tscore:
  *                     tsummit = [(tend + tstart) // 2, ]
  */
-      __Pyx_TraceLine(1122,0,__PYX_ERR(0, 1122, __pyx_L1_error))
+      __Pyx_TraceLine(1124,0,__PYX_ERR(0, 1124, __pyx_L1_error))
       __pyx_v_tscore = __pyx_v_ttreat_p;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1123
+      /* "MACS2/IO/CallPeakUnit.pyx":1125
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *                 tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *                 if not summit_value or summit_value < tscore:             # <<<<<<<<<<<<<<
  *                     tsummit = [(tend + tstart) // 2, ]
  *                     tsummit_index = [ i, ]
  */
-      __Pyx_TraceLine(1123,0,__PYX_ERR(0, 1123, __pyx_L1_error))
-      __pyx_t_18 = __Pyx_PyObject_IsTrue(__pyx_v_summit_value); if (unlikely(__pyx_t_18 < 0)) __PYX_ERR(0, 1123, __pyx_L1_error)
+      __Pyx_TraceLine(1125,0,__PYX_ERR(0, 1125, __pyx_L1_error))
+      __pyx_t_18 = __Pyx_PyObject_IsTrue(__pyx_v_summit_value); if (unlikely(__pyx_t_18 < 0)) __PYX_ERR(0, 1125, __pyx_L1_error)
       __pyx_t_19 = ((!__pyx_t_18) != 0);
       if (!__pyx_t_19) {
       } else {
         __pyx_t_4 = __pyx_t_19;
         goto __pyx_L9_bool_binop_done;
       }
-      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1123, __pyx_L1_error)
+      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1125, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_10 = PyObject_RichCompare(__pyx_v_summit_value, __pyx_t_3, Py_LT); __Pyx_XGOTREF(__pyx_t_10); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1123, __pyx_L1_error)
+      __pyx_t_10 = PyObject_RichCompare(__pyx_v_summit_value, __pyx_t_3, Py_LT); __Pyx_XGOTREF(__pyx_t_10); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1125, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-      __pyx_t_19 = __Pyx_PyObject_IsTrue(__pyx_t_10); if (unlikely(__pyx_t_19 < 0)) __PYX_ERR(0, 1123, __pyx_L1_error)
+      __pyx_t_19 = __Pyx_PyObject_IsTrue(__pyx_t_10); if (unlikely(__pyx_t_19 < 0)) __PYX_ERR(0, 1125, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
       __pyx_t_4 = __pyx_t_19;
       __pyx_L9_bool_binop_done:;
       if (__pyx_t_4) {
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1124
+        /* "MACS2/IO/CallPeakUnit.pyx":1126
  *                 tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *                 if not summit_value or summit_value < tscore:
  *                     tsummit = [(tend + tstart) // 2, ]             # <<<<<<<<<<<<<<
  *                     tsummit_index = [ i, ]
  *                     summit_value = tscore
  */
-        __Pyx_TraceLine(1124,0,__PYX_ERR(0, 1124, __pyx_L1_error))
-        __pyx_t_10 = __Pyx_PyInt_From_long(__Pyx_div_long((__pyx_v_tend + __pyx_v_tstart), 2)); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1124, __pyx_L1_error)
+        __Pyx_TraceLine(1126,0,__PYX_ERR(0, 1126, __pyx_L1_error))
+        __pyx_t_10 = __Pyx_PyInt_From_long(__Pyx_div_long((__pyx_v_tend + __pyx_v_tstart), 2)); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1126, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_10);
-        __pyx_t_3 = PyList_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1124, __pyx_L1_error)
+        __pyx_t_3 = PyList_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1126, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
         __Pyx_GIVEREF(__pyx_t_10);
         PyList_SET_ITEM(__pyx_t_3, 0, __pyx_t_10);
@@ -15913,17 +15945,17 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         __Pyx_DECREF_SET(__pyx_v_tsummit, ((PyObject*)__pyx_t_3));
         __pyx_t_3 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1125
+        /* "MACS2/IO/CallPeakUnit.pyx":1127
  *                 if not summit_value or summit_value < tscore:
  *                     tsummit = [(tend + tstart) // 2, ]
  *                     tsummit_index = [ i, ]             # <<<<<<<<<<<<<<
  *                     summit_value = tscore
  *                 elif summit_value == tscore:
  */
-        __Pyx_TraceLine(1125,0,__PYX_ERR(0, 1125, __pyx_L1_error))
-        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_i); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1125, __pyx_L1_error)
+        __Pyx_TraceLine(1127,0,__PYX_ERR(0, 1127, __pyx_L1_error))
+        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_i); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1127, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_10 = PyList_New(1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1125, __pyx_L1_error)
+        __pyx_t_10 = PyList_New(1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1127, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_10);
         __Pyx_GIVEREF(__pyx_t_3);
         PyList_SET_ITEM(__pyx_t_10, 0, __pyx_t_3);
@@ -15931,20 +15963,20 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         __Pyx_XDECREF_SET(__pyx_v_tsummit_index, ((PyObject*)__pyx_t_10));
         __pyx_t_10 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1126
+        /* "MACS2/IO/CallPeakUnit.pyx":1128
  *                     tsummit = [(tend + tstart) // 2, ]
  *                     tsummit_index = [ i, ]
  *                     summit_value = tscore             # <<<<<<<<<<<<<<
  *                 elif summit_value == tscore:
  *                     # remember continuous summit values
  */
-        __Pyx_TraceLine(1126,0,__PYX_ERR(0, 1126, __pyx_L1_error))
-        __pyx_t_10 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1126, __pyx_L1_error)
+        __Pyx_TraceLine(1128,0,__PYX_ERR(0, 1128, __pyx_L1_error))
+        __pyx_t_10 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1128, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_10);
         __Pyx_DECREF_SET(__pyx_v_summit_value, __pyx_t_10);
         __pyx_t_10 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1123
+        /* "MACS2/IO/CallPeakUnit.pyx":1125
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *                 tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *                 if not summit_value or summit_value < tscore:             # <<<<<<<<<<<<<<
@@ -15954,50 +15986,50 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         goto __pyx_L8;
       }
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1127
+      /* "MACS2/IO/CallPeakUnit.pyx":1129
  *                     tsummit_index = [ i, ]
  *                     summit_value = tscore
  *                 elif summit_value == tscore:             # <<<<<<<<<<<<<<
  *                     # remember continuous summit values
  *                     tsummit.append((tend + tstart) // 2)
  */
-      __Pyx_TraceLine(1127,0,__PYX_ERR(0, 1127, __pyx_L1_error))
-      __pyx_t_10 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1127, __pyx_L1_error)
+      __Pyx_TraceLine(1129,0,__PYX_ERR(0, 1129, __pyx_L1_error))
+      __pyx_t_10 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1129, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_10);
-      __pyx_t_3 = PyObject_RichCompare(__pyx_v_summit_value, __pyx_t_10, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1127, __pyx_L1_error)
+      __pyx_t_3 = PyObject_RichCompare(__pyx_v_summit_value, __pyx_t_10, Py_EQ); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1129, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
-      __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1127, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1129, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       if (__pyx_t_4) {
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1129
+        /* "MACS2/IO/CallPeakUnit.pyx":1131
  *                 elif summit_value == tscore:
  *                     # remember continuous summit values
  *                     tsummit.append((tend + tstart) // 2)             # <<<<<<<<<<<<<<
  *                     tsummit_index.append( i )
  *             # the middle of all highest points in peak region is defined as summit
  */
-        __Pyx_TraceLine(1129,0,__PYX_ERR(0, 1129, __pyx_L1_error))
-        __pyx_t_3 = __Pyx_PyInt_From_long(__Pyx_div_long((__pyx_v_tend + __pyx_v_tstart), 2)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1129, __pyx_L1_error)
+        __Pyx_TraceLine(1131,0,__PYX_ERR(0, 1131, __pyx_L1_error))
+        __pyx_t_3 = __Pyx_PyInt_From_long(__Pyx_div_long((__pyx_v_tend + __pyx_v_tstart), 2)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1131, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_20 = __Pyx_PyList_Append(__pyx_v_tsummit, __pyx_t_3); if (unlikely(__pyx_t_20 == ((int)-1))) __PYX_ERR(0, 1129, __pyx_L1_error)
+        __pyx_t_20 = __Pyx_PyList_Append(__pyx_v_tsummit, __pyx_t_3); if (unlikely(__pyx_t_20 == ((int)-1))) __PYX_ERR(0, 1131, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1130
+        /* "MACS2/IO/CallPeakUnit.pyx":1132
  *                     # remember continuous summit values
  *                     tsummit.append((tend + tstart) // 2)
  *                     tsummit_index.append( i )             # <<<<<<<<<<<<<<
  *             # the middle of all highest points in peak region is defined as summit
  *             midindex = (len(tsummit) + 1) // 2 - 1
  */
-        __Pyx_TraceLine(1130,0,__PYX_ERR(0, 1130, __pyx_L1_error))
-        if (unlikely(!__pyx_v_tsummit_index)) { __Pyx_RaiseUnboundLocalError("tsummit_index"); __PYX_ERR(0, 1130, __pyx_L1_error) }
-        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_i); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1130, __pyx_L1_error)
+        __Pyx_TraceLine(1132,0,__PYX_ERR(0, 1132, __pyx_L1_error))
+        if (unlikely(!__pyx_v_tsummit_index)) { __Pyx_RaiseUnboundLocalError("tsummit_index"); __PYX_ERR(0, 1132, __pyx_L1_error) }
+        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_i); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1132, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_20 = __Pyx_PyList_Append(__pyx_v_tsummit_index, __pyx_t_3); if (unlikely(__pyx_t_20 == ((int)-1))) __PYX_ERR(0, 1130, __pyx_L1_error)
+        __pyx_t_20 = __Pyx_PyList_Append(__pyx_v_tsummit_index, __pyx_t_3); if (unlikely(__pyx_t_20 == ((int)-1))) __PYX_ERR(0, 1132, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1127
+        /* "MACS2/IO/CallPeakUnit.pyx":1129
  *                     tsummit_index = [ i, ]
  *                     summit_value = tscore
  *                 elif summit_value == tscore:             # <<<<<<<<<<<<<<
@@ -16008,159 +16040,159 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_L8:;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1132
+    /* "MACS2/IO/CallPeakUnit.pyx":1134
  *                     tsummit_index.append( i )
  *             # the middle of all highest points in peak region is defined as summit
  *             midindex = (len(tsummit) + 1) // 2 - 1             # <<<<<<<<<<<<<<
  *             summit_pos    = tsummit[ midindex ]
  *             summit_index  = tsummit_index[ midindex ]
  */
-    __Pyx_TraceLine(1132,0,__PYX_ERR(0, 1132, __pyx_L1_error))
-    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_tsummit); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1132, __pyx_L1_error)
+    __Pyx_TraceLine(1134,0,__PYX_ERR(0, 1134, __pyx_L1_error))
+    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_tsummit); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1134, __pyx_L1_error)
     __pyx_v_midindex = (__Pyx_div_Py_ssize_t((__pyx_t_5 + 1), 2) - 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1133
+    /* "MACS2/IO/CallPeakUnit.pyx":1135
  *             # the middle of all highest points in peak region is defined as summit
  *             midindex = (len(tsummit) + 1) // 2 - 1
  *             summit_pos    = tsummit[ midindex ]             # <<<<<<<<<<<<<<
  *             summit_index  = tsummit_index[ midindex ]
  * 
  */
-    __Pyx_TraceLine(1133,0,__PYX_ERR(0, 1133, __pyx_L1_error))
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_tsummit, __pyx_v_midindex, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1133, __pyx_L1_error)
+    __Pyx_TraceLine(1135,0,__PYX_ERR(0, 1135, __pyx_L1_error))
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_tsummit, __pyx_v_midindex, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1135, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_7 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_7 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1133, __pyx_L1_error)
+    __pyx_t_7 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_7 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1135, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_v_summit_pos = __pyx_t_7;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1134
+    /* "MACS2/IO/CallPeakUnit.pyx":1136
  *             midindex = (len(tsummit) + 1) // 2 - 1
  *             summit_pos    = tsummit[ midindex ]
  *             summit_index  = tsummit_index[ midindex ]             # <<<<<<<<<<<<<<
  * 
  *             summit_treat = peak_content[ summit_index ][ 2 ]
  */
-    __Pyx_TraceLine(1134,0,__PYX_ERR(0, 1134, __pyx_L1_error))
-    if (unlikely(!__pyx_v_tsummit_index)) { __Pyx_RaiseUnboundLocalError("tsummit_index"); __PYX_ERR(0, 1134, __pyx_L1_error) }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_tsummit_index, __pyx_v_midindex, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1134, __pyx_L1_error)
+    __Pyx_TraceLine(1136,0,__PYX_ERR(0, 1136, __pyx_L1_error))
+    if (unlikely(!__pyx_v_tsummit_index)) { __Pyx_RaiseUnboundLocalError("tsummit_index"); __PYX_ERR(0, 1136, __pyx_L1_error) }
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_tsummit_index, __pyx_v_midindex, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1136, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_7 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_7 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1134, __pyx_L1_error)
+    __pyx_t_7 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_7 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1136, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_v_summit_index = __pyx_t_7;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1136
+    /* "MACS2/IO/CallPeakUnit.pyx":1138
  *             summit_index  = tsummit_index[ midindex ]
  * 
  *             summit_treat = peak_content[ summit_index ][ 2 ]             # <<<<<<<<<<<<<<
  *             summit_ctrl = peak_content[ summit_index ][ 3 ]
  * 
  */
-    __Pyx_TraceLine(1136,0,__PYX_ERR(0, 1136, __pyx_L1_error))
+    __Pyx_TraceLine(1138,0,__PYX_ERR(0, 1138, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1136, __pyx_L1_error)
+      __PYX_ERR(0, 1138, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1136, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1138, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_10 = __Pyx_GetItemInt(__pyx_t_3, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1136, __pyx_L1_error)
+    __pyx_t_10 = __Pyx_GetItemInt(__pyx_t_3, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1138, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_10); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1136, __pyx_L1_error)
+    __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_10); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1138, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
     __pyx_v_summit_treat = __pyx_t_16;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1137
+    /* "MACS2/IO/CallPeakUnit.pyx":1139
  * 
  *             summit_treat = peak_content[ summit_index ][ 2 ]
  *             summit_ctrl = peak_content[ summit_index ][ 3 ]             # <<<<<<<<<<<<<<
  * 
  *             # this is a double-check to see if the summit can pass cutoff values.
  */
-    __Pyx_TraceLine(1137,0,__PYX_ERR(0, 1137, __pyx_L1_error))
+    __Pyx_TraceLine(1139,0,__PYX_ERR(0, 1139, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1137, __pyx_L1_error)
+      __PYX_ERR(0, 1139, __pyx_L1_error)
     }
-    __pyx_t_10 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1137, __pyx_L1_error)
+    __pyx_t_10 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1139, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
-    __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_10, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1137, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_10, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1139, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
-    __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_3); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1137, __pyx_L1_error)
+    __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_3); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1139, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __pyx_v_summit_ctrl = __pyx_t_16;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1140
+    /* "MACS2/IO/CallPeakUnit.pyx":1142
  * 
  *             # this is a double-check to see if the summit can pass cutoff values.
  *             for i in range(len(score_cutoff_s)):             # <<<<<<<<<<<<<<
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:
  *                     return False # not passed, then disgard this peak.
  */
-    __Pyx_TraceLine(1140,0,__PYX_ERR(0, 1140, __pyx_L1_error))
+    __Pyx_TraceLine(1142,0,__PYX_ERR(0, 1142, __pyx_L1_error))
     if (unlikely(__pyx_v_score_cutoff_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1140, __pyx_L1_error)
+      __PYX_ERR(0, 1142, __pyx_L1_error)
     }
-    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_score_cutoff_s); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1140, __pyx_L1_error)
+    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_score_cutoff_s); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1142, __pyx_L1_error)
     __pyx_t_6 = __pyx_t_5;
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_i = __pyx_t_7;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1141
+      /* "MACS2/IO/CallPeakUnit.pyx":1143
  *             # this is a double-check to see if the summit can pass cutoff values.
  *             for i in range(len(score_cutoff_s)):
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:             # <<<<<<<<<<<<<<
  *                     return False # not passed, then disgard this peak.
  * 
  */
-      __Pyx_TraceLine(1141,0,__PYX_ERR(0, 1141, __pyx_L1_error))
+      __Pyx_TraceLine(1143,0,__PYX_ERR(0, 1143, __pyx_L1_error))
       if (unlikely(__pyx_v_score_cutoff_s == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1141, __pyx_L1_error)
+        __PYX_ERR(0, 1143, __pyx_L1_error)
       }
-      __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_score_cutoff_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1141, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_score_cutoff_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1143, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       if (unlikely(__pyx_v_score_array_s == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1141, __pyx_L1_error)
+        __PYX_ERR(0, 1143, __pyx_L1_error)
       }
-      __pyx_t_10 = __Pyx_GetItemInt_List(__pyx_v_score_array_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1141, __pyx_L1_error)
+      __pyx_t_10 = __Pyx_GetItemInt_List(__pyx_v_score_array_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1143, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_10);
       if (unlikely(__pyx_v_peak_content == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1141, __pyx_L1_error)
+        __PYX_ERR(0, 1143, __pyx_L1_error)
       }
-      __pyx_t_9 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1141, __pyx_L1_error)
+      __pyx_t_9 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1143, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_9);
-      __pyx_t_8 = __Pyx_GetItemInt(__pyx_t_9, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1141, __pyx_L1_error)
+      __pyx_t_8 = __Pyx_GetItemInt(__pyx_t_9, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1143, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-      __pyx_t_9 = __Pyx_PyObject_GetItem(__pyx_t_10, __pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1141, __pyx_L1_error)
+      __pyx_t_9 = __Pyx_PyObject_GetItem(__pyx_t_10, __pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1143, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_9);
       __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-      __pyx_t_8 = PyObject_RichCompare(__pyx_t_3, __pyx_t_9, Py_GT); __Pyx_XGOTREF(__pyx_t_8); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1141, __pyx_L1_error)
+      __pyx_t_8 = PyObject_RichCompare(__pyx_t_3, __pyx_t_9, Py_GT); __Pyx_XGOTREF(__pyx_t_8); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1143, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
       __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-      __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_8); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1141, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_8); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1143, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
       if (__pyx_t_4) {
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1142
+        /* "MACS2/IO/CallPeakUnit.pyx":1144
  *             for i in range(len(score_cutoff_s)):
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:
  *                     return False # not passed, then disgard this peak.             # <<<<<<<<<<<<<<
  * 
  *             #summit_p_score = get_pscore( int(summit_treat), summit_ctrl )
  */
-        __Pyx_TraceLine(1142,0,__PYX_ERR(0, 1142, __pyx_L1_error))
+        __Pyx_TraceLine(1144,0,__PYX_ERR(0, 1144, __pyx_L1_error))
         __Pyx_XDECREF(((PyObject *)__pyx_r));
         __Pyx_INCREF(Py_False);
         __pyx_r = ((PyBoolObject *)Py_False);
         goto __pyx_L0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1141
+        /* "MACS2/IO/CallPeakUnit.pyx":1143
  *             # this is a double-check to see if the summit can pass cutoff values.
  *             for i in range(len(score_cutoff_s)):
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:             # <<<<<<<<<<<<<<
@@ -16170,19 +16202,19 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       }
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1145
+    /* "MACS2/IO/CallPeakUnit.pyx":1147
  * 
  *             #summit_p_score = get_pscore( int(summit_treat), summit_ctrl )
  *             summit_p_score = get_pscore(( <int32_t>(summit_treat), summit_ctrl ) )             # <<<<<<<<<<<<<<
  *             summit_q_score = self.pqtable[ summit_p_score ]
  * 
  */
-    __Pyx_TraceLine(1145,0,__PYX_ERR(0, 1145, __pyx_L1_error))
-    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)__pyx_v_summit_treat)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1145, __pyx_L1_error)
+    __Pyx_TraceLine(1147,0,__PYX_ERR(0, 1147, __pyx_L1_error))
+    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)__pyx_v_summit_treat)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1147, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    __pyx_t_9 = PyFloat_FromDouble(__pyx_v_summit_ctrl); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1145, __pyx_L1_error)
+    __pyx_t_9 = PyFloat_FromDouble(__pyx_v_summit_ctrl); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1147, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
-    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1145, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1147, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_GIVEREF(__pyx_t_8);
     PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_8);
@@ -16193,83 +16225,83 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __pyx_v_summit_p_score = __pyx_f_5MACS2_2IO_12CallPeakUnit_get_pscore(((PyObject*)__pyx_t_3));
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1146
+    /* "MACS2/IO/CallPeakUnit.pyx":1148
  *             #summit_p_score = get_pscore( int(summit_treat), summit_ctrl )
  *             summit_p_score = get_pscore(( <int32_t>(summit_treat), summit_ctrl ) )
  *             summit_q_score = self.pqtable[ summit_p_score ]             # <<<<<<<<<<<<<<
  * 
  *             peaks.add( chrom,           # chromosome
  */
-    __Pyx_TraceLine(1146,0,__PYX_ERR(0, 1146, __pyx_L1_error))
+    __Pyx_TraceLine(1148,0,__PYX_ERR(0, 1148, __pyx_L1_error))
     if (unlikely(__pyx_v_self->pqtable == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1146, __pyx_L1_error)
+      __PYX_ERR(0, 1148, __pyx_L1_error)
     }
-    __pyx_t_3 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1146, __pyx_L1_error)
+    __pyx_t_3 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1148, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_9 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_3); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1146, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_3); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1148, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_9); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1146, __pyx_L1_error)
+    __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_9); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1148, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     __pyx_v_summit_q_score = __pyx_t_16;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1148
+    /* "MACS2/IO/CallPeakUnit.pyx":1150
  *             summit_q_score = self.pqtable[ summit_p_score ]
  * 
  *             peaks.add( chrom,           # chromosome             # <<<<<<<<<<<<<<
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  */
-    __Pyx_TraceLine(1148,0,__PYX_ERR(0, 1148, __pyx_L1_error))
-    __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_add); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1148, __pyx_L1_error)
+    __Pyx_TraceLine(1150,0,__PYX_ERR(0, 1150, __pyx_L1_error))
+    __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_add); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1150, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1149
+    /* "MACS2/IO/CallPeakUnit.pyx":1151
  * 
  *             peaks.add( chrom,           # chromosome
  *                        peak_content[0][0], # start             # <<<<<<<<<<<<<<
  *                        peak_content[-1][1], # end
  *                        summit      = summit_pos, # summit position
  */
-    __Pyx_TraceLine(1149,0,__PYX_ERR(0, 1149, __pyx_L1_error))
+    __Pyx_TraceLine(1151,0,__PYX_ERR(0, 1151, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1149, __pyx_L1_error)
+      __PYX_ERR(0, 1151, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1149, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1151, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_8 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1149, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1151, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1150
+    /* "MACS2/IO/CallPeakUnit.pyx":1152
  *             peaks.add( chrom,           # chromosome
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end             # <<<<<<<<<<<<<<
  *                        summit      = summit_pos, # summit position
  *                        peak_score  = summit_q_score, # score at summit
  */
-    __Pyx_TraceLine(1150,0,__PYX_ERR(0, 1150, __pyx_L1_error))
+    __Pyx_TraceLine(1152,0,__PYX_ERR(0, 1152, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1150, __pyx_L1_error)
+      __PYX_ERR(0, 1152, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1150, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1152, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_10 = __Pyx_GetItemInt(__pyx_t_3, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1150, __pyx_L1_error)
+    __pyx_t_10 = __Pyx_GetItemInt(__pyx_t_3, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1152, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1148
+    /* "MACS2/IO/CallPeakUnit.pyx":1150
  *             summit_q_score = self.pqtable[ summit_p_score ]
  * 
  *             peaks.add( chrom,           # chromosome             # <<<<<<<<<<<<<<
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  */
-    __Pyx_TraceLine(1148,0,__PYX_ERR(0, 1148, __pyx_L1_error))
-    __pyx_t_3 = PyTuple_New(3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1148, __pyx_L1_error)
+    __Pyx_TraceLine(1150,0,__PYX_ERR(0, 1150, __pyx_L1_error))
+    __pyx_t_3 = PyTuple_New(3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1150, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_v_chrom);
     __Pyx_GIVEREF(__pyx_v_chrom);
@@ -16281,121 +16313,121 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __pyx_t_8 = 0;
     __pyx_t_10 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1151
+    /* "MACS2/IO/CallPeakUnit.pyx":1153
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  *                        summit      = summit_pos, # summit position             # <<<<<<<<<<<<<<
  *                        peak_score  = summit_q_score, # score at summit
  *                        pileup      = summit_treat, # pileup
  */
-    __Pyx_TraceLine(1151,0,__PYX_ERR(0, 1151, __pyx_L1_error))
-    __pyx_t_10 = __Pyx_PyDict_NewPresized(6); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1151, __pyx_L1_error)
+    __Pyx_TraceLine(1153,0,__PYX_ERR(0, 1153, __pyx_L1_error))
+    __pyx_t_10 = __Pyx_PyDict_NewPresized(6); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
-    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_summit_pos); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1151, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_summit_pos); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_summit, __pyx_t_8) < 0) __PYX_ERR(0, 1151, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_summit, __pyx_t_8) < 0) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1152
+    /* "MACS2/IO/CallPeakUnit.pyx":1154
  *                        peak_content[-1][1], # end
  *                        summit      = summit_pos, # summit position
  *                        peak_score  = summit_q_score, # score at summit             # <<<<<<<<<<<<<<
  *                        pileup      = summit_treat, # pileup
  *                        pscore      = summit_p_score, # pvalue
  */
-    __Pyx_TraceLine(1152,0,__PYX_ERR(0, 1152, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1152, __pyx_L1_error)
+    __Pyx_TraceLine(1154,0,__PYX_ERR(0, 1154, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1154, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_peak_score, __pyx_t_8) < 0) __PYX_ERR(0, 1151, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_peak_score, __pyx_t_8) < 0) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1153
+    /* "MACS2/IO/CallPeakUnit.pyx":1155
  *                        summit      = summit_pos, # summit position
  *                        peak_score  = summit_q_score, # score at summit
  *                        pileup      = summit_treat, # pileup             # <<<<<<<<<<<<<<
  *                        pscore      = summit_p_score, # pvalue
  *                        fold_change = ( summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change
  */
-    __Pyx_TraceLine(1153,0,__PYX_ERR(0, 1153, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_treat); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1153, __pyx_L1_error)
+    __Pyx_TraceLine(1155,0,__PYX_ERR(0, 1155, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_treat); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1155, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_pileup, __pyx_t_8) < 0) __PYX_ERR(0, 1151, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_pileup, __pyx_t_8) < 0) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1154
+    /* "MACS2/IO/CallPeakUnit.pyx":1156
  *                        peak_score  = summit_q_score, # score at summit
  *                        pileup      = summit_treat, # pileup
  *                        pscore      = summit_p_score, # pvalue             # <<<<<<<<<<<<<<
  *                        fold_change = ( summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change
  *                        qscore      = summit_q_score # qvalue
  */
-    __Pyx_TraceLine(1154,0,__PYX_ERR(0, 1154, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1154, __pyx_L1_error)
+    __Pyx_TraceLine(1156,0,__PYX_ERR(0, 1156, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1156, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_pscore, __pyx_t_8) < 0) __PYX_ERR(0, 1151, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_pscore, __pyx_t_8) < 0) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1155
+    /* "MACS2/IO/CallPeakUnit.pyx":1157
  *                        pileup      = summit_treat, # pileup
  *                        pscore      = summit_p_score, # pvalue
  *                        fold_change = ( summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change             # <<<<<<<<<<<<<<
  *                        qscore      = summit_q_score # qvalue
  *                        )
  */
-    __Pyx_TraceLine(1155,0,__PYX_ERR(0, 1155, __pyx_L1_error))
+    __Pyx_TraceLine(1157,0,__PYX_ERR(0, 1157, __pyx_L1_error))
     __pyx_t_16 = (__pyx_v_summit_treat + __pyx_v_self->pseudocount);
     __pyx_t_15 = (__pyx_v_summit_ctrl + __pyx_v_self->pseudocount);
     if (unlikely(__pyx_t_15 == 0)) {
       PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-      __PYX_ERR(0, 1155, __pyx_L1_error)
+      __PYX_ERR(0, 1157, __pyx_L1_error)
     }
-    __pyx_t_8 = PyFloat_FromDouble((__pyx_t_16 / __pyx_t_15)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1155, __pyx_L1_error)
+    __pyx_t_8 = PyFloat_FromDouble((__pyx_t_16 / __pyx_t_15)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1157, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_fold_change, __pyx_t_8) < 0) __PYX_ERR(0, 1151, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_fold_change, __pyx_t_8) < 0) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1156
+    /* "MACS2/IO/CallPeakUnit.pyx":1158
  *                        pscore      = summit_p_score, # pvalue
  *                        fold_change = ( summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change
  *                        qscore      = summit_q_score # qvalue             # <<<<<<<<<<<<<<
  *                        )
  *             # start a new peak
  */
-    __Pyx_TraceLine(1156,0,__PYX_ERR(0, 1156, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1156, __pyx_L1_error)
+    __Pyx_TraceLine(1158,0,__PYX_ERR(0, 1158, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1158, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_qscore, __pyx_t_8) < 0) __PYX_ERR(0, 1151, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_10, __pyx_n_s_qscore, __pyx_t_8) < 0) __PYX_ERR(0, 1153, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1148
+    /* "MACS2/IO/CallPeakUnit.pyx":1150
  *             summit_q_score = self.pqtable[ summit_p_score ]
  * 
  *             peaks.add( chrom,           # chromosome             # <<<<<<<<<<<<<<
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  */
-    __Pyx_TraceLine(1148,0,__PYX_ERR(0, 1148, __pyx_L1_error))
-    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_9, __pyx_t_3, __pyx_t_10); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1148, __pyx_L1_error)
+    __Pyx_TraceLine(1150,0,__PYX_ERR(0, 1150, __pyx_L1_error))
+    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_9, __pyx_t_3, __pyx_t_10); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1150, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1159
+    /* "MACS2/IO/CallPeakUnit.pyx":1161
  *                        )
  *             # start a new peak
  *             return True             # <<<<<<<<<<<<<<
  * 
  *     cdef bool __close_peak_with_subpeaks (self, list peak_content, peaks, int32_t min_length,
  */
-    __Pyx_TraceLine(1159,0,__PYX_ERR(0, 1159, __pyx_L1_error))
+    __Pyx_TraceLine(1161,0,__PYX_ERR(0, 1161, __pyx_L1_error))
     __Pyx_XDECREF(((PyObject *)__pyx_r));
     __Pyx_INCREF(Py_True);
     __pyx_r = ((PyBoolObject *)Py_True);
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1116
+    /* "MACS2/IO/CallPeakUnit.pyx":1118
  * 
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]
  *         if peak_length >= min_length: # if the peak is too small, reject it             # <<<<<<<<<<<<<<
@@ -16404,7 +16436,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1100
+  /* "MACS2/IO/CallPeakUnit.pyx":1102
  *         return
  * 
  *     cdef bool __close_peak_wo_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -16436,7 +16468,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1161
+/* "MACS2/IO/CallPeakUnit.pyx":1163
  *             return True
  * 
  *     cdef bool __close_peak_with_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -16504,7 +16536,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___close_peak_wo_subpeaks __pyx_t_24;
   Py_ssize_t __pyx_t_25;
   __Pyx_RefNannySetupContext("__close_peak_with_subpeaks", 0);
-  __Pyx_TraceCall("__close_peak_with_subpeaks", __pyx_f[0], 1161, 0, __PYX_ERR(0, 1161, __pyx_L1_error));
+  __Pyx_TraceCall("__close_peak_with_subpeaks", __pyx_f[0], 1163, 0, __PYX_ERR(0, 1163, __pyx_L1_error));
   if (__pyx_optional_args) {
     if (__pyx_optional_args->__pyx_n > 0) {
       __pyx_v_score_cutoff_s = __pyx_optional_args->score_cutoff_s;
@@ -16523,52 +16555,52 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   __pyx_pybuffernd_summit_offsets.data = NULL;
   __pyx_pybuffernd_summit_offsets.rcbuffer = &__pyx_pybuffer_summit_offsets;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1177
+  /* "MACS2/IO/CallPeakUnit.pyx":1179
  *             int32_t tlist_scores_p
  * 
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]             # <<<<<<<<<<<<<<
  * 
  *         if peak_length < min_length: return  # if the region is too small, reject it
  */
-  __Pyx_TraceLine(1177,0,__PYX_ERR(0, 1177, __pyx_L1_error))
+  __Pyx_TraceLine(1179,0,__PYX_ERR(0, 1179, __pyx_L1_error))
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1177, __pyx_L1_error)
+    __PYX_ERR(0, 1179, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1179, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1179, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1177, __pyx_L1_error)
+    __PYX_ERR(0, 1179, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1179, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1179, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = PyNumber_Subtract(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1177, __pyx_L1_error)
+  __pyx_t_1 = PyNumber_Subtract(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1179, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_peak_length = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1179
+  /* "MACS2/IO/CallPeakUnit.pyx":1181
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]
  * 
  *         if peak_length < min_length: return  # if the region is too small, reject it             # <<<<<<<<<<<<<<
  * 
  *         # Add 10 bp padding to peak region so that we can get true minima
  */
-  __Pyx_TraceLine(1179,0,__PYX_ERR(0, 1179, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1179, __pyx_L1_error)
+  __Pyx_TraceLine(1181,0,__PYX_ERR(0, 1181, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1181, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyObject_RichCompare(__pyx_v_peak_length, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1179, __pyx_L1_error)
+  __pyx_t_3 = PyObject_RichCompare(__pyx_v_peak_length, __pyx_t_1, Py_LT); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1181, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1179, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1181, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   if (__pyx_t_4) {
     __Pyx_XDECREF(((PyObject *)__pyx_r));
@@ -16576,86 +16608,86 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     goto __pyx_L0;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1182
+  /* "MACS2/IO/CallPeakUnit.pyx":1184
  * 
  *         # Add 10 bp padding to peak region so that we can get true minima
  *         end = peak_content[ -1 ][ 1 ] + 10             # <<<<<<<<<<<<<<
  *         start = peak_content[ 0 ][ 0 ] - 10
  *         if start < 0:
  */
-  __Pyx_TraceLine(1182,0,__PYX_ERR(0, 1182, __pyx_L1_error))
+  __Pyx_TraceLine(1184,0,__PYX_ERR(0, 1184, __pyx_L1_error))
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1182, __pyx_L1_error)
+    __PYX_ERR(0, 1184, __pyx_L1_error)
   }
-  __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1182, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1184, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1182, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1184, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyInt_AddObjC(__pyx_t_1, __pyx_int_10, 10, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1182, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_AddObjC(__pyx_t_1, __pyx_int_10, 10, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1184, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1182, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1184, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_end = __pyx_t_5;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1183
+  /* "MACS2/IO/CallPeakUnit.pyx":1185
  *         # Add 10 bp padding to peak region so that we can get true minima
  *         end = peak_content[ -1 ][ 1 ] + 10
  *         start = peak_content[ 0 ][ 0 ] - 10             # <<<<<<<<<<<<<<
  *         if start < 0:
  *             start_boundary = 10 + start # this is the offset of original peak boundary in peakdata list.
  */
-  __Pyx_TraceLine(1183,0,__PYX_ERR(0, 1183, __pyx_L1_error))
+  __Pyx_TraceLine(1185,0,__PYX_ERR(0, 1185, __pyx_L1_error))
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1183, __pyx_L1_error)
+    __PYX_ERR(0, 1185, __pyx_L1_error)
   }
-  __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1183, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1185, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1183, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1185, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyInt_SubtractObjC(__pyx_t_1, __pyx_int_10, 10, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1183, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_SubtractObjC(__pyx_t_1, __pyx_int_10, 10, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1185, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1183, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_3); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1185, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_start = __pyx_t_5;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1184
+  /* "MACS2/IO/CallPeakUnit.pyx":1186
  *         end = peak_content[ -1 ][ 1 ] + 10
  *         start = peak_content[ 0 ][ 0 ] - 10
  *         if start < 0:             # <<<<<<<<<<<<<<
  *             start_boundary = 10 + start # this is the offset of original peak boundary in peakdata list.
  *             start = 0
  */
-  __Pyx_TraceLine(1184,0,__PYX_ERR(0, 1184, __pyx_L1_error))
+  __Pyx_TraceLine(1186,0,__PYX_ERR(0, 1186, __pyx_L1_error))
   __pyx_t_4 = ((__pyx_v_start < 0) != 0);
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1185
+    /* "MACS2/IO/CallPeakUnit.pyx":1187
  *         start = peak_content[ 0 ][ 0 ] - 10
  *         if start < 0:
  *             start_boundary = 10 + start # this is the offset of original peak boundary in peakdata list.             # <<<<<<<<<<<<<<
  *             start = 0
  *         else:
  */
-    __Pyx_TraceLine(1185,0,__PYX_ERR(0, 1185, __pyx_L1_error))
+    __Pyx_TraceLine(1187,0,__PYX_ERR(0, 1187, __pyx_L1_error))
     __pyx_v_start_boundary = (10 + __pyx_v_start);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1186
+    /* "MACS2/IO/CallPeakUnit.pyx":1188
  *         if start < 0:
  *             start_boundary = 10 + start # this is the offset of original peak boundary in peakdata list.
  *             start = 0             # <<<<<<<<<<<<<<
  *         else:
  *             start_boundary = 10 # this is the offset of original peak boundary in peakdata list.
  */
-    __Pyx_TraceLine(1186,0,__PYX_ERR(0, 1186, __pyx_L1_error))
+    __Pyx_TraceLine(1188,0,__PYX_ERR(0, 1188, __pyx_L1_error))
     __pyx_v_start = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1184
+    /* "MACS2/IO/CallPeakUnit.pyx":1186
  *         end = peak_content[ -1 ][ 1 ] + 10
  *         start = peak_content[ 0 ][ 0 ] - 10
  *         if start < 0:             # <<<<<<<<<<<<<<
@@ -16665,48 +16697,48 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     goto __pyx_L4;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1188
+  /* "MACS2/IO/CallPeakUnit.pyx":1190
  *             start = 0
  *         else:
  *             start_boundary = 10 # this is the offset of original peak boundary in peakdata list.             # <<<<<<<<<<<<<<
  * 
  *         peakdata = np.zeros(end - start, dtype='float32') # save the scores (qscore) for each position in this region
  */
-  __Pyx_TraceLine(1188,0,__PYX_ERR(0, 1188, __pyx_L1_error))
+  __Pyx_TraceLine(1190,0,__PYX_ERR(0, 1190, __pyx_L1_error))
   /*else*/ {
     __pyx_v_start_boundary = 10;
   }
   __pyx_L4:;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1190
+  /* "MACS2/IO/CallPeakUnit.pyx":1192
  *             start_boundary = 10 # this is the offset of original peak boundary in peakdata list.
  * 
  *         peakdata = np.zeros(end - start, dtype='float32') # save the scores (qscore) for each position in this region             # <<<<<<<<<<<<<<
  *         peakindices = np.zeros(end - start, dtype='int32') # save the indices for each position in this region
  *         for i in range(len(peak_content)):
  */
-  __Pyx_TraceLine(1190,0,__PYX_ERR(0, 1190, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1190, __pyx_L1_error)
+  __Pyx_TraceLine(1192,0,__PYX_ERR(0, 1192, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1192, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1190, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_zeros); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1192, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyInt_From_npy_int32((__pyx_v_end - __pyx_v_start)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1190, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_From_npy_int32((__pyx_v_end - __pyx_v_start)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1192, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1190, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1192, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_3);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3);
   __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1190, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1192, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1190, __pyx_L1_error)
-  __pyx_t_6 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1190, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1192, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1192, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (!(likely(((__pyx_t_6) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1190, __pyx_L1_error)
+  if (!(likely(((__pyx_t_6) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1192, __pyx_L1_error)
   __pyx_t_7 = ((PyArrayObject *)__pyx_t_6);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -16723,41 +16755,41 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_9 = __pyx_t_10 = __pyx_t_11 = 0;
     }
     __pyx_pybuffernd_peakdata.diminfo[0].strides = __pyx_pybuffernd_peakdata.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_peakdata.diminfo[0].shape = __pyx_pybuffernd_peakdata.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1190, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1192, __pyx_L1_error)
   }
   __pyx_t_7 = 0;
   __pyx_v_peakdata = ((PyArrayObject *)__pyx_t_6);
   __pyx_t_6 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1191
+  /* "MACS2/IO/CallPeakUnit.pyx":1193
  * 
  *         peakdata = np.zeros(end - start, dtype='float32') # save the scores (qscore) for each position in this region
  *         peakindices = np.zeros(end - start, dtype='int32') # save the indices for each position in this region             # <<<<<<<<<<<<<<
  *         for i in range(len(peak_content)):
  *             (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  */
-  __Pyx_TraceLine(1191,0,__PYX_ERR(0, 1191, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1191, __pyx_L1_error)
+  __Pyx_TraceLine(1193,0,__PYX_ERR(0, 1193, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1193, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_zeros); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1191, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_zeros); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1193, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __Pyx_PyInt_From_npy_int32((__pyx_v_end - __pyx_v_start)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1191, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyInt_From_npy_int32((__pyx_v_end - __pyx_v_start)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1193, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1191, __pyx_L1_error)
+  __pyx_t_2 = PyTuple_New(1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1193, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_6);
   PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_6);
   __pyx_t_6 = 0;
-  __pyx_t_6 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1191, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1193, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1191, __pyx_L1_error)
-  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_2, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1191, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1193, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_2, __pyx_t_6); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1193, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1191, __pyx_L1_error)
+  if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1193, __pyx_L1_error)
   __pyx_t_12 = ((PyArrayObject *)__pyx_t_1);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -16774,42 +16806,42 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_11 = __pyx_t_10 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_peakindices.diminfo[0].strides = __pyx_pybuffernd_peakindices.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_peakindices.diminfo[0].shape = __pyx_pybuffernd_peakindices.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1191, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1193, __pyx_L1_error)
   }
   __pyx_t_12 = 0;
   __pyx_v_peakindices = ((PyArrayObject *)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1192
+  /* "MACS2/IO/CallPeakUnit.pyx":1194
  *         peakdata = np.zeros(end - start, dtype='float32') # save the scores (qscore) for each position in this region
  *         peakindices = np.zeros(end - start, dtype='int32') # save the indices for each position in this region
  *         for i in range(len(peak_content)):             # <<<<<<<<<<<<<<
  *             (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *             #tscore = self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  */
-  __Pyx_TraceLine(1192,0,__PYX_ERR(0, 1192, __pyx_L1_error))
+  __Pyx_TraceLine(1194,0,__PYX_ERR(0, 1194, __pyx_L1_error))
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 1192, __pyx_L1_error)
+    __PYX_ERR(0, 1194, __pyx_L1_error)
   }
-  __pyx_t_13 = PyList_GET_SIZE(__pyx_v_peak_content); if (unlikely(__pyx_t_13 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1192, __pyx_L1_error)
+  __pyx_t_13 = PyList_GET_SIZE(__pyx_v_peak_content); if (unlikely(__pyx_t_13 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1194, __pyx_L1_error)
   __pyx_t_14 = __pyx_t_13;
   for (__pyx_t_5 = 0; __pyx_t_5 < __pyx_t_14; __pyx_t_5+=1) {
     __pyx_v_i = __pyx_t_5;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1193
+    /* "MACS2/IO/CallPeakUnit.pyx":1195
  *         peakindices = np.zeros(end - start, dtype='int32') # save the indices for each position in this region
  *         for i in range(len(peak_content)):
  *             (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]             # <<<<<<<<<<<<<<
  *             #tscore = self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *             tscore = ttreat_p # use pileup as general score to find summit
  */
-    __Pyx_TraceLine(1193,0,__PYX_ERR(0, 1193, __pyx_L1_error))
+    __Pyx_TraceLine(1195,0,__PYX_ERR(0, 1195, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1193, __pyx_L1_error)
+      __PYX_ERR(0, 1195, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1193, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1195, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
       PyObject* sequence = __pyx_t_1;
@@ -16817,7 +16849,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       if (unlikely(size != 5)) {
         if (size > 5) __Pyx_RaiseTooManyValuesError(5);
         else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-        __PYX_ERR(0, 1193, __pyx_L1_error)
+        __PYX_ERR(0, 1195, __pyx_L1_error)
       }
       #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
       if (likely(PyTuple_CheckExact(sequence))) {
@@ -16843,7 +16875,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         Py_ssize_t i;
         PyObject** temps[5] = {&__pyx_t_6,&__pyx_t_2,&__pyx_t_3,&__pyx_t_15,&__pyx_t_16};
         for (i=0; i < 5; i++) {
-          PyObject* item = PySequence_ITEM(sequence, i); if (unlikely(!item)) __PYX_ERR(0, 1193, __pyx_L1_error)
+          PyObject* item = PySequence_ITEM(sequence, i); if (unlikely(!item)) __PYX_ERR(0, 1195, __pyx_L1_error)
           __Pyx_GOTREF(item);
           *(temps[i]) = item;
         }
@@ -16853,7 +16885,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     } else {
       Py_ssize_t index = -1;
       PyObject** temps[5] = {&__pyx_t_6,&__pyx_t_2,&__pyx_t_3,&__pyx_t_15,&__pyx_t_16};
-      __pyx_t_17 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_17)) __PYX_ERR(0, 1193, __pyx_L1_error)
+      __pyx_t_17 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_17)) __PYX_ERR(0, 1195, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_17);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_18 = Py_TYPE(__pyx_t_17)->tp_iternext;
@@ -16862,7 +16894,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         __Pyx_GOTREF(item);
         *(temps[index]) = item;
       }
-      if (__Pyx_IternextUnpackEndCheck(__pyx_t_18(__pyx_t_17), 5) < 0) __PYX_ERR(0, 1193, __pyx_L1_error)
+      if (__Pyx_IternextUnpackEndCheck(__pyx_t_18(__pyx_t_17), 5) < 0) __PYX_ERR(0, 1195, __pyx_L1_error)
       __pyx_t_18 = NULL;
       __Pyx_DECREF(__pyx_t_17); __pyx_t_17 = 0;
       goto __pyx_L8_unpacking_done;
@@ -16870,18 +16902,18 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __Pyx_DECREF(__pyx_t_17); __pyx_t_17 = 0;
       __pyx_t_18 = NULL;
       if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-      __PYX_ERR(0, 1193, __pyx_L1_error)
+      __PYX_ERR(0, 1195, __pyx_L1_error)
       __pyx_L8_unpacking_done:;
     }
-    __pyx_t_19 = __Pyx_PyInt_As_npy_int32(__pyx_t_6); if (unlikely((__pyx_t_19 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1193, __pyx_L1_error)
+    __pyx_t_19 = __Pyx_PyInt_As_npy_int32(__pyx_t_6); if (unlikely((__pyx_t_19 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1195, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_20 = __Pyx_PyInt_As_npy_int32(__pyx_t_2); if (unlikely((__pyx_t_20 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1193, __pyx_L1_error)
+    __pyx_t_20 = __Pyx_PyInt_As_npy_int32(__pyx_t_2); if (unlikely((__pyx_t_20 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1195, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_21 = __pyx_PyFloat_AsDouble(__pyx_t_3); if (unlikely((__pyx_t_21 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1193, __pyx_L1_error)
+    __pyx_t_21 = __pyx_PyFloat_AsDouble(__pyx_t_3); if (unlikely((__pyx_t_21 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1195, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_15); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1193, __pyx_L1_error)
+    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_15); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1195, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-    __pyx_t_23 = __Pyx_PyInt_As_npy_int32(__pyx_t_16); if (unlikely((__pyx_t_23 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1193, __pyx_L1_error)
+    __pyx_t_23 = __Pyx_PyInt_As_npy_int32(__pyx_t_16); if (unlikely((__pyx_t_23 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1195, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
     __pyx_v_tstart = __pyx_t_19;
     __pyx_v_tend = __pyx_t_20;
@@ -16889,92 +16921,92 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __pyx_v_tctrl_p = __pyx_t_22;
     __pyx_v_tlist_scores_p = __pyx_t_23;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1195
+    /* "MACS2/IO/CallPeakUnit.pyx":1197
  *             (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *             #tscore = self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *             tscore = ttreat_p # use pileup as general score to find summit             # <<<<<<<<<<<<<<
  *             m = tstart - start + start_boundary
  *             n = tend - start + start_boundary
  */
-    __Pyx_TraceLine(1195,0,__PYX_ERR(0, 1195, __pyx_L1_error))
+    __Pyx_TraceLine(1197,0,__PYX_ERR(0, 1197, __pyx_L1_error))
     __pyx_v_tscore = __pyx_v_ttreat_p;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1196
+    /* "MACS2/IO/CallPeakUnit.pyx":1198
  *             #tscore = self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *             tscore = ttreat_p # use pileup as general score to find summit
  *             m = tstart - start + start_boundary             # <<<<<<<<<<<<<<
  *             n = tend - start + start_boundary
  *             peakdata[m:n] = tscore
  */
-    __Pyx_TraceLine(1196,0,__PYX_ERR(0, 1196, __pyx_L1_error))
+    __Pyx_TraceLine(1198,0,__PYX_ERR(0, 1198, __pyx_L1_error))
     __pyx_v_m = ((__pyx_v_tstart - __pyx_v_start) + __pyx_v_start_boundary);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1197
+    /* "MACS2/IO/CallPeakUnit.pyx":1199
  *             tscore = ttreat_p # use pileup as general score to find summit
  *             m = tstart - start + start_boundary
  *             n = tend - start + start_boundary             # <<<<<<<<<<<<<<
  *             peakdata[m:n] = tscore
  *             peakindices[m:n] = i
  */
-    __Pyx_TraceLine(1197,0,__PYX_ERR(0, 1197, __pyx_L1_error))
+    __Pyx_TraceLine(1199,0,__PYX_ERR(0, 1199, __pyx_L1_error))
     __pyx_v_n = ((__pyx_v_tend - __pyx_v_start) + __pyx_v_start_boundary);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1198
+    /* "MACS2/IO/CallPeakUnit.pyx":1200
  *             m = tstart - start + start_boundary
  *             n = tend - start + start_boundary
  *             peakdata[m:n] = tscore             # <<<<<<<<<<<<<<
  *             peakindices[m:n] = i
  * 
  */
-    __Pyx_TraceLine(1198,0,__PYX_ERR(0, 1198, __pyx_L1_error))
-    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1198, __pyx_L1_error)
+    __Pyx_TraceLine(1200,0,__PYX_ERR(0, 1200, __pyx_L1_error))
+    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_tscore); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1200, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_16 = __Pyx_PyInt_From_npy_int32(__pyx_v_m); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1198, __pyx_L1_error)
+    __pyx_t_16 = __Pyx_PyInt_From_npy_int32(__pyx_v_m); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1200, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
-    __pyx_t_15 = __Pyx_PyInt_From_npy_int32(__pyx_v_n); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1198, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_PyInt_From_npy_int32(__pyx_v_n); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1200, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
-    __pyx_t_3 = PySlice_New(__pyx_t_16, __pyx_t_15, Py_None); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1198, __pyx_L1_error)
+    __pyx_t_3 = PySlice_New(__pyx_t_16, __pyx_t_15, Py_None); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1200, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-    if (unlikely(PyObject_SetItem(((PyObject *)__pyx_v_peakdata), __pyx_t_3, __pyx_t_1) < 0)) __PYX_ERR(0, 1198, __pyx_L1_error)
+    if (unlikely(PyObject_SetItem(((PyObject *)__pyx_v_peakdata), __pyx_t_3, __pyx_t_1) < 0)) __PYX_ERR(0, 1200, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1199
+    /* "MACS2/IO/CallPeakUnit.pyx":1201
  *             n = tend - start + start_boundary
  *             peakdata[m:n] = tscore
  *             peakindices[m:n] = i             # <<<<<<<<<<<<<<
  * 
  *         summit_offsets = maxima(peakdata, smoothlen) # offsets are the indices for summits in peakdata/peakindices array.
  */
-    __Pyx_TraceLine(1199,0,__PYX_ERR(0, 1199, __pyx_L1_error))
-    __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_i); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1199, __pyx_L1_error)
+    __Pyx_TraceLine(1201,0,__PYX_ERR(0, 1201, __pyx_L1_error))
+    __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_i); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1201, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_m); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1199, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_m); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1201, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_15 = __Pyx_PyInt_From_npy_int32(__pyx_v_n); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1199, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_PyInt_From_npy_int32(__pyx_v_n); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1201, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
-    __pyx_t_16 = PySlice_New(__pyx_t_3, __pyx_t_15, Py_None); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1199, __pyx_L1_error)
+    __pyx_t_16 = PySlice_New(__pyx_t_3, __pyx_t_15, Py_None); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1201, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-    if (unlikely(PyObject_SetItem(((PyObject *)__pyx_v_peakindices), __pyx_t_16, __pyx_t_1) < 0)) __PYX_ERR(0, 1199, __pyx_L1_error)
+    if (unlikely(PyObject_SetItem(((PyObject *)__pyx_v_peakindices), __pyx_t_16, __pyx_t_1) < 0)) __PYX_ERR(0, 1201, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1201
+  /* "MACS2/IO/CallPeakUnit.pyx":1203
  *             peakindices[m:n] = i
  * 
  *         summit_offsets = maxima(peakdata, smoothlen) # offsets are the indices for summits in peakdata/peakindices array.             # <<<<<<<<<<<<<<
  * 
  *         if summit_offsets.shape[0] == 0:
  */
-  __Pyx_TraceLine(1201,0,__PYX_ERR(0, 1201, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_16, __pyx_n_s_maxima); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1201, __pyx_L1_error)
+  __Pyx_TraceLine(1203,0,__PYX_ERR(0, 1203, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_16, __pyx_n_s_maxima); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1203, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_16);
-  __pyx_t_15 = __Pyx_PyInt_From_npy_int32(__pyx_v_smoothlen); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1201, __pyx_L1_error)
+  __pyx_t_15 = __Pyx_PyInt_From_npy_int32(__pyx_v_smoothlen); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1203, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_15);
   __pyx_t_3 = NULL;
   __pyx_t_8 = 0;
@@ -16991,7 +17023,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_16)) {
     PyObject *__pyx_temp[3] = {__pyx_t_3, ((PyObject *)__pyx_v_peakdata), __pyx_t_15};
-    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_16, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1201, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_16, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1203, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
@@ -17000,14 +17032,14 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_16)) {
     PyObject *__pyx_temp[3] = {__pyx_t_3, ((PyObject *)__pyx_v_peakdata), __pyx_t_15};
-    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_16, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1201, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_16, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1203, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
   } else
   #endif
   {
-    __pyx_t_2 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1201, __pyx_L1_error)
+    __pyx_t_2 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1203, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     if (__pyx_t_3) {
       __Pyx_GIVEREF(__pyx_t_3); PyTuple_SET_ITEM(__pyx_t_2, 0, __pyx_t_3); __pyx_t_3 = NULL;
@@ -17018,12 +17050,12 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __Pyx_GIVEREF(__pyx_t_15);
     PyTuple_SET_ITEM(__pyx_t_2, 1+__pyx_t_8, __pyx_t_15);
     __pyx_t_15 = 0;
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_16, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1201, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_16, __pyx_t_2, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1203, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   }
   __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-  if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1201, __pyx_L1_error)
+  if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1203, __pyx_L1_error)
   __pyx_t_12 = ((PyArrayObject *)__pyx_t_1);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -17040,41 +17072,41 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_9 = __pyx_t_10 = __pyx_t_11 = 0;
     }
     __pyx_pybuffernd_summit_offsets.diminfo[0].strides = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_summit_offsets.diminfo[0].shape = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1201, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1203, __pyx_L1_error)
   }
   __pyx_t_12 = 0;
   __pyx_v_summit_offsets = ((PyArrayObject *)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1203
+  /* "MACS2/IO/CallPeakUnit.pyx":1205
  *         summit_offsets = maxima(peakdata, smoothlen) # offsets are the indices for summits in peakdata/peakindices array.
  * 
  *         if summit_offsets.shape[0] == 0:             # <<<<<<<<<<<<<<
  *             # **failsafe** if no summits, fall back on old approach #
  *             return self.__close_peak_wo_subpeaks(peak_content, peaks, min_length, chrom, smoothlen, score_array_s, score_cutoff_s)
  */
-  __Pyx_TraceLine(1203,0,__PYX_ERR(0, 1203, __pyx_L1_error))
+  __Pyx_TraceLine(1205,0,__PYX_ERR(0, 1205, __pyx_L1_error))
   __pyx_t_4 = (((__pyx_v_summit_offsets->dimensions[0]) == 0) != 0);
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1205
+    /* "MACS2/IO/CallPeakUnit.pyx":1207
  *         if summit_offsets.shape[0] == 0:
  *             # **failsafe** if no summits, fall back on old approach #
  *             return self.__close_peak_wo_subpeaks(peak_content, peaks, min_length, chrom, smoothlen, score_array_s, score_cutoff_s)             # <<<<<<<<<<<<<<
  *         else:
  *             # remove maxima that occurred in padding
  */
-    __Pyx_TraceLine(1205,0,__PYX_ERR(0, 1205, __pyx_L1_error))
+    __Pyx_TraceLine(1207,0,__PYX_ERR(0, 1207, __pyx_L1_error))
     __Pyx_XDECREF(((PyObject *)__pyx_r));
     __pyx_t_24.__pyx_n = 1;
     __pyx_t_24.score_cutoff_s = __pyx_v_score_cutoff_s;
-    __pyx_t_1 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_smoothlen, __pyx_v_score_array_s, &__pyx_t_24)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1205, __pyx_L1_error)
+    __pyx_t_1 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_smoothlen, __pyx_v_score_array_s, &__pyx_t_24)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1207, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __pyx_r = ((PyBoolObject *)__pyx_t_1);
     __pyx_t_1 = 0;
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1203
+    /* "MACS2/IO/CallPeakUnit.pyx":1205
  *         summit_offsets = maxima(peakdata, smoothlen) # offsets are the indices for summits in peakdata/peakindices array.
  * 
  *         if summit_offsets.shape[0] == 0:             # <<<<<<<<<<<<<<
@@ -17083,21 +17115,21 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1208
+  /* "MACS2/IO/CallPeakUnit.pyx":1210
  *         else:
  *             # remove maxima that occurred in padding
  *             m = np.searchsorted(summit_offsets, start_boundary)             # <<<<<<<<<<<<<<
  *             n = np.searchsorted(summit_offsets, peak_length + start_boundary, 'right')
  *             summit_offsets = summit_offsets[m:n]
  */
-  __Pyx_TraceLine(1208,0,__PYX_ERR(0, 1208, __pyx_L1_error))
+  __Pyx_TraceLine(1210,0,__PYX_ERR(0, 1210, __pyx_L1_error))
   /*else*/ {
-    __Pyx_GetModuleGlobalName(__pyx_t_16, __pyx_n_s_np); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1208, __pyx_L1_error)
+    __Pyx_GetModuleGlobalName(__pyx_t_16, __pyx_n_s_np); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1210, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_searchsorted); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1208, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_16, __pyx_n_s_searchsorted); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1210, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-    __pyx_t_16 = __Pyx_PyInt_From_npy_int32(__pyx_v_start_boundary); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1208, __pyx_L1_error)
+    __pyx_t_16 = __Pyx_PyInt_From_npy_int32(__pyx_v_start_boundary); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1210, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __pyx_t_15 = NULL;
     __pyx_t_8 = 0;
@@ -17114,7 +17146,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_2)) {
       PyObject *__pyx_temp[3] = {__pyx_t_15, ((PyObject *)__pyx_v_summit_offsets), __pyx_t_16};
-      __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1208, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1210, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_15); __pyx_t_15 = 0;
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
@@ -17123,14 +17155,14 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_2)) {
       PyObject *__pyx_temp[3] = {__pyx_t_15, ((PyObject *)__pyx_v_summit_offsets), __pyx_t_16};
-      __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1208, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_2, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1210, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_15); __pyx_t_15 = 0;
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
     } else
     #endif
     {
-      __pyx_t_3 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1208, __pyx_L1_error)
+      __pyx_t_3 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1210, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       if (__pyx_t_15) {
         __Pyx_GIVEREF(__pyx_t_15); PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_15); __pyx_t_15 = NULL;
@@ -17141,31 +17173,31 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __Pyx_GIVEREF(__pyx_t_16);
       PyTuple_SET_ITEM(__pyx_t_3, 1+__pyx_t_8, __pyx_t_16);
       __pyx_t_16 = 0;
-      __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1208, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1210, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     }
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1208, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1210, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_m = __pyx_t_5;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1209
+    /* "MACS2/IO/CallPeakUnit.pyx":1211
  *             # remove maxima that occurred in padding
  *             m = np.searchsorted(summit_offsets, start_boundary)
  *             n = np.searchsorted(summit_offsets, peak_length + start_boundary, 'right')             # <<<<<<<<<<<<<<
  *             summit_offsets = summit_offsets[m:n]
  * 
  */
-    __Pyx_TraceLine(1209,0,__PYX_ERR(0, 1209, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1209, __pyx_L1_error)
+    __Pyx_TraceLine(1211,0,__PYX_ERR(0, 1211, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1211, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_searchsorted); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1209, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_searchsorted); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1211, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_2 = __Pyx_PyInt_From_npy_int32(__pyx_v_start_boundary); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1209, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyInt_From_npy_int32(__pyx_v_start_boundary); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1211, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_16 = PyNumber_Add(__pyx_v_peak_length, __pyx_t_2); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1209, __pyx_L1_error)
+    __pyx_t_16 = PyNumber_Add(__pyx_v_peak_length, __pyx_t_2); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1211, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_2 = NULL;
@@ -17183,7 +17215,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     #if CYTHON_FAST_PYCALL
     if (PyFunction_Check(__pyx_t_3)) {
       PyObject *__pyx_temp[4] = {__pyx_t_2, ((PyObject *)__pyx_v_summit_offsets), __pyx_t_16, __pyx_n_u_right};
-      __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1209, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1211, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
@@ -17192,14 +17224,14 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     #if CYTHON_FAST_PYCCALL
     if (__Pyx_PyFastCFunction_Check(__pyx_t_3)) {
       PyObject *__pyx_temp[4] = {__pyx_t_2, ((PyObject *)__pyx_v_summit_offsets), __pyx_t_16, __pyx_n_u_right};
-      __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1209, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_3, __pyx_temp+1-__pyx_t_8, 3+__pyx_t_8); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1211, __pyx_L1_error)
       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
     } else
     #endif
     {
-      __pyx_t_15 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1209, __pyx_L1_error)
+      __pyx_t_15 = PyTuple_New(3+__pyx_t_8); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1211, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_15);
       if (__pyx_t_2) {
         __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_15, 0, __pyx_t_2); __pyx_t_2 = NULL;
@@ -17213,35 +17245,35 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __Pyx_GIVEREF(__pyx_n_u_right);
       PyTuple_SET_ITEM(__pyx_t_15, 2+__pyx_t_8, __pyx_n_u_right);
       __pyx_t_16 = 0;
-      __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_15, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1209, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_15, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1211, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
     }
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1209, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1211, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_n = __pyx_t_5;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1210
+    /* "MACS2/IO/CallPeakUnit.pyx":1212
  *             m = np.searchsorted(summit_offsets, start_boundary)
  *             n = np.searchsorted(summit_offsets, peak_length + start_boundary, 'right')
  *             summit_offsets = summit_offsets[m:n]             # <<<<<<<<<<<<<<
  * 
  *         summit_offsets = enforce_peakyness(peakdata, summit_offsets)
  */
-    __Pyx_TraceLine(1210,0,__PYX_ERR(0, 1210, __pyx_L1_error))
-    __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_m); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1210, __pyx_L1_error)
+    __Pyx_TraceLine(1212,0,__PYX_ERR(0, 1212, __pyx_L1_error))
+    __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_m); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1212, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_n); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1210, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_n); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1212, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_15 = PySlice_New(__pyx_t_1, __pyx_t_3, Py_None); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1210, __pyx_L1_error)
+    __pyx_t_15 = PySlice_New(__pyx_t_1, __pyx_t_3, Py_None); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1212, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_3 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_summit_offsets), __pyx_t_15); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1210, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_summit_offsets), __pyx_t_15); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1212, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-    if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1210, __pyx_L1_error)
+    if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1212, __pyx_L1_error)
     __pyx_t_12 = ((PyArrayObject *)__pyx_t_3);
     {
       __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -17258,22 +17290,22 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         __pyx_t_11 = __pyx_t_10 = __pyx_t_9 = 0;
       }
       __pyx_pybuffernd_summit_offsets.diminfo[0].strides = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_summit_offsets.diminfo[0].shape = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.shape[0];
-      if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1210, __pyx_L1_error)
+      if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1212, __pyx_L1_error)
     }
     __pyx_t_12 = 0;
     __Pyx_DECREF_SET(__pyx_v_summit_offsets, ((PyArrayObject *)__pyx_t_3));
     __pyx_t_3 = 0;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1212
+  /* "MACS2/IO/CallPeakUnit.pyx":1214
  *             summit_offsets = summit_offsets[m:n]
  * 
  *         summit_offsets = enforce_peakyness(peakdata, summit_offsets)             # <<<<<<<<<<<<<<
  * 
  *         #print "enforced:",summit_offsets
  */
-  __Pyx_TraceLine(1212,0,__PYX_ERR(0, 1212, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_15, __pyx_n_s_enforce_peakyness); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1212, __pyx_L1_error)
+  __Pyx_TraceLine(1214,0,__PYX_ERR(0, 1214, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_15, __pyx_n_s_enforce_peakyness); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1214, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_15);
   __pyx_t_1 = NULL;
   __pyx_t_8 = 0;
@@ -17290,7 +17322,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   #if CYTHON_FAST_PYCALL
   if (PyFunction_Check(__pyx_t_15)) {
     PyObject *__pyx_temp[3] = {__pyx_t_1, ((PyObject *)__pyx_v_peakdata), ((PyObject *)__pyx_v_summit_offsets)};
-    __pyx_t_3 = __Pyx_PyFunction_FastCall(__pyx_t_15, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1212, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyFunction_FastCall(__pyx_t_15, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1214, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_GOTREF(__pyx_t_3);
   } else
@@ -17298,13 +17330,13 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   #if CYTHON_FAST_PYCCALL
   if (__Pyx_PyFastCFunction_Check(__pyx_t_15)) {
     PyObject *__pyx_temp[3] = {__pyx_t_1, ((PyObject *)__pyx_v_peakdata), ((PyObject *)__pyx_v_summit_offsets)};
-    __pyx_t_3 = __Pyx_PyCFunction_FastCall(__pyx_t_15, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1212, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyCFunction_FastCall(__pyx_t_15, __pyx_temp+1-__pyx_t_8, 2+__pyx_t_8); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1214, __pyx_L1_error)
     __Pyx_XDECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_GOTREF(__pyx_t_3);
   } else
   #endif
   {
-    __pyx_t_16 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1212, __pyx_L1_error)
+    __pyx_t_16 = PyTuple_New(2+__pyx_t_8); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1214, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     if (__pyx_t_1) {
       __Pyx_GIVEREF(__pyx_t_1); PyTuple_SET_ITEM(__pyx_t_16, 0, __pyx_t_1); __pyx_t_1 = NULL;
@@ -17315,12 +17347,12 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __Pyx_INCREF(((PyObject *)__pyx_v_summit_offsets));
     __Pyx_GIVEREF(((PyObject *)__pyx_v_summit_offsets));
     PyTuple_SET_ITEM(__pyx_t_16, 1+__pyx_t_8, ((PyObject *)__pyx_v_summit_offsets));
-    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_15, __pyx_t_16, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1212, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_15, __pyx_t_16, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1214, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
   }
   __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-  if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1212, __pyx_L1_error)
+  if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1214, __pyx_L1_error)
   __pyx_t_12 = ((PyArrayObject *)__pyx_t_3);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -17337,41 +17369,41 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_9 = __pyx_t_10 = __pyx_t_11 = 0;
     }
     __pyx_pybuffernd_summit_offsets.diminfo[0].strides = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_summit_offsets.diminfo[0].shape = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1212, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1214, __pyx_L1_error)
   }
   __pyx_t_12 = 0;
   __Pyx_DECREF_SET(__pyx_v_summit_offsets, ((PyArrayObject *)__pyx_t_3));
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1215
+  /* "MACS2/IO/CallPeakUnit.pyx":1217
  * 
  *         #print "enforced:",summit_offsets
  *         if summit_offsets.shape[0] == 0:             # <<<<<<<<<<<<<<
  *             # **failsafe** if no summits, fall back on old approach #
  *             return self.__close_peak_wo_subpeaks(peak_content, peaks, min_length, chrom, smoothlen, score_array_s, score_cutoff_s)
  */
-  __Pyx_TraceLine(1215,0,__PYX_ERR(0, 1215, __pyx_L1_error))
+  __Pyx_TraceLine(1217,0,__PYX_ERR(0, 1217, __pyx_L1_error))
   __pyx_t_4 = (((__pyx_v_summit_offsets->dimensions[0]) == 0) != 0);
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1217
+    /* "MACS2/IO/CallPeakUnit.pyx":1219
  *         if summit_offsets.shape[0] == 0:
  *             # **failsafe** if no summits, fall back on old approach #
  *             return self.__close_peak_wo_subpeaks(peak_content, peaks, min_length, chrom, smoothlen, score_array_s, score_cutoff_s)             # <<<<<<<<<<<<<<
  * 
  *         summit_indices = peakindices[summit_offsets] # indices are those point to peak_content
  */
-    __Pyx_TraceLine(1217,0,__PYX_ERR(0, 1217, __pyx_L1_error))
+    __Pyx_TraceLine(1219,0,__PYX_ERR(0, 1219, __pyx_L1_error))
     __Pyx_XDECREF(((PyObject *)__pyx_r));
     __pyx_t_24.__pyx_n = 1;
     __pyx_t_24.score_cutoff_s = __pyx_v_score_cutoff_s;
-    __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_smoothlen, __pyx_v_score_array_s, &__pyx_t_24)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1217, __pyx_L1_error)
+    __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_wo_subpeaks(__pyx_v_self, __pyx_v_peak_content, __pyx_v_peaks, __pyx_v_min_length, __pyx_v_chrom, __pyx_v_smoothlen, __pyx_v_score_array_s, &__pyx_t_24)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1219, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_r = ((PyBoolObject *)__pyx_t_3);
     __pyx_t_3 = 0;
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1215
+    /* "MACS2/IO/CallPeakUnit.pyx":1217
  * 
  *         #print "enforced:",summit_offsets
  *         if summit_offsets.shape[0] == 0:             # <<<<<<<<<<<<<<
@@ -17380,33 +17412,33 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1219
+  /* "MACS2/IO/CallPeakUnit.pyx":1221
  *             return self.__close_peak_wo_subpeaks(peak_content, peaks, min_length, chrom, smoothlen, score_array_s, score_cutoff_s)
  * 
  *         summit_indices = peakindices[summit_offsets] # indices are those point to peak_content             # <<<<<<<<<<<<<<
  *         summit_offsets -= start_boundary
  * 
  */
-  __Pyx_TraceLine(1219,0,__PYX_ERR(0, 1219, __pyx_L1_error))
-  __pyx_t_3 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_peakindices), ((PyObject *)__pyx_v_summit_offsets)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1219, __pyx_L1_error)
+  __Pyx_TraceLine(1221,0,__PYX_ERR(0, 1221, __pyx_L1_error))
+  __pyx_t_3 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_peakindices), ((PyObject *)__pyx_v_summit_offsets)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1221, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_v_summit_indices = __pyx_t_3;
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1220
+  /* "MACS2/IO/CallPeakUnit.pyx":1222
  * 
  *         summit_indices = peakindices[summit_offsets] # indices are those point to peak_content
  *         summit_offsets -= start_boundary             # <<<<<<<<<<<<<<
  * 
  *         for summit_offset, summit_index in list(zip(summit_offsets, summit_indices)):
  */
-  __Pyx_TraceLine(1220,0,__PYX_ERR(0, 1220, __pyx_L1_error))
-  __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_start_boundary); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1220, __pyx_L1_error)
+  __Pyx_TraceLine(1222,0,__PYX_ERR(0, 1222, __pyx_L1_error))
+  __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_start_boundary); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1222, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_15 = PyNumber_InPlaceSubtract(((PyObject *)__pyx_v_summit_offsets), __pyx_t_3); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1220, __pyx_L1_error)
+  __pyx_t_15 = PyNumber_InPlaceSubtract(((PyObject *)__pyx_v_summit_offsets), __pyx_t_3); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1222, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_15);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (!(likely(((__pyx_t_15) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_15, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1220, __pyx_L1_error)
+  if (!(likely(((__pyx_t_15) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_15, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1222, __pyx_L1_error)
   __pyx_t_12 = ((PyArrayObject *)__pyx_t_15);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -17423,21 +17455,21 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_11 = __pyx_t_10 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_summit_offsets.diminfo[0].strides = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_summit_offsets.diminfo[0].shape = __pyx_pybuffernd_summit_offsets.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1220, __pyx_L1_error)
+    if (unlikely(__pyx_t_8 < 0)) __PYX_ERR(0, 1222, __pyx_L1_error)
   }
   __pyx_t_12 = 0;
   __Pyx_DECREF_SET(__pyx_v_summit_offsets, ((PyArrayObject *)__pyx_t_15));
   __pyx_t_15 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1222
+  /* "MACS2/IO/CallPeakUnit.pyx":1224
  *         summit_offsets -= start_boundary
  * 
  *         for summit_offset, summit_index in list(zip(summit_offsets, summit_indices)):             # <<<<<<<<<<<<<<
  * 
  *             summit_treat = peak_content[ summit_index ][ 2 ]
  */
-  __Pyx_TraceLine(1222,0,__PYX_ERR(0, 1222, __pyx_L1_error))
-  __pyx_t_15 = PyTuple_New(2); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1222, __pyx_L1_error)
+  __Pyx_TraceLine(1224,0,__PYX_ERR(0, 1224, __pyx_L1_error))
+  __pyx_t_15 = PyTuple_New(2); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1224, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_15);
   __Pyx_INCREF(((PyObject *)__pyx_v_summit_offsets));
   __Pyx_GIVEREF(((PyObject *)__pyx_v_summit_offsets));
@@ -17445,10 +17477,10 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   __Pyx_INCREF(__pyx_v_summit_indices);
   __Pyx_GIVEREF(__pyx_v_summit_indices);
   PyTuple_SET_ITEM(__pyx_t_15, 1, __pyx_v_summit_indices);
-  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_15, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1222, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_zip, __pyx_t_15, NULL); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1224, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-  __pyx_t_15 = PySequence_List(__pyx_t_3); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1222, __pyx_L1_error)
+  __pyx_t_15 = PySequence_List(__pyx_t_3); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1224, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_15);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_t_3 = __pyx_t_15; __Pyx_INCREF(__pyx_t_3); __pyx_t_13 = 0;
@@ -17456,9 +17488,9 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   for (;;) {
     if (__pyx_t_13 >= PyList_GET_SIZE(__pyx_t_3)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_15 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_13); __Pyx_INCREF(__pyx_t_15); __pyx_t_13++; if (unlikely(0 < 0)) __PYX_ERR(0, 1222, __pyx_L1_error)
+    __pyx_t_15 = PyList_GET_ITEM(__pyx_t_3, __pyx_t_13); __Pyx_INCREF(__pyx_t_15); __pyx_t_13++; if (unlikely(0 < 0)) __PYX_ERR(0, 1224, __pyx_L1_error)
     #else
-    __pyx_t_15 = PySequence_ITEM(__pyx_t_3, __pyx_t_13); __pyx_t_13++; if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1222, __pyx_L1_error)
+    __pyx_t_15 = PySequence_ITEM(__pyx_t_3, __pyx_t_13); __pyx_t_13++; if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1224, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
     #endif
     if ((likely(PyTuple_CheckExact(__pyx_t_15))) || (PyList_CheckExact(__pyx_t_15))) {
@@ -17467,7 +17499,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       if (unlikely(size != 2)) {
         if (size > 2) __Pyx_RaiseTooManyValuesError(2);
         else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-        __PYX_ERR(0, 1222, __pyx_L1_error)
+        __PYX_ERR(0, 1224, __pyx_L1_error)
       }
       #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
       if (likely(PyTuple_CheckExact(sequence))) {
@@ -17480,15 +17512,15 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __Pyx_INCREF(__pyx_t_16);
       __Pyx_INCREF(__pyx_t_1);
       #else
-      __pyx_t_16 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1222, __pyx_L1_error)
+      __pyx_t_16 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1224, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_16);
-      __pyx_t_1 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1222, __pyx_L1_error)
+      __pyx_t_1 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1224, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       #endif
       __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
     } else {
       Py_ssize_t index = -1;
-      __pyx_t_2 = PyObject_GetIter(__pyx_t_15); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1222, __pyx_L1_error)
+      __pyx_t_2 = PyObject_GetIter(__pyx_t_15); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1224, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
       __pyx_t_18 = Py_TYPE(__pyx_t_2)->tp_iternext;
@@ -17496,7 +17528,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __Pyx_GOTREF(__pyx_t_16);
       index = 1; __pyx_t_1 = __pyx_t_18(__pyx_t_2); if (unlikely(!__pyx_t_1)) goto __pyx_L13_unpacking_failed;
       __Pyx_GOTREF(__pyx_t_1);
-      if (__Pyx_IternextUnpackEndCheck(__pyx_t_18(__pyx_t_2), 2) < 0) __PYX_ERR(0, 1222, __pyx_L1_error)
+      if (__Pyx_IternextUnpackEndCheck(__pyx_t_18(__pyx_t_2), 2) < 0) __PYX_ERR(0, 1224, __pyx_L1_error)
       __pyx_t_18 = NULL;
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       goto __pyx_L14_unpacking_done;
@@ -17504,71 +17536,71 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_18 = NULL;
       if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-      __PYX_ERR(0, 1222, __pyx_L1_error)
+      __PYX_ERR(0, 1224, __pyx_L1_error)
       __pyx_L14_unpacking_done:;
     }
-    __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_16); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1222, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_As_npy_int32(__pyx_t_16); if (unlikely((__pyx_t_5 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1224, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-    __pyx_t_23 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_23 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1222, __pyx_L1_error)
+    __pyx_t_23 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_23 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1224, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_summit_offset = __pyx_t_5;
     __pyx_v_summit_index = __pyx_t_23;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1224
+    /* "MACS2/IO/CallPeakUnit.pyx":1226
  *         for summit_offset, summit_index in list(zip(summit_offsets, summit_indices)):
  * 
  *             summit_treat = peak_content[ summit_index ][ 2 ]             # <<<<<<<<<<<<<<
  *             summit_ctrl = peak_content[ summit_index ][ 3 ]
  * 
  */
-    __Pyx_TraceLine(1224,0,__PYX_ERR(0, 1224, __pyx_L1_error))
+    __Pyx_TraceLine(1226,0,__PYX_ERR(0, 1226, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1224, __pyx_L1_error)
+      __PYX_ERR(0, 1226, __pyx_L1_error)
     }
-    __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1224, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1226, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_15, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1224, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_15, 2, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1226, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1224, __pyx_L1_error)
+    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1226, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_summit_treat = __pyx_t_22;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1225
+    /* "MACS2/IO/CallPeakUnit.pyx":1227
  * 
  *             summit_treat = peak_content[ summit_index ][ 2 ]
  *             summit_ctrl = peak_content[ summit_index ][ 3 ]             # <<<<<<<<<<<<<<
  * 
  *             #summit_p_score = get_pscore( int(summit_treat), summit_ctrl )
  */
-    __Pyx_TraceLine(1225,0,__PYX_ERR(0, 1225, __pyx_L1_error))
+    __Pyx_TraceLine(1227,0,__PYX_ERR(0, 1227, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1225, __pyx_L1_error)
+      __PYX_ERR(0, 1227, __pyx_L1_error)
     }
-    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1225, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1227, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_15 = __Pyx_GetItemInt(__pyx_t_1, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1225, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_GetItemInt(__pyx_t_1, 3, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1227, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_15); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1225, __pyx_L1_error)
+    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_15); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1227, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
     __pyx_v_summit_ctrl = __pyx_t_22;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1228
+    /* "MACS2/IO/CallPeakUnit.pyx":1230
  * 
  *             #summit_p_score = get_pscore( int(summit_treat), summit_ctrl )
  *             summit_p_score = get_pscore(( <int32_t>(summit_treat), summit_ctrl ) )             # <<<<<<<<<<<<<<
  *             summit_q_score = self.pqtable[ summit_p_score ]
  * 
  */
-    __Pyx_TraceLine(1228,0,__PYX_ERR(0, 1228, __pyx_L1_error))
-    __pyx_t_15 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)__pyx_v_summit_treat)); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1228, __pyx_L1_error)
+    __Pyx_TraceLine(1230,0,__PYX_ERR(0, 1230, __pyx_L1_error))
+    __pyx_t_15 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)__pyx_v_summit_treat)); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1230, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
-    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_ctrl); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1228, __pyx_L1_error)
+    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_ctrl); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1230, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_16 = PyTuple_New(2); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1228, __pyx_L1_error)
+    __pyx_t_16 = PyTuple_New(2); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1230, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_GIVEREF(__pyx_t_15);
     PyTuple_SET_ITEM(__pyx_t_16, 0, __pyx_t_15);
@@ -17579,99 +17611,99 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __pyx_v_summit_p_score = __pyx_f_5MACS2_2IO_12CallPeakUnit_get_pscore(((PyObject*)__pyx_t_16));
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1229
+    /* "MACS2/IO/CallPeakUnit.pyx":1231
  *             #summit_p_score = get_pscore( int(summit_treat), summit_ctrl )
  *             summit_p_score = get_pscore(( <int32_t>(summit_treat), summit_ctrl ) )
  *             summit_q_score = self.pqtable[ summit_p_score ]             # <<<<<<<<<<<<<<
  * 
  *             for i in range(len(score_cutoff_s)):
  */
-    __Pyx_TraceLine(1229,0,__PYX_ERR(0, 1229, __pyx_L1_error))
+    __Pyx_TraceLine(1231,0,__PYX_ERR(0, 1231, __pyx_L1_error))
     if (unlikely(__pyx_v_self->pqtable == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1229, __pyx_L1_error)
+      __PYX_ERR(0, 1231, __pyx_L1_error)
     }
-    __pyx_t_16 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1229, __pyx_L1_error)
+    __pyx_t_16 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1231, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
-    __pyx_t_1 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_16); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1229, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_16); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1231, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
-    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1229, __pyx_L1_error)
+    __pyx_t_22 = __pyx_PyFloat_AsDouble(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1231, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __pyx_v_summit_q_score = __pyx_t_22;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1231
+    /* "MACS2/IO/CallPeakUnit.pyx":1233
  *             summit_q_score = self.pqtable[ summit_p_score ]
  * 
  *             for i in range(len(score_cutoff_s)):             # <<<<<<<<<<<<<<
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:
  *                     return False # not passed, then disgard this summit.
  */
-    __Pyx_TraceLine(1231,0,__PYX_ERR(0, 1231, __pyx_L1_error))
+    __Pyx_TraceLine(1233,0,__PYX_ERR(0, 1233, __pyx_L1_error))
     if (unlikely(__pyx_v_score_cutoff_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1231, __pyx_L1_error)
+      __PYX_ERR(0, 1233, __pyx_L1_error)
     }
-    __pyx_t_14 = PyList_GET_SIZE(__pyx_v_score_cutoff_s); if (unlikely(__pyx_t_14 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1231, __pyx_L1_error)
+    __pyx_t_14 = PyList_GET_SIZE(__pyx_v_score_cutoff_s); if (unlikely(__pyx_t_14 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1233, __pyx_L1_error)
     __pyx_t_25 = __pyx_t_14;
     for (__pyx_t_23 = 0; __pyx_t_23 < __pyx_t_25; __pyx_t_23+=1) {
       __pyx_v_i = __pyx_t_23;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1232
+      /* "MACS2/IO/CallPeakUnit.pyx":1234
  * 
  *             for i in range(len(score_cutoff_s)):
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:             # <<<<<<<<<<<<<<
  *                     return False # not passed, then disgard this summit.
  * 
  */
-      __Pyx_TraceLine(1232,0,__PYX_ERR(0, 1232, __pyx_L1_error))
+      __Pyx_TraceLine(1234,0,__PYX_ERR(0, 1234, __pyx_L1_error))
       if (unlikely(__pyx_v_score_cutoff_s == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1232, __pyx_L1_error)
+        __PYX_ERR(0, 1234, __pyx_L1_error)
       }
-      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_score_cutoff_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1232, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_score_cutoff_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1234, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       if (unlikely(__pyx_v_score_array_s == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1232, __pyx_L1_error)
+        __PYX_ERR(0, 1234, __pyx_L1_error)
       }
-      __pyx_t_16 = __Pyx_GetItemInt_List(__pyx_v_score_array_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1232, __pyx_L1_error)
+      __pyx_t_16 = __Pyx_GetItemInt_List(__pyx_v_score_array_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1234, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_16);
       if (unlikely(__pyx_v_peak_content == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1232, __pyx_L1_error)
+        __PYX_ERR(0, 1234, __pyx_L1_error)
       }
-      __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1232, __pyx_L1_error)
+      __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_summit_index, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1234, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_15);
-      __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_15, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1232, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_15, 4, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1234, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-      __pyx_t_15 = __Pyx_PyObject_GetItem(__pyx_t_16, __pyx_t_2); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1232, __pyx_L1_error)
+      __pyx_t_15 = __Pyx_PyObject_GetItem(__pyx_t_16, __pyx_t_2); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1234, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_15);
       __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      __pyx_t_2 = PyObject_RichCompare(__pyx_t_1, __pyx_t_15, Py_GT); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1232, __pyx_L1_error)
+      __pyx_t_2 = PyObject_RichCompare(__pyx_t_1, __pyx_t_15, Py_GT); __Pyx_XGOTREF(__pyx_t_2); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1234, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
-      __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1232, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_2); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1234, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       if (__pyx_t_4) {
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1233
+        /* "MACS2/IO/CallPeakUnit.pyx":1235
  *             for i in range(len(score_cutoff_s)):
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:
  *                     return False # not passed, then disgard this summit.             # <<<<<<<<<<<<<<
  * 
  *             peaks.add( chrom,
  */
-        __Pyx_TraceLine(1233,0,__PYX_ERR(0, 1233, __pyx_L1_error))
+        __Pyx_TraceLine(1235,0,__PYX_ERR(0, 1235, __pyx_L1_error))
         __Pyx_XDECREF(((PyObject *)__pyx_r));
         __Pyx_INCREF(Py_False);
         __pyx_r = ((PyBoolObject *)Py_False);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         goto __pyx_L0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1232
+        /* "MACS2/IO/CallPeakUnit.pyx":1234
  * 
  *             for i in range(len(score_cutoff_s)):
  *                 if score_cutoff_s[i] > score_array_s[ i ][ peak_content[ summit_index ][ 4 ] ]:             # <<<<<<<<<<<<<<
@@ -17681,62 +17713,62 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       }
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1235
+    /* "MACS2/IO/CallPeakUnit.pyx":1237
  *                     return False # not passed, then disgard this summit.
  * 
  *             peaks.add( chrom,             # <<<<<<<<<<<<<<
  *                        peak_content[ 0 ][ 0 ],
  *                        peak_content[ -1 ][ 1 ],
  */
-    __Pyx_TraceLine(1235,0,__PYX_ERR(0, 1235, __pyx_L1_error))
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_add); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1235, __pyx_L1_error)
+    __Pyx_TraceLine(1237,0,__PYX_ERR(0, 1237, __pyx_L1_error))
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_add); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1237, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1236
+    /* "MACS2/IO/CallPeakUnit.pyx":1238
  * 
  *             peaks.add( chrom,
  *                        peak_content[ 0 ][ 0 ],             # <<<<<<<<<<<<<<
  *                        peak_content[ -1 ][ 1 ],
  *                        summit      = start + summit_offset,
  */
-    __Pyx_TraceLine(1236,0,__PYX_ERR(0, 1236, __pyx_L1_error))
+    __Pyx_TraceLine(1238,0,__PYX_ERR(0, 1238, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1236, __pyx_L1_error)
+      __PYX_ERR(0, 1238, __pyx_L1_error)
     }
-    __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1236, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1238, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_15, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1236, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_t_15, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1238, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1237
+    /* "MACS2/IO/CallPeakUnit.pyx":1239
  *             peaks.add( chrom,
  *                        peak_content[ 0 ][ 0 ],
  *                        peak_content[ -1 ][ 1 ],             # <<<<<<<<<<<<<<
  *                        summit      = start + summit_offset,
  *                        peak_score  = summit_q_score,
  */
-    __Pyx_TraceLine(1237,0,__PYX_ERR(0, 1237, __pyx_L1_error))
+    __Pyx_TraceLine(1239,0,__PYX_ERR(0, 1239, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1237, __pyx_L1_error)
+      __PYX_ERR(0, 1239, __pyx_L1_error)
     }
-    __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1237, __pyx_L1_error)
+    __pyx_t_15 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1239, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
-    __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_15, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1237, __pyx_L1_error)
+    __pyx_t_16 = __Pyx_GetItemInt(__pyx_t_15, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1239, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1235
+    /* "MACS2/IO/CallPeakUnit.pyx":1237
  *                     return False # not passed, then disgard this summit.
  * 
  *             peaks.add( chrom,             # <<<<<<<<<<<<<<
  *                        peak_content[ 0 ][ 0 ],
  *                        peak_content[ -1 ][ 1 ],
  */
-    __Pyx_TraceLine(1235,0,__PYX_ERR(0, 1235, __pyx_L1_error))
-    __pyx_t_15 = PyTuple_New(3); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1235, __pyx_L1_error)
+    __Pyx_TraceLine(1237,0,__PYX_ERR(0, 1237, __pyx_L1_error))
+    __pyx_t_15 = PyTuple_New(3); if (unlikely(!__pyx_t_15)) __PYX_ERR(0, 1237, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_15);
     __Pyx_INCREF(__pyx_v_chrom);
     __Pyx_GIVEREF(__pyx_v_chrom);
@@ -17748,132 +17780,132 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __pyx_t_1 = 0;
     __pyx_t_16 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1238
+    /* "MACS2/IO/CallPeakUnit.pyx":1240
  *                        peak_content[ 0 ][ 0 ],
  *                        peak_content[ -1 ][ 1 ],
  *                        summit      = start + summit_offset,             # <<<<<<<<<<<<<<
  *                        peak_score  = summit_q_score,
  *                        pileup      = summit_treat,
  */
-    __Pyx_TraceLine(1238,0,__PYX_ERR(0, 1238, __pyx_L1_error))
-    __pyx_t_16 = __Pyx_PyDict_NewPresized(6); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1238, __pyx_L1_error)
+    __Pyx_TraceLine(1240,0,__PYX_ERR(0, 1240, __pyx_L1_error))
+    __pyx_t_16 = __Pyx_PyDict_NewPresized(6); if (unlikely(!__pyx_t_16)) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_16);
-    __pyx_t_1 = __Pyx_PyInt_From_npy_int32((__pyx_v_start + __pyx_v_summit_offset)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1238, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyInt_From_npy_int32((__pyx_v_start + __pyx_v_summit_offset)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_summit, __pyx_t_1) < 0) __PYX_ERR(0, 1238, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_summit, __pyx_t_1) < 0) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1239
+    /* "MACS2/IO/CallPeakUnit.pyx":1241
  *                        peak_content[ -1 ][ 1 ],
  *                        summit      = start + summit_offset,
  *                        peak_score  = summit_q_score,             # <<<<<<<<<<<<<<
  *                        pileup      = summit_treat,
  *                        pscore      = summit_p_score,
  */
-    __Pyx_TraceLine(1239,0,__PYX_ERR(0, 1239, __pyx_L1_error))
-    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1239, __pyx_L1_error)
+    __Pyx_TraceLine(1241,0,__PYX_ERR(0, 1241, __pyx_L1_error))
+    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1241, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_peak_score, __pyx_t_1) < 0) __PYX_ERR(0, 1238, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_peak_score, __pyx_t_1) < 0) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1240
+    /* "MACS2/IO/CallPeakUnit.pyx":1242
  *                        summit      = start + summit_offset,
  *                        peak_score  = summit_q_score,
  *                        pileup      = summit_treat,             # <<<<<<<<<<<<<<
  *                        pscore      = summit_p_score,
  *                        fold_change = (summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change
  */
-    __Pyx_TraceLine(1240,0,__PYX_ERR(0, 1240, __pyx_L1_error))
-    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_treat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1240, __pyx_L1_error)
+    __Pyx_TraceLine(1242,0,__PYX_ERR(0, 1242, __pyx_L1_error))
+    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_treat); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1242, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_pileup, __pyx_t_1) < 0) __PYX_ERR(0, 1238, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_pileup, __pyx_t_1) < 0) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1241
+    /* "MACS2/IO/CallPeakUnit.pyx":1243
  *                        peak_score  = summit_q_score,
  *                        pileup      = summit_treat,
  *                        pscore      = summit_p_score,             # <<<<<<<<<<<<<<
  *                        fold_change = (summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change
  *                        qscore      = summit_q_score
  */
-    __Pyx_TraceLine(1241,0,__PYX_ERR(0, 1241, __pyx_L1_error))
-    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1241, __pyx_L1_error)
+    __Pyx_TraceLine(1243,0,__PYX_ERR(0, 1243, __pyx_L1_error))
+    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_p_score); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1243, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_pscore, __pyx_t_1) < 0) __PYX_ERR(0, 1238, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_pscore, __pyx_t_1) < 0) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1242
+    /* "MACS2/IO/CallPeakUnit.pyx":1244
  *                        pileup      = summit_treat,
  *                        pscore      = summit_p_score,
  *                        fold_change = (summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change             # <<<<<<<<<<<<<<
  *                        qscore      = summit_q_score
  *                        )
  */
-    __Pyx_TraceLine(1242,0,__PYX_ERR(0, 1242, __pyx_L1_error))
+    __Pyx_TraceLine(1244,0,__PYX_ERR(0, 1244, __pyx_L1_error))
     __pyx_t_22 = (__pyx_v_summit_treat + __pyx_v_self->pseudocount);
     __pyx_t_21 = (__pyx_v_summit_ctrl + __pyx_v_self->pseudocount);
     if (unlikely(__pyx_t_21 == 0)) {
       PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-      __PYX_ERR(0, 1242, __pyx_L1_error)
+      __PYX_ERR(0, 1244, __pyx_L1_error)
     }
-    __pyx_t_1 = PyFloat_FromDouble((__pyx_t_22 / __pyx_t_21)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1242, __pyx_L1_error)
+    __pyx_t_1 = PyFloat_FromDouble((__pyx_t_22 / __pyx_t_21)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1244, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_fold_change, __pyx_t_1) < 0) __PYX_ERR(0, 1238, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_fold_change, __pyx_t_1) < 0) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1243
+    /* "MACS2/IO/CallPeakUnit.pyx":1245
  *                        pscore      = summit_p_score,
  *                        fold_change = (summit_treat + self.pseudocount ) / ( summit_ctrl + self.pseudocount ), # fold change
  *                        qscore      = summit_q_score             # <<<<<<<<<<<<<<
  *                        )
  *         # start a new peak
  */
-    __Pyx_TraceLine(1243,0,__PYX_ERR(0, 1243, __pyx_L1_error))
-    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1243, __pyx_L1_error)
+    __Pyx_TraceLine(1245,0,__PYX_ERR(0, 1245, __pyx_L1_error))
+    __pyx_t_1 = PyFloat_FromDouble(__pyx_v_summit_q_score); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1245, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_qscore, __pyx_t_1) < 0) __PYX_ERR(0, 1238, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_16, __pyx_n_s_qscore, __pyx_t_1) < 0) __PYX_ERR(0, 1240, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1235
+    /* "MACS2/IO/CallPeakUnit.pyx":1237
  *                     return False # not passed, then disgard this summit.
  * 
  *             peaks.add( chrom,             # <<<<<<<<<<<<<<
  *                        peak_content[ 0 ][ 0 ],
  *                        peak_content[ -1 ][ 1 ],
  */
-    __Pyx_TraceLine(1235,0,__PYX_ERR(0, 1235, __pyx_L1_error))
-    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_15, __pyx_t_16); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1235, __pyx_L1_error)
+    __Pyx_TraceLine(1237,0,__PYX_ERR(0, 1237, __pyx_L1_error))
+    __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_15, __pyx_t_16); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1237, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_DECREF(__pyx_t_15); __pyx_t_15 = 0;
     __Pyx_DECREF(__pyx_t_16); __pyx_t_16 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1222
+    /* "MACS2/IO/CallPeakUnit.pyx":1224
  *         summit_offsets -= start_boundary
  * 
  *         for summit_offset, summit_index in list(zip(summit_offsets, summit_indices)):             # <<<<<<<<<<<<<<
  * 
  *             summit_treat = peak_content[ summit_index ][ 2 ]
  */
-    __Pyx_TraceLine(1222,0,__PYX_ERR(0, 1222, __pyx_L1_error))
+    __Pyx_TraceLine(1224,0,__PYX_ERR(0, 1224, __pyx_L1_error))
   }
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1246
+  /* "MACS2/IO/CallPeakUnit.pyx":1248
  *                        )
  *         # start a new peak
  *         return True             # <<<<<<<<<<<<<<
  * 
  *     cdef np.ndarray __cal_pscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):
  */
-  __Pyx_TraceLine(1246,0,__PYX_ERR(0, 1246, __pyx_L1_error))
+  __Pyx_TraceLine(1248,0,__PYX_ERR(0, 1248, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(Py_True);
   __pyx_r = ((PyBoolObject *)Py_True);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1161
+  /* "MACS2/IO/CallPeakUnit.pyx":1163
  *             return True
  * 
  *     cdef bool __close_peak_with_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -17917,7 +17949,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1248
+/* "MACS2/IO/CallPeakUnit.pyx":1250
  *         return True
  * 
  *     cdef np.ndarray __cal_pscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -17954,7 +17986,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_t_5numpy_int64_t __pyx_t_11;
   __pyx_t_5numpy_int64_t __pyx_t_12;
   __Pyx_RefNannySetupContext("__cal_pscore", 0);
-  __Pyx_TraceCall("__cal_pscore", __pyx_f[0], 1248, 0, __PYX_ERR(0, 1248, __pyx_L1_error));
+  __Pyx_TraceCall("__cal_pscore", __pyx_f[0], 1250, 0, __PYX_ERR(0, 1250, __pyx_L1_error));
   __pyx_pybuffer_s.pybuffer.buf = NULL;
   __pyx_pybuffer_s.refcount = 0;
   __pyx_pybuffernd_s.data = NULL;
@@ -17969,61 +18001,61 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_pybuffernd_array2.rcbuffer = &__pyx_pybuffer_array2;
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1248, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1250, __pyx_L1_error)
   }
   __pyx_pybuffernd_array1.diminfo[0].strides = __pyx_pybuffernd_array1.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array1.diminfo[0].shape = __pyx_pybuffernd_array1.rcbuffer->pybuffer.shape[0];
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1248, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1250, __pyx_L1_error)
   }
   __pyx_pybuffernd_array2.diminfo[0].strides = __pyx_pybuffernd_array2.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array2.diminfo[0].shape = __pyx_pybuffernd_array2.rcbuffer->pybuffer.shape[0];
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1256
+  /* "MACS2/IO/CallPeakUnit.pyx":1258
  *             float32_t * s_ptr
  * 
  *         assert array1.shape[0] == array2.shape[0]             # <<<<<<<<<<<<<<
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  */
-  __Pyx_TraceLine(1256,0,__PYX_ERR(0, 1256, __pyx_L1_error))
+  __Pyx_TraceLine(1258,0,__PYX_ERR(0, 1258, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!(((__pyx_v_array1->dimensions[0]) == (__pyx_v_array2->dimensions[0])) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 1256, __pyx_L1_error)
+      __PYX_ERR(0, 1258, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1257
+  /* "MACS2/IO/CallPeakUnit.pyx":1259
  * 
  *         assert array1.shape[0] == array2.shape[0]
  *         s = np.zeros(array1.shape[0], dtype="float32")             # <<<<<<<<<<<<<<
  * 
  *         a1_ptr = <float32_t *> array1.data
  */
-  __Pyx_TraceLine(1257,0,__PYX_ERR(0, 1257, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1257, __pyx_L1_error)
+  __Pyx_TraceLine(1259,0,__PYX_ERR(0, 1259, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1259, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1257, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1259, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1257, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1259, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1257, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1259, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1257, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1259, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1257, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1257, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1259, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1259, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1257, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1259, __pyx_L1_error)
   __pyx_t_5 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -18040,78 +18072,78 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_s.diminfo[0].strides = __pyx_pybuffernd_s.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_s.diminfo[0].shape = __pyx_pybuffernd_s.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1257, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1259, __pyx_L1_error)
   }
   __pyx_t_5 = 0;
   __pyx_v_s = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1259
+  /* "MACS2/IO/CallPeakUnit.pyx":1261
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  *         a1_ptr = <float32_t *> array1.data             # <<<<<<<<<<<<<<
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data
  */
-  __Pyx_TraceLine(1259,0,__PYX_ERR(0, 1259, __pyx_L1_error))
+  __Pyx_TraceLine(1261,0,__PYX_ERR(0, 1261, __pyx_L1_error))
   __pyx_v_a1_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array1->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1260
+  /* "MACS2/IO/CallPeakUnit.pyx":1262
  * 
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data             # <<<<<<<<<<<<<<
  *         s_ptr = <float32_t *> s.data
  * 
  */
-  __Pyx_TraceLine(1260,0,__PYX_ERR(0, 1260, __pyx_L1_error))
+  __Pyx_TraceLine(1262,0,__PYX_ERR(0, 1262, __pyx_L1_error))
   __pyx_v_a2_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array2->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1261
+  /* "MACS2/IO/CallPeakUnit.pyx":1263
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data             # <<<<<<<<<<<<<<
  * 
  *         array1_size = array1.shape[0]
  */
-  __Pyx_TraceLine(1261,0,__PYX_ERR(0, 1261, __pyx_L1_error))
+  __Pyx_TraceLine(1263,0,__PYX_ERR(0, 1263, __pyx_L1_error))
   __pyx_v_s_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_s->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1263
+  /* "MACS2/IO/CallPeakUnit.pyx":1265
  *         s_ptr = <float32_t *> s.data
  * 
  *         array1_size = array1.shape[0]             # <<<<<<<<<<<<<<
  * 
  *         for i in range(array1_size):
  */
-  __Pyx_TraceLine(1263,0,__PYX_ERR(0, 1263, __pyx_L1_error))
+  __Pyx_TraceLine(1265,0,__PYX_ERR(0, 1265, __pyx_L1_error))
   __pyx_v_array1_size = (__pyx_v_array1->dimensions[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1265
+  /* "MACS2/IO/CallPeakUnit.pyx":1267
  *         array1_size = array1.shape[0]
  * 
  *         for i in range(array1_size):             # <<<<<<<<<<<<<<
  *             #s_ptr[0] = get_pscore( int(a1_ptr[0]), a2_ptr[0] )
  *             s_ptr[0] = get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] ))
  */
-  __Pyx_TraceLine(1265,0,__PYX_ERR(0, 1265, __pyx_L1_error))
+  __Pyx_TraceLine(1267,0,__PYX_ERR(0, 1267, __pyx_L1_error))
   __pyx_t_10 = __pyx_v_array1_size;
   __pyx_t_11 = __pyx_t_10;
   for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
     __pyx_v_i = __pyx_t_12;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1267
+    /* "MACS2/IO/CallPeakUnit.pyx":1269
  *         for i in range(array1_size):
  *             #s_ptr[0] = get_pscore( int(a1_ptr[0]), a2_ptr[0] )
  *             s_ptr[0] = get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] ))             # <<<<<<<<<<<<<<
  *             s_ptr += 1
  *             a1_ptr += 1
  */
-    __Pyx_TraceLine(1267,0,__PYX_ERR(0, 1267, __pyx_L1_error))
-    __pyx_t_4 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)(__pyx_v_a1_ptr[0]))); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1267, __pyx_L1_error)
+    __Pyx_TraceLine(1269,0,__PYX_ERR(0, 1269, __pyx_L1_error))
+    __pyx_t_4 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)(__pyx_v_a1_ptr[0]))); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1269, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_1 = PyFloat_FromDouble((__pyx_v_a2_ptr[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1267, __pyx_L1_error)
+    __pyx_t_1 = PyFloat_FromDouble((__pyx_v_a2_ptr[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1269, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1267, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1269, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_GIVEREF(__pyx_t_4);
     PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_4);
@@ -18122,51 +18154,51 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
     (__pyx_v_s_ptr[0]) = __pyx_f_5MACS2_2IO_12CallPeakUnit_get_pscore(((PyObject*)__pyx_t_3));
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1268
+    /* "MACS2/IO/CallPeakUnit.pyx":1270
  *             #s_ptr[0] = get_pscore( int(a1_ptr[0]), a2_ptr[0] )
  *             s_ptr[0] = get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] ))
  *             s_ptr += 1             # <<<<<<<<<<<<<<
  *             a1_ptr += 1
  *             a2_ptr += 1
  */
-    __Pyx_TraceLine(1268,0,__PYX_ERR(0, 1268, __pyx_L1_error))
+    __Pyx_TraceLine(1270,0,__PYX_ERR(0, 1270, __pyx_L1_error))
     __pyx_v_s_ptr = (__pyx_v_s_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1269
+    /* "MACS2/IO/CallPeakUnit.pyx":1271
  *             s_ptr[0] = get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] ))
  *             s_ptr += 1
  *             a1_ptr += 1             # <<<<<<<<<<<<<<
  *             a2_ptr += 1
  *         return s
  */
-    __Pyx_TraceLine(1269,0,__PYX_ERR(0, 1269, __pyx_L1_error))
+    __Pyx_TraceLine(1271,0,__PYX_ERR(0, 1271, __pyx_L1_error))
     __pyx_v_a1_ptr = (__pyx_v_a1_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1270
+    /* "MACS2/IO/CallPeakUnit.pyx":1272
  *             s_ptr += 1
  *             a1_ptr += 1
  *             a2_ptr += 1             # <<<<<<<<<<<<<<
  *         return s
  * 
  */
-    __Pyx_TraceLine(1270,0,__PYX_ERR(0, 1270, __pyx_L1_error))
+    __Pyx_TraceLine(1272,0,__PYX_ERR(0, 1272, __pyx_L1_error))
     __pyx_v_a2_ptr = (__pyx_v_a2_ptr + 1);
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1271
+  /* "MACS2/IO/CallPeakUnit.pyx":1273
  *             a1_ptr += 1
  *             a2_ptr += 1
  *         return s             # <<<<<<<<<<<<<<
  * 
  *     cdef np.ndarray __cal_qscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):
  */
-  __Pyx_TraceLine(1271,0,__PYX_ERR(0, 1271, __pyx_L1_error))
+  __Pyx_TraceLine(1273,0,__PYX_ERR(0, 1273, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(((PyObject *)__pyx_v_s));
   __pyx_r = ((PyArrayObject *)__pyx_v_s);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1248
+  /* "MACS2/IO/CallPeakUnit.pyx":1250
  *         return True
  * 
  *     cdef np.ndarray __cal_pscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -18203,7 +18235,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1273
+/* "MACS2/IO/CallPeakUnit.pyx":1275
  *         return s
  * 
  *     cdef np.ndarray __cal_qscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -18240,7 +18272,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_t_5numpy_int64_t __pyx_t_12;
   __pyx_t_5numpy_float32_t __pyx_t_13;
   __Pyx_RefNannySetupContext("__cal_qscore", 0);
-  __Pyx_TraceCall("__cal_qscore", __pyx_f[0], 1273, 0, __PYX_ERR(0, 1273, __pyx_L1_error));
+  __Pyx_TraceCall("__cal_qscore", __pyx_f[0], 1275, 0, __PYX_ERR(0, 1275, __pyx_L1_error));
   __pyx_pybuffer_s.pybuffer.buf = NULL;
   __pyx_pybuffer_s.refcount = 0;
   __pyx_pybuffernd_s.data = NULL;
@@ -18255,61 +18287,61 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_pybuffernd_array2.rcbuffer = &__pyx_pybuffer_array2;
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1273, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1275, __pyx_L1_error)
   }
   __pyx_pybuffernd_array1.diminfo[0].strides = __pyx_pybuffernd_array1.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array1.diminfo[0].shape = __pyx_pybuffernd_array1.rcbuffer->pybuffer.shape[0];
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1273, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1275, __pyx_L1_error)
   }
   __pyx_pybuffernd_array2.diminfo[0].strides = __pyx_pybuffernd_array2.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array2.diminfo[0].shape = __pyx_pybuffernd_array2.rcbuffer->pybuffer.shape[0];
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1281
+  /* "MACS2/IO/CallPeakUnit.pyx":1283
  *             float32_t * s_ptr
  * 
  *         assert array1.shape[0] == array2.shape[0]             # <<<<<<<<<<<<<<
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  */
-  __Pyx_TraceLine(1281,0,__PYX_ERR(0, 1281, __pyx_L1_error))
+  __Pyx_TraceLine(1283,0,__PYX_ERR(0, 1283, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!(((__pyx_v_array1->dimensions[0]) == (__pyx_v_array2->dimensions[0])) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 1281, __pyx_L1_error)
+      __PYX_ERR(0, 1283, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1282
+  /* "MACS2/IO/CallPeakUnit.pyx":1284
  * 
  *         assert array1.shape[0] == array2.shape[0]
  *         s = np.zeros(array1.shape[0], dtype="float32")             # <<<<<<<<<<<<<<
  * 
  *         a1_ptr = <float32_t *> array1.data
  */
-  __Pyx_TraceLine(1282,0,__PYX_ERR(0, 1282, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1282, __pyx_L1_error)
+  __Pyx_TraceLine(1284,0,__PYX_ERR(0, 1284, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1284, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1282, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1284, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1282, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1284, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1282, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1284, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1282, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1284, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1282, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1282, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1284, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1284, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1282, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1284, __pyx_L1_error)
   __pyx_t_5 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -18326,72 +18358,72 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_s.diminfo[0].strides = __pyx_pybuffernd_s.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_s.diminfo[0].shape = __pyx_pybuffernd_s.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1282, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1284, __pyx_L1_error)
   }
   __pyx_t_5 = 0;
   __pyx_v_s = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1284
+  /* "MACS2/IO/CallPeakUnit.pyx":1286
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  *         a1_ptr = <float32_t *> array1.data             # <<<<<<<<<<<<<<
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data
  */
-  __Pyx_TraceLine(1284,0,__PYX_ERR(0, 1284, __pyx_L1_error))
+  __Pyx_TraceLine(1286,0,__PYX_ERR(0, 1286, __pyx_L1_error))
   __pyx_v_a1_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array1->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1285
+  /* "MACS2/IO/CallPeakUnit.pyx":1287
  * 
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data             # <<<<<<<<<<<<<<
  *         s_ptr = <float32_t *> s.data
  * 
  */
-  __Pyx_TraceLine(1285,0,__PYX_ERR(0, 1285, __pyx_L1_error))
+  __Pyx_TraceLine(1287,0,__PYX_ERR(0, 1287, __pyx_L1_error))
   __pyx_v_a2_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array2->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1286
+  /* "MACS2/IO/CallPeakUnit.pyx":1288
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data             # <<<<<<<<<<<<<<
  * 
  *         for i in range(array1.shape[0]):
  */
-  __Pyx_TraceLine(1286,0,__PYX_ERR(0, 1286, __pyx_L1_error))
+  __Pyx_TraceLine(1288,0,__PYX_ERR(0, 1288, __pyx_L1_error))
   __pyx_v_s_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_s->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1288
+  /* "MACS2/IO/CallPeakUnit.pyx":1290
  *         s_ptr = <float32_t *> s.data
  * 
  *         for i in range(array1.shape[0]):             # <<<<<<<<<<<<<<
  *             #s_ptr[0] = self.pqtable[ get_pscore( int(a1_ptr[0]), a2_ptr[0] ) ]
  *             s_ptr[0] = self.pqtable[ get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] )) ]
  */
-  __Pyx_TraceLine(1288,0,__PYX_ERR(0, 1288, __pyx_L1_error))
+  __Pyx_TraceLine(1290,0,__PYX_ERR(0, 1290, __pyx_L1_error))
   __pyx_t_10 = (__pyx_v_array1->dimensions[0]);
   __pyx_t_11 = __pyx_t_10;
   for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
     __pyx_v_i = __pyx_t_12;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1290
+    /* "MACS2/IO/CallPeakUnit.pyx":1292
  *         for i in range(array1.shape[0]):
  *             #s_ptr[0] = self.pqtable[ get_pscore( int(a1_ptr[0]), a2_ptr[0] ) ]
  *             s_ptr[0] = self.pqtable[ get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] )) ]             # <<<<<<<<<<<<<<
  *             s_ptr += 1
  *             a1_ptr += 1
  */
-    __Pyx_TraceLine(1290,0,__PYX_ERR(0, 1290, __pyx_L1_error))
+    __Pyx_TraceLine(1292,0,__PYX_ERR(0, 1292, __pyx_L1_error))
     if (unlikely(__pyx_v_self->pqtable == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1290, __pyx_L1_error)
+      __PYX_ERR(0, 1292, __pyx_L1_error)
     }
-    __pyx_t_4 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)(__pyx_v_a1_ptr[0]))); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1290, __pyx_L1_error)
+    __pyx_t_4 = __Pyx_PyInt_From_npy_int32(((__pyx_t_5numpy_int32_t)(__pyx_v_a1_ptr[0]))); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1292, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_1 = PyFloat_FromDouble((__pyx_v_a2_ptr[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1290, __pyx_L1_error)
+    __pyx_t_1 = PyFloat_FromDouble((__pyx_v_a2_ptr[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1292, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1290, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(2); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1292, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_GIVEREF(__pyx_t_4);
     PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_4);
@@ -18399,61 +18431,61 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
     PyTuple_SET_ITEM(__pyx_t_3, 1, __pyx_t_1);
     __pyx_t_4 = 0;
     __pyx_t_1 = 0;
-    __pyx_t_1 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_get_pscore(((PyObject*)__pyx_t_3))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1290, __pyx_L1_error)
+    __pyx_t_1 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_get_pscore(((PyObject*)__pyx_t_3))); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1292, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_3 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1290, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyDict_GetItem(__pyx_v_self->pqtable, __pyx_t_1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1292, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-    __pyx_t_13 = __pyx_PyFloat_AsFloat(__pyx_t_3); if (unlikely((__pyx_t_13 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1290, __pyx_L1_error)
+    __pyx_t_13 = __pyx_PyFloat_AsFloat(__pyx_t_3); if (unlikely((__pyx_t_13 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1292, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     (__pyx_v_s_ptr[0]) = __pyx_t_13;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1291
+    /* "MACS2/IO/CallPeakUnit.pyx":1293
  *             #s_ptr[0] = self.pqtable[ get_pscore( int(a1_ptr[0]), a2_ptr[0] ) ]
  *             s_ptr[0] = self.pqtable[ get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] )) ]
  *             s_ptr += 1             # <<<<<<<<<<<<<<
  *             a1_ptr += 1
  *             a2_ptr += 1
  */
-    __Pyx_TraceLine(1291,0,__PYX_ERR(0, 1291, __pyx_L1_error))
+    __Pyx_TraceLine(1293,0,__PYX_ERR(0, 1293, __pyx_L1_error))
     __pyx_v_s_ptr = (__pyx_v_s_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1292
+    /* "MACS2/IO/CallPeakUnit.pyx":1294
  *             s_ptr[0] = self.pqtable[ get_pscore(( <int32_t>(a1_ptr[0]), a2_ptr[0] )) ]
  *             s_ptr += 1
  *             a1_ptr += 1             # <<<<<<<<<<<<<<
  *             a2_ptr += 1
  *         return s
  */
-    __Pyx_TraceLine(1292,0,__PYX_ERR(0, 1292, __pyx_L1_error))
+    __Pyx_TraceLine(1294,0,__PYX_ERR(0, 1294, __pyx_L1_error))
     __pyx_v_a1_ptr = (__pyx_v_a1_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1293
+    /* "MACS2/IO/CallPeakUnit.pyx":1295
  *             s_ptr += 1
  *             a1_ptr += 1
  *             a2_ptr += 1             # <<<<<<<<<<<<<<
  *         return s
  * 
  */
-    __Pyx_TraceLine(1293,0,__PYX_ERR(0, 1293, __pyx_L1_error))
+    __Pyx_TraceLine(1295,0,__PYX_ERR(0, 1295, __pyx_L1_error))
     __pyx_v_a2_ptr = (__pyx_v_a2_ptr + 1);
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1294
+  /* "MACS2/IO/CallPeakUnit.pyx":1296
  *             a1_ptr += 1
  *             a2_ptr += 1
  *         return s             # <<<<<<<<<<<<<<
  * 
  *     cdef np.ndarray __cal_logLR ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):
  */
-  __Pyx_TraceLine(1294,0,__PYX_ERR(0, 1294, __pyx_L1_error))
+  __Pyx_TraceLine(1296,0,__PYX_ERR(0, 1296, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(((PyObject *)__pyx_v_s));
   __pyx_r = ((PyArrayObject *)__pyx_v_s);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1273
+  /* "MACS2/IO/CallPeakUnit.pyx":1275
  *         return s
  * 
  *     cdef np.ndarray __cal_qscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -18490,7 +18522,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1296
+/* "MACS2/IO/CallPeakUnit.pyx":1298
  *         return s
  * 
  *     cdef np.ndarray __cal_logLR ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -18526,7 +18558,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   npy_intp __pyx_t_11;
   __pyx_t_5numpy_int64_t __pyx_t_12;
   __Pyx_RefNannySetupContext("__cal_logLR", 0);
-  __Pyx_TraceCall("__cal_logLR", __pyx_f[0], 1296, 0, __PYX_ERR(0, 1296, __pyx_L1_error));
+  __Pyx_TraceCall("__cal_logLR", __pyx_f[0], 1298, 0, __PYX_ERR(0, 1298, __pyx_L1_error));
   __pyx_pybuffer_s.pybuffer.buf = NULL;
   __pyx_pybuffer_s.refcount = 0;
   __pyx_pybuffernd_s.data = NULL;
@@ -18541,61 +18573,61 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_pybuffernd_array2.rcbuffer = &__pyx_pybuffer_array2;
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1296, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1298, __pyx_L1_error)
   }
   __pyx_pybuffernd_array1.diminfo[0].strides = __pyx_pybuffernd_array1.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array1.diminfo[0].shape = __pyx_pybuffernd_array1.rcbuffer->pybuffer.shape[0];
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1296, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1298, __pyx_L1_error)
   }
   __pyx_pybuffernd_array2.diminfo[0].strides = __pyx_pybuffernd_array2.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array2.diminfo[0].shape = __pyx_pybuffernd_array2.rcbuffer->pybuffer.shape[0];
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1304
+  /* "MACS2/IO/CallPeakUnit.pyx":1306
  *             float32_t * s_ptr
  * 
  *         assert array1.shape[0] == array2.shape[0]             # <<<<<<<<<<<<<<
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  */
-  __Pyx_TraceLine(1304,0,__PYX_ERR(0, 1304, __pyx_L1_error))
+  __Pyx_TraceLine(1306,0,__PYX_ERR(0, 1306, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!(((__pyx_v_array1->dimensions[0]) == (__pyx_v_array2->dimensions[0])) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 1304, __pyx_L1_error)
+      __PYX_ERR(0, 1306, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1305
+  /* "MACS2/IO/CallPeakUnit.pyx":1307
  * 
  *         assert array1.shape[0] == array2.shape[0]
  *         s = np.zeros(array1.shape[0], dtype="float32")             # <<<<<<<<<<<<<<
  * 
  *         a1_ptr = <float32_t *> array1.data
  */
-  __Pyx_TraceLine(1305,0,__PYX_ERR(0, 1305, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1305, __pyx_L1_error)
+  __Pyx_TraceLine(1307,0,__PYX_ERR(0, 1307, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1307, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1305, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1307, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1305, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1307, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1305, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1307, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1305, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1307, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1305, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1305, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1307, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1307, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1305, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1307, __pyx_L1_error)
   __pyx_t_5 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -18612,110 +18644,110 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_s.diminfo[0].strides = __pyx_pybuffernd_s.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_s.diminfo[0].shape = __pyx_pybuffernd_s.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1305, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1307, __pyx_L1_error)
   }
   __pyx_t_5 = 0;
   __pyx_v_s = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1307
+  /* "MACS2/IO/CallPeakUnit.pyx":1309
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  *         a1_ptr = <float32_t *> array1.data             # <<<<<<<<<<<<<<
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data
  */
-  __Pyx_TraceLine(1307,0,__PYX_ERR(0, 1307, __pyx_L1_error))
+  __Pyx_TraceLine(1309,0,__PYX_ERR(0, 1309, __pyx_L1_error))
   __pyx_v_a1_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array1->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1308
+  /* "MACS2/IO/CallPeakUnit.pyx":1310
  * 
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data             # <<<<<<<<<<<<<<
  *         s_ptr = <float32_t *> s.data
  * 
  */
-  __Pyx_TraceLine(1308,0,__PYX_ERR(0, 1308, __pyx_L1_error))
+  __Pyx_TraceLine(1310,0,__PYX_ERR(0, 1310, __pyx_L1_error))
   __pyx_v_a2_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array2->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1309
+  /* "MACS2/IO/CallPeakUnit.pyx":1311
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data             # <<<<<<<<<<<<<<
  * 
  *         for i in range(array1.shape[0]):
  */
-  __Pyx_TraceLine(1309,0,__PYX_ERR(0, 1309, __pyx_L1_error))
+  __Pyx_TraceLine(1311,0,__PYX_ERR(0, 1311, __pyx_L1_error))
   __pyx_v_s_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_s->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1311
+  /* "MACS2/IO/CallPeakUnit.pyx":1313
  *         s_ptr = <float32_t *> s.data
  * 
  *         for i in range(array1.shape[0]):             # <<<<<<<<<<<<<<
  *             s_ptr[0] = get_logLR_asym( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1
  */
-  __Pyx_TraceLine(1311,0,__PYX_ERR(0, 1311, __pyx_L1_error))
+  __Pyx_TraceLine(1313,0,__PYX_ERR(0, 1313, __pyx_L1_error))
   __pyx_t_10 = (__pyx_v_array1->dimensions[0]);
   __pyx_t_11 = __pyx_t_10;
   for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
     __pyx_v_i = __pyx_t_12;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1312
+    /* "MACS2/IO/CallPeakUnit.pyx":1314
  * 
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = get_logLR_asym( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )             # <<<<<<<<<<<<<<
  *             s_ptr += 1
  *             a1_ptr += 1
  */
-    __Pyx_TraceLine(1312,0,__PYX_ERR(0, 1312, __pyx_L1_error))
+    __Pyx_TraceLine(1314,0,__PYX_ERR(0, 1314, __pyx_L1_error))
     (__pyx_v_s_ptr[0]) = __pyx_f_5MACS2_2IO_12CallPeakUnit_get_logLR_asym(((__pyx_v_a1_ptr[0]) + __pyx_v_self->pseudocount), ((__pyx_v_a2_ptr[0]) + __pyx_v_self->pseudocount));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1313
+    /* "MACS2/IO/CallPeakUnit.pyx":1315
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = get_logLR_asym( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1             # <<<<<<<<<<<<<<
  *             a1_ptr += 1
  *             a2_ptr += 1
  */
-    __Pyx_TraceLine(1313,0,__PYX_ERR(0, 1313, __pyx_L1_error))
+    __Pyx_TraceLine(1315,0,__PYX_ERR(0, 1315, __pyx_L1_error))
     __pyx_v_s_ptr = (__pyx_v_s_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1314
+    /* "MACS2/IO/CallPeakUnit.pyx":1316
  *             s_ptr[0] = get_logLR_asym( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1
  *             a1_ptr += 1             # <<<<<<<<<<<<<<
  *             a2_ptr += 1
  *         return s
  */
-    __Pyx_TraceLine(1314,0,__PYX_ERR(0, 1314, __pyx_L1_error))
+    __Pyx_TraceLine(1316,0,__PYX_ERR(0, 1316, __pyx_L1_error))
     __pyx_v_a1_ptr = (__pyx_v_a1_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1315
+    /* "MACS2/IO/CallPeakUnit.pyx":1317
  *             s_ptr += 1
  *             a1_ptr += 1
  *             a2_ptr += 1             # <<<<<<<<<<<<<<
  *         return s
  * 
  */
-    __Pyx_TraceLine(1315,0,__PYX_ERR(0, 1315, __pyx_L1_error))
+    __Pyx_TraceLine(1317,0,__PYX_ERR(0, 1317, __pyx_L1_error))
     __pyx_v_a2_ptr = (__pyx_v_a2_ptr + 1);
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1316
+  /* "MACS2/IO/CallPeakUnit.pyx":1318
  *             a1_ptr += 1
  *             a2_ptr += 1
  *         return s             # <<<<<<<<<<<<<<
  * 
  *     cdef np.ndarray __cal_logFE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):
  */
-  __Pyx_TraceLine(1316,0,__PYX_ERR(0, 1316, __pyx_L1_error))
+  __Pyx_TraceLine(1318,0,__PYX_ERR(0, 1318, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(((PyObject *)__pyx_v_s));
   __pyx_r = ((PyArrayObject *)__pyx_v_s);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1296
+  /* "MACS2/IO/CallPeakUnit.pyx":1298
  *         return s
  * 
  *     cdef np.ndarray __cal_logLR ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -18752,7 +18784,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1318
+/* "MACS2/IO/CallPeakUnit.pyx":1320
  *         return s
  * 
  *     cdef np.ndarray __cal_logFE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -18788,7 +18820,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   npy_intp __pyx_t_11;
   __pyx_t_5numpy_int64_t __pyx_t_12;
   __Pyx_RefNannySetupContext("__cal_logFE", 0);
-  __Pyx_TraceCall("__cal_logFE", __pyx_f[0], 1318, 0, __PYX_ERR(0, 1318, __pyx_L1_error));
+  __Pyx_TraceCall("__cal_logFE", __pyx_f[0], 1320, 0, __PYX_ERR(0, 1320, __pyx_L1_error));
   __pyx_pybuffer_s.pybuffer.buf = NULL;
   __pyx_pybuffer_s.refcount = 0;
   __pyx_pybuffernd_s.data = NULL;
@@ -18803,61 +18835,61 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_pybuffernd_array2.rcbuffer = &__pyx_pybuffer_array2;
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1318, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1320, __pyx_L1_error)
   }
   __pyx_pybuffernd_array1.diminfo[0].strides = __pyx_pybuffernd_array1.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array1.diminfo[0].shape = __pyx_pybuffernd_array1.rcbuffer->pybuffer.shape[0];
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1318, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1320, __pyx_L1_error)
   }
   __pyx_pybuffernd_array2.diminfo[0].strides = __pyx_pybuffernd_array2.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array2.diminfo[0].shape = __pyx_pybuffernd_array2.rcbuffer->pybuffer.shape[0];
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1326
+  /* "MACS2/IO/CallPeakUnit.pyx":1328
  *             float32_t * s_ptr
  * 
  *         assert array1.shape[0] == array2.shape[0]             # <<<<<<<<<<<<<<
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  */
-  __Pyx_TraceLine(1326,0,__PYX_ERR(0, 1326, __pyx_L1_error))
+  __Pyx_TraceLine(1328,0,__PYX_ERR(0, 1328, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!(((__pyx_v_array1->dimensions[0]) == (__pyx_v_array2->dimensions[0])) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 1326, __pyx_L1_error)
+      __PYX_ERR(0, 1328, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1327
+  /* "MACS2/IO/CallPeakUnit.pyx":1329
  * 
  *         assert array1.shape[0] == array2.shape[0]
  *         s = np.zeros(array1.shape[0], dtype="float32")             # <<<<<<<<<<<<<<
  * 
  *         a1_ptr = <float32_t *> array1.data
  */
-  __Pyx_TraceLine(1327,0,__PYX_ERR(0, 1327, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1327, __pyx_L1_error)
+  __Pyx_TraceLine(1329,0,__PYX_ERR(0, 1329, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1329, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1327, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1329, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1327, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1329, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1327, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1329, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1327, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1329, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1327, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1327, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1329, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1329, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1327, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1329, __pyx_L1_error)
   __pyx_t_5 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -18874,110 +18906,110 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_s.diminfo[0].strides = __pyx_pybuffernd_s.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_s.diminfo[0].shape = __pyx_pybuffernd_s.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1327, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1329, __pyx_L1_error)
   }
   __pyx_t_5 = 0;
   __pyx_v_s = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1329
+  /* "MACS2/IO/CallPeakUnit.pyx":1331
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  *         a1_ptr = <float32_t *> array1.data             # <<<<<<<<<<<<<<
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data
  */
-  __Pyx_TraceLine(1329,0,__PYX_ERR(0, 1329, __pyx_L1_error))
+  __Pyx_TraceLine(1331,0,__PYX_ERR(0, 1331, __pyx_L1_error))
   __pyx_v_a1_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array1->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1330
+  /* "MACS2/IO/CallPeakUnit.pyx":1332
  * 
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data             # <<<<<<<<<<<<<<
  *         s_ptr = <float32_t *> s.data
  * 
  */
-  __Pyx_TraceLine(1330,0,__PYX_ERR(0, 1330, __pyx_L1_error))
+  __Pyx_TraceLine(1332,0,__PYX_ERR(0, 1332, __pyx_L1_error))
   __pyx_v_a2_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array2->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1331
+  /* "MACS2/IO/CallPeakUnit.pyx":1333
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data             # <<<<<<<<<<<<<<
  * 
  *         for i in range(array1.shape[0]):
  */
-  __Pyx_TraceLine(1331,0,__PYX_ERR(0, 1331, __pyx_L1_error))
+  __Pyx_TraceLine(1333,0,__PYX_ERR(0, 1333, __pyx_L1_error))
   __pyx_v_s_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_s->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1333
+  /* "MACS2/IO/CallPeakUnit.pyx":1335
  *         s_ptr = <float32_t *> s.data
  * 
  *         for i in range(array1.shape[0]):             # <<<<<<<<<<<<<<
  *             s_ptr[0] = get_logFE( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1
  */
-  __Pyx_TraceLine(1333,0,__PYX_ERR(0, 1333, __pyx_L1_error))
+  __Pyx_TraceLine(1335,0,__PYX_ERR(0, 1335, __pyx_L1_error))
   __pyx_t_10 = (__pyx_v_array1->dimensions[0]);
   __pyx_t_11 = __pyx_t_10;
   for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
     __pyx_v_i = __pyx_t_12;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1334
+    /* "MACS2/IO/CallPeakUnit.pyx":1336
  * 
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = get_logFE( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )             # <<<<<<<<<<<<<<
  *             s_ptr += 1
  *             a1_ptr += 1
  */
-    __Pyx_TraceLine(1334,0,__PYX_ERR(0, 1334, __pyx_L1_error))
+    __Pyx_TraceLine(1336,0,__PYX_ERR(0, 1336, __pyx_L1_error))
     (__pyx_v_s_ptr[0]) = __pyx_f_5MACS2_2IO_12CallPeakUnit_get_logFE(((__pyx_v_a1_ptr[0]) + __pyx_v_self->pseudocount), ((__pyx_v_a2_ptr[0]) + __pyx_v_self->pseudocount));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1335
+    /* "MACS2/IO/CallPeakUnit.pyx":1337
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = get_logFE( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1             # <<<<<<<<<<<<<<
  *             a1_ptr += 1
  *             a2_ptr += 1
  */
-    __Pyx_TraceLine(1335,0,__PYX_ERR(0, 1335, __pyx_L1_error))
+    __Pyx_TraceLine(1337,0,__PYX_ERR(0, 1337, __pyx_L1_error))
     __pyx_v_s_ptr = (__pyx_v_s_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1336
+    /* "MACS2/IO/CallPeakUnit.pyx":1338
  *             s_ptr[0] = get_logFE( a1_ptr[0] + self.pseudocount, a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1
  *             a1_ptr += 1             # <<<<<<<<<<<<<<
  *             a2_ptr += 1
  *         return s
  */
-    __Pyx_TraceLine(1336,0,__PYX_ERR(0, 1336, __pyx_L1_error))
+    __Pyx_TraceLine(1338,0,__PYX_ERR(0, 1338, __pyx_L1_error))
     __pyx_v_a1_ptr = (__pyx_v_a1_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1337
+    /* "MACS2/IO/CallPeakUnit.pyx":1339
  *             s_ptr += 1
  *             a1_ptr += 1
  *             a2_ptr += 1             # <<<<<<<<<<<<<<
  *         return s
  * 
  */
-    __Pyx_TraceLine(1337,0,__PYX_ERR(0, 1337, __pyx_L1_error))
+    __Pyx_TraceLine(1339,0,__PYX_ERR(0, 1339, __pyx_L1_error))
     __pyx_v_a2_ptr = (__pyx_v_a2_ptr + 1);
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1338
+  /* "MACS2/IO/CallPeakUnit.pyx":1340
  *             a1_ptr += 1
  *             a2_ptr += 1
  *         return s             # <<<<<<<<<<<<<<
  * 
  *     cdef np.ndarray __cal_FE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):
  */
-  __Pyx_TraceLine(1338,0,__PYX_ERR(0, 1338, __pyx_L1_error))
+  __Pyx_TraceLine(1340,0,__PYX_ERR(0, 1340, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(((PyObject *)__pyx_v_s));
   __pyx_r = ((PyArrayObject *)__pyx_v_s);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1318
+  /* "MACS2/IO/CallPeakUnit.pyx":1320
  *         return s
  * 
  *     cdef np.ndarray __cal_logFE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -19014,7 +19046,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1340
+/* "MACS2/IO/CallPeakUnit.pyx":1342
  *         return s
  * 
  *     cdef np.ndarray __cal_FE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -19052,7 +19084,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_t_5numpy_float64_t __pyx_t_13;
   __pyx_t_5numpy_float64_t __pyx_t_14;
   __Pyx_RefNannySetupContext("__cal_FE", 0);
-  __Pyx_TraceCall("__cal_FE", __pyx_f[0], 1340, 0, __PYX_ERR(0, 1340, __pyx_L1_error));
+  __Pyx_TraceCall("__cal_FE", __pyx_f[0], 1342, 0, __PYX_ERR(0, 1342, __pyx_L1_error));
   __pyx_pybuffer_s.pybuffer.buf = NULL;
   __pyx_pybuffer_s.refcount = 0;
   __pyx_pybuffernd_s.data = NULL;
@@ -19067,61 +19099,61 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_pybuffernd_array2.rcbuffer = &__pyx_pybuffer_array2;
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1340, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1342, __pyx_L1_error)
   }
   __pyx_pybuffernd_array1.diminfo[0].strides = __pyx_pybuffernd_array1.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array1.diminfo[0].shape = __pyx_pybuffernd_array1.rcbuffer->pybuffer.shape[0];
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1340, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1342, __pyx_L1_error)
   }
   __pyx_pybuffernd_array2.diminfo[0].strides = __pyx_pybuffernd_array2.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array2.diminfo[0].shape = __pyx_pybuffernd_array2.rcbuffer->pybuffer.shape[0];
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1348
+  /* "MACS2/IO/CallPeakUnit.pyx":1350
  *             float32_t * s_ptr
  * 
  *         assert array1.shape[0] == array2.shape[0]             # <<<<<<<<<<<<<<
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  */
-  __Pyx_TraceLine(1348,0,__PYX_ERR(0, 1348, __pyx_L1_error))
+  __Pyx_TraceLine(1350,0,__PYX_ERR(0, 1350, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!(((__pyx_v_array1->dimensions[0]) == (__pyx_v_array2->dimensions[0])) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 1348, __pyx_L1_error)
+      __PYX_ERR(0, 1350, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1349
+  /* "MACS2/IO/CallPeakUnit.pyx":1351
  * 
  *         assert array1.shape[0] == array2.shape[0]
  *         s = np.zeros(array1.shape[0], dtype="float32")             # <<<<<<<<<<<<<<
  * 
  *         a1_ptr = <float32_t *> array1.data
  */
-  __Pyx_TraceLine(1349,0,__PYX_ERR(0, 1349, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1349, __pyx_L1_error)
+  __Pyx_TraceLine(1351,0,__PYX_ERR(0, 1351, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1351, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1349, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1351, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1349, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1351, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1349, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1351, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1349, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1351, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1349, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1349, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1351, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1351, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1349, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1351, __pyx_L1_error)
   __pyx_t_5 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -19138,116 +19170,116 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_s.diminfo[0].strides = __pyx_pybuffernd_s.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_s.diminfo[0].shape = __pyx_pybuffernd_s.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1349, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1351, __pyx_L1_error)
   }
   __pyx_t_5 = 0;
   __pyx_v_s = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1351
+  /* "MACS2/IO/CallPeakUnit.pyx":1353
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  *         a1_ptr = <float32_t *> array1.data             # <<<<<<<<<<<<<<
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data
  */
-  __Pyx_TraceLine(1351,0,__PYX_ERR(0, 1351, __pyx_L1_error))
+  __Pyx_TraceLine(1353,0,__PYX_ERR(0, 1353, __pyx_L1_error))
   __pyx_v_a1_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array1->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1352
+  /* "MACS2/IO/CallPeakUnit.pyx":1354
  * 
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data             # <<<<<<<<<<<<<<
  *         s_ptr = <float32_t *> s.data
  * 
  */
-  __Pyx_TraceLine(1352,0,__PYX_ERR(0, 1352, __pyx_L1_error))
+  __Pyx_TraceLine(1354,0,__PYX_ERR(0, 1354, __pyx_L1_error))
   __pyx_v_a2_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array2->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1353
+  /* "MACS2/IO/CallPeakUnit.pyx":1355
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data             # <<<<<<<<<<<<<<
  * 
  *         for i in range(array1.shape[0]):
  */
-  __Pyx_TraceLine(1353,0,__PYX_ERR(0, 1353, __pyx_L1_error))
+  __Pyx_TraceLine(1355,0,__PYX_ERR(0, 1355, __pyx_L1_error))
   __pyx_v_s_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_s->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1355
+  /* "MACS2/IO/CallPeakUnit.pyx":1357
  *         s_ptr = <float32_t *> s.data
  * 
  *         for i in range(array1.shape[0]):             # <<<<<<<<<<<<<<
  *             s_ptr[0] = (a1_ptr[0] + self.pseudocount) / ( a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1
  */
-  __Pyx_TraceLine(1355,0,__PYX_ERR(0, 1355, __pyx_L1_error))
+  __Pyx_TraceLine(1357,0,__PYX_ERR(0, 1357, __pyx_L1_error))
   __pyx_t_10 = (__pyx_v_array1->dimensions[0]);
   __pyx_t_11 = __pyx_t_10;
   for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
     __pyx_v_i = __pyx_t_12;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1356
+    /* "MACS2/IO/CallPeakUnit.pyx":1358
  * 
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = (a1_ptr[0] + self.pseudocount) / ( a2_ptr[0] + self.pseudocount )             # <<<<<<<<<<<<<<
  *             s_ptr += 1
  *             a1_ptr += 1
  */
-    __Pyx_TraceLine(1356,0,__PYX_ERR(0, 1356, __pyx_L1_error))
+    __Pyx_TraceLine(1358,0,__PYX_ERR(0, 1358, __pyx_L1_error))
     __pyx_t_13 = ((__pyx_v_a1_ptr[0]) + __pyx_v_self->pseudocount);
     __pyx_t_14 = ((__pyx_v_a2_ptr[0]) + __pyx_v_self->pseudocount);
     if (unlikely(__pyx_t_14 == 0)) {
       PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-      __PYX_ERR(0, 1356, __pyx_L1_error)
+      __PYX_ERR(0, 1358, __pyx_L1_error)
     }
     (__pyx_v_s_ptr[0]) = (__pyx_t_13 / __pyx_t_14);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1357
+    /* "MACS2/IO/CallPeakUnit.pyx":1359
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = (a1_ptr[0] + self.pseudocount) / ( a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1             # <<<<<<<<<<<<<<
  *             a1_ptr += 1
  *             a2_ptr += 1
  */
-    __Pyx_TraceLine(1357,0,__PYX_ERR(0, 1357, __pyx_L1_error))
+    __Pyx_TraceLine(1359,0,__PYX_ERR(0, 1359, __pyx_L1_error))
     __pyx_v_s_ptr = (__pyx_v_s_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1358
+    /* "MACS2/IO/CallPeakUnit.pyx":1360
  *             s_ptr[0] = (a1_ptr[0] + self.pseudocount) / ( a2_ptr[0] + self.pseudocount )
  *             s_ptr += 1
  *             a1_ptr += 1             # <<<<<<<<<<<<<<
  *             a2_ptr += 1
  *         return s
  */
-    __Pyx_TraceLine(1358,0,__PYX_ERR(0, 1358, __pyx_L1_error))
+    __Pyx_TraceLine(1360,0,__PYX_ERR(0, 1360, __pyx_L1_error))
     __pyx_v_a1_ptr = (__pyx_v_a1_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1359
+    /* "MACS2/IO/CallPeakUnit.pyx":1361
  *             s_ptr += 1
  *             a1_ptr += 1
  *             a2_ptr += 1             # <<<<<<<<<<<<<<
  *         return s
  * 
  */
-    __Pyx_TraceLine(1359,0,__PYX_ERR(0, 1359, __pyx_L1_error))
+    __Pyx_TraceLine(1361,0,__PYX_ERR(0, 1361, __pyx_L1_error))
     __pyx_v_a2_ptr = (__pyx_v_a2_ptr + 1);
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1360
+  /* "MACS2/IO/CallPeakUnit.pyx":1362
  *             a1_ptr += 1
  *             a2_ptr += 1
  *         return s             # <<<<<<<<<<<<<<
  * 
  *     cdef np.ndarray __cal_subtraction ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):
  */
-  __Pyx_TraceLine(1360,0,__PYX_ERR(0, 1360, __pyx_L1_error))
+  __Pyx_TraceLine(1362,0,__PYX_ERR(0, 1362, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(((PyObject *)__pyx_v_s));
   __pyx_r = ((PyArrayObject *)__pyx_v_s);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1340
+  /* "MACS2/IO/CallPeakUnit.pyx":1342
  *         return s
  * 
  *     cdef np.ndarray __cal_FE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -19284,7 +19316,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1362
+/* "MACS2/IO/CallPeakUnit.pyx":1364
  *         return s
  * 
  *     cdef np.ndarray __cal_subtraction ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -19320,7 +19352,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   npy_intp __pyx_t_11;
   __pyx_t_5numpy_int64_t __pyx_t_12;
   __Pyx_RefNannySetupContext("__cal_subtraction", 0);
-  __Pyx_TraceCall("__cal_subtraction", __pyx_f[0], 1362, 0, __PYX_ERR(0, 1362, __pyx_L1_error));
+  __Pyx_TraceCall("__cal_subtraction", __pyx_f[0], 1364, 0, __PYX_ERR(0, 1364, __pyx_L1_error));
   __pyx_pybuffer_s.pybuffer.buf = NULL;
   __pyx_pybuffer_s.refcount = 0;
   __pyx_pybuffernd_s.data = NULL;
@@ -19335,61 +19367,61 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   __pyx_pybuffernd_array2.rcbuffer = &__pyx_pybuffer_array2;
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1362, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array1.rcbuffer->pybuffer, (PyObject*)__pyx_v_array1, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1364, __pyx_L1_error)
   }
   __pyx_pybuffernd_array1.diminfo[0].strides = __pyx_pybuffernd_array1.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array1.diminfo[0].shape = __pyx_pybuffernd_array1.rcbuffer->pybuffer.shape[0];
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
-    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1362, __pyx_L1_error)
+    if (unlikely(__Pyx_GetBufferAndValidate(&__pyx_pybuffernd_array2.rcbuffer->pybuffer, (PyObject*)__pyx_v_array2, &__Pyx_TypeInfo_nn___pyx_t_5numpy_float32_t, PyBUF_FORMAT| PyBUF_STRIDES, 1, 0, __pyx_stack) == -1)) __PYX_ERR(0, 1364, __pyx_L1_error)
   }
   __pyx_pybuffernd_array2.diminfo[0].strides = __pyx_pybuffernd_array2.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_array2.diminfo[0].shape = __pyx_pybuffernd_array2.rcbuffer->pybuffer.shape[0];
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1370
+  /* "MACS2/IO/CallPeakUnit.pyx":1372
  *             float32_t * s_ptr
  * 
  *         assert array1.shape[0] == array2.shape[0]             # <<<<<<<<<<<<<<
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  */
-  __Pyx_TraceLine(1370,0,__PYX_ERR(0, 1370, __pyx_L1_error))
+  __Pyx_TraceLine(1372,0,__PYX_ERR(0, 1372, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(!(((__pyx_v_array1->dimensions[0]) == (__pyx_v_array2->dimensions[0])) != 0))) {
       PyErr_SetNone(PyExc_AssertionError);
-      __PYX_ERR(0, 1370, __pyx_L1_error)
+      __PYX_ERR(0, 1372, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1371
+  /* "MACS2/IO/CallPeakUnit.pyx":1373
  * 
  *         assert array1.shape[0] == array2.shape[0]
  *         s = np.zeros(array1.shape[0], dtype="float32")             # <<<<<<<<<<<<<<
  * 
  *         a1_ptr = <float32_t *> array1.data
  */
-  __Pyx_TraceLine(1371,0,__PYX_ERR(0, 1371, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1371, __pyx_L1_error)
+  __Pyx_TraceLine(1373,0,__PYX_ERR(0, 1373, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_1, __pyx_n_s_np); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1373, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1371, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_1, __pyx_n_s_zeros); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1373, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1371, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_array1->dimensions[0])); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1373, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1371, __pyx_L1_error)
+  __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1373, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_GIVEREF(__pyx_t_1);
   PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_1);
   __pyx_t_1 = 0;
-  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1371, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1373, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1371, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1371, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_1, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1373, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_2, __pyx_t_3, __pyx_t_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1373, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1371, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1373, __pyx_L1_error)
   __pyx_t_5 = ((PyArrayObject *)__pyx_t_4);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -19406,110 +19438,110 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_s.diminfo[0].strides = __pyx_pybuffernd_s.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_s.diminfo[0].shape = __pyx_pybuffernd_s.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1371, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1373, __pyx_L1_error)
   }
   __pyx_t_5 = 0;
   __pyx_v_s = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1373
+  /* "MACS2/IO/CallPeakUnit.pyx":1375
  *         s = np.zeros(array1.shape[0], dtype="float32")
  * 
  *         a1_ptr = <float32_t *> array1.data             # <<<<<<<<<<<<<<
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data
  */
-  __Pyx_TraceLine(1373,0,__PYX_ERR(0, 1373, __pyx_L1_error))
+  __Pyx_TraceLine(1375,0,__PYX_ERR(0, 1375, __pyx_L1_error))
   __pyx_v_a1_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array1->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1374
+  /* "MACS2/IO/CallPeakUnit.pyx":1376
  * 
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data             # <<<<<<<<<<<<<<
  *         s_ptr = <float32_t *> s.data
  * 
  */
-  __Pyx_TraceLine(1374,0,__PYX_ERR(0, 1374, __pyx_L1_error))
+  __Pyx_TraceLine(1376,0,__PYX_ERR(0, 1376, __pyx_L1_error))
   __pyx_v_a2_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_array2->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1375
+  /* "MACS2/IO/CallPeakUnit.pyx":1377
  *         a1_ptr = <float32_t *> array1.data
  *         a2_ptr = <float32_t *> array2.data
  *         s_ptr = <float32_t *> s.data             # <<<<<<<<<<<<<<
  * 
  *         for i in range(array1.shape[0]):
  */
-  __Pyx_TraceLine(1375,0,__PYX_ERR(0, 1375, __pyx_L1_error))
+  __Pyx_TraceLine(1377,0,__PYX_ERR(0, 1377, __pyx_L1_error))
   __pyx_v_s_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_s->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1377
+  /* "MACS2/IO/CallPeakUnit.pyx":1379
  *         s_ptr = <float32_t *> s.data
  * 
  *         for i in range(array1.shape[0]):             # <<<<<<<<<<<<<<
  *             s_ptr[0] = a1_ptr[0] - a2_ptr[0]
  *             s_ptr += 1
  */
-  __Pyx_TraceLine(1377,0,__PYX_ERR(0, 1377, __pyx_L1_error))
+  __Pyx_TraceLine(1379,0,__PYX_ERR(0, 1379, __pyx_L1_error))
   __pyx_t_10 = (__pyx_v_array1->dimensions[0]);
   __pyx_t_11 = __pyx_t_10;
   for (__pyx_t_12 = 0; __pyx_t_12 < __pyx_t_11; __pyx_t_12+=1) {
     __pyx_v_i = __pyx_t_12;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1378
+    /* "MACS2/IO/CallPeakUnit.pyx":1380
  * 
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = a1_ptr[0] - a2_ptr[0]             # <<<<<<<<<<<<<<
  *             s_ptr += 1
  *             a1_ptr += 1
  */
-    __Pyx_TraceLine(1378,0,__PYX_ERR(0, 1378, __pyx_L1_error))
+    __Pyx_TraceLine(1380,0,__PYX_ERR(0, 1380, __pyx_L1_error))
     (__pyx_v_s_ptr[0]) = ((__pyx_v_a1_ptr[0]) - (__pyx_v_a2_ptr[0]));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1379
+    /* "MACS2/IO/CallPeakUnit.pyx":1381
  *         for i in range(array1.shape[0]):
  *             s_ptr[0] = a1_ptr[0] - a2_ptr[0]
  *             s_ptr += 1             # <<<<<<<<<<<<<<
  *             a1_ptr += 1
  *             a2_ptr += 1
  */
-    __Pyx_TraceLine(1379,0,__PYX_ERR(0, 1379, __pyx_L1_error))
+    __Pyx_TraceLine(1381,0,__PYX_ERR(0, 1381, __pyx_L1_error))
     __pyx_v_s_ptr = (__pyx_v_s_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1380
+    /* "MACS2/IO/CallPeakUnit.pyx":1382
  *             s_ptr[0] = a1_ptr[0] - a2_ptr[0]
  *             s_ptr += 1
  *             a1_ptr += 1             # <<<<<<<<<<<<<<
  *             a2_ptr += 1
  *         return s
  */
-    __Pyx_TraceLine(1380,0,__PYX_ERR(0, 1380, __pyx_L1_error))
+    __Pyx_TraceLine(1382,0,__PYX_ERR(0, 1382, __pyx_L1_error))
     __pyx_v_a1_ptr = (__pyx_v_a1_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1381
+    /* "MACS2/IO/CallPeakUnit.pyx":1383
  *             s_ptr += 1
  *             a1_ptr += 1
  *             a2_ptr += 1             # <<<<<<<<<<<<<<
  *         return s
  * 
  */
-    __Pyx_TraceLine(1381,0,__PYX_ERR(0, 1381, __pyx_L1_error))
+    __Pyx_TraceLine(1383,0,__PYX_ERR(0, 1383, __pyx_L1_error))
     __pyx_v_a2_ptr = (__pyx_v_a2_ptr + 1);
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1382
+  /* "MACS2/IO/CallPeakUnit.pyx":1384
  *             a1_ptr += 1
  *             a2_ptr += 1
  *         return s             # <<<<<<<<<<<<<<
  * 
  * 
  */
-  __Pyx_TraceLine(1382,0,__PYX_ERR(0, 1382, __pyx_L1_error))
+  __Pyx_TraceLine(1384,0,__PYX_ERR(0, 1384, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(((PyObject *)__pyx_v_s));
   __pyx_r = ((PyArrayObject *)__pyx_v_s);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1362
+  /* "MACS2/IO/CallPeakUnit.pyx":1364
  *         return s
  * 
  *     cdef np.ndarray __cal_subtraction ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
@@ -19546,7 +19578,7 @@ static PyArrayObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments__
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1385
+/* "MACS2/IO/CallPeakUnit.pyx":1387
  * 
  * 
  *     cdef bool __write_bedGraph_for_a_chromosome ( self, bytes chrom ):             # <<<<<<<<<<<<<<
@@ -19600,7 +19632,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   __pyx_t_5numpy_int32_t __pyx_t_16;
   char *__pyx_t_17;
   __Pyx_RefNannySetupContext("__write_bedGraph_for_a_chromosome", 0);
-  __Pyx_TraceCall("__write_bedGraph_for_a_chromosome", __pyx_f[0], 1385, 0, __PYX_ERR(0, 1385, __pyx_L1_error));
+  __Pyx_TraceCall("__write_bedGraph_for_a_chromosome", __pyx_f[0], 1387, 0, __PYX_ERR(0, 1387, __pyx_L1_error));
   __pyx_pybuffer_pos_array.pybuffer.buf = NULL;
   __pyx_pybuffer_pos_array.refcount = 0;
   __pyx_pybuffernd_pos_array.data = NULL;
@@ -19614,14 +19646,14 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   __pyx_pybuffernd_ctrl_array.data = NULL;
   __pyx_pybuffernd_ctrl_array.rcbuffer = &__pyx_pybuffer_ctrl_array;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1404
+  /* "MACS2/IO/CallPeakUnit.pyx":1406
  *             basestring tmp_bytes
  * 
  *         [pos_array, treat_array, ctrl_array] = self.chr_pos_treat_ctrl             # <<<<<<<<<<<<<<
  *         pos_array_ptr = <int32_t *> pos_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  */
-  __Pyx_TraceLine(1404,0,__PYX_ERR(0, 1404, __pyx_L1_error))
+  __Pyx_TraceLine(1406,0,__PYX_ERR(0, 1406, __pyx_L1_error))
   __pyx_t_1 = __pyx_v_self->chr_pos_treat_ctrl;
   __Pyx_INCREF(__pyx_t_1);
   if (likely(__pyx_t_1 != Py_None)) {
@@ -19630,7 +19662,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     if (unlikely(size != 3)) {
       if (size > 3) __Pyx_RaiseTooManyValuesError(3);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 1404, __pyx_L1_error)
+      __PYX_ERR(0, 1406, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     __pyx_t_2 = PyList_GET_ITEM(sequence, 0); 
@@ -19640,20 +19672,20 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __Pyx_INCREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_t_4);
     #else
-    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1404, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1406, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1404, __pyx_L1_error)
+    __pyx_t_3 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1406, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_4 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1404, __pyx_L1_error)
+    __pyx_t_4 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1406, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
     #endif
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   } else {
-    __Pyx_RaiseNoneNotIterableError(); __PYX_ERR(0, 1404, __pyx_L1_error)
+    __Pyx_RaiseNoneNotIterableError(); __PYX_ERR(0, 1406, __pyx_L1_error)
   }
-  if (!(likely(((__pyx_t_2) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_2, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1404, __pyx_L1_error)
-  if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1404, __pyx_L1_error)
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1404, __pyx_L1_error)
+  if (!(likely(((__pyx_t_2) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_2, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1406, __pyx_L1_error)
+  if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1406, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1406, __pyx_L1_error)
   __pyx_t_5 = ((PyArrayObject *)__pyx_t_2);
   {
     __Pyx_BufFmt_StackElem __pyx_stack[1];
@@ -19670,7 +19702,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_pos_array.diminfo[0].strides = __pyx_pybuffernd_pos_array.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_pos_array.diminfo[0].shape = __pyx_pybuffernd_pos_array.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1404, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1406, __pyx_L1_error)
   }
   __pyx_t_5 = 0;
   __pyx_v_pos_array = ((PyArrayObject *)__pyx_t_2);
@@ -19691,7 +19723,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_9 = __pyx_t_8 = __pyx_t_7 = 0;
     }
     __pyx_pybuffernd_treat_array.diminfo[0].strides = __pyx_pybuffernd_treat_array.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_treat_array.diminfo[0].shape = __pyx_pybuffernd_treat_array.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1404, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1406, __pyx_L1_error)
   }
   __pyx_t_10 = 0;
   __pyx_v_treat_array = ((PyArrayObject *)__pyx_t_3);
@@ -19712,82 +19744,82 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_t_7 = __pyx_t_8 = __pyx_t_9 = 0;
     }
     __pyx_pybuffernd_ctrl_array.diminfo[0].strides = __pyx_pybuffernd_ctrl_array.rcbuffer->pybuffer.strides[0]; __pyx_pybuffernd_ctrl_array.diminfo[0].shape = __pyx_pybuffernd_ctrl_array.rcbuffer->pybuffer.shape[0];
-    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1404, __pyx_L1_error)
+    if (unlikely(__pyx_t_6 < 0)) __PYX_ERR(0, 1406, __pyx_L1_error)
   }
   __pyx_t_10 = 0;
   __pyx_v_ctrl_array = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1405
+  /* "MACS2/IO/CallPeakUnit.pyx":1407
  * 
  *         [pos_array, treat_array, ctrl_array] = self.chr_pos_treat_ctrl
  *         pos_array_ptr = <int32_t *> pos_array.data             # <<<<<<<<<<<<<<
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  */
-  __Pyx_TraceLine(1405,0,__PYX_ERR(0, 1405, __pyx_L1_error))
+  __Pyx_TraceLine(1407,0,__PYX_ERR(0, 1407, __pyx_L1_error))
   __pyx_v_pos_array_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_pos_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1406
+  /* "MACS2/IO/CallPeakUnit.pyx":1408
  *         [pos_array, treat_array, ctrl_array] = self.chr_pos_treat_ctrl
  *         pos_array_ptr = <int32_t *> pos_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data             # <<<<<<<<<<<<<<
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  */
-  __Pyx_TraceLine(1406,0,__PYX_ERR(0, 1406, __pyx_L1_error))
+  __Pyx_TraceLine(1408,0,__PYX_ERR(0, 1408, __pyx_L1_error))
   __pyx_v_treat_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_treat_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1407
+  /* "MACS2/IO/CallPeakUnit.pyx":1409
  *         pos_array_ptr = <int32_t *> pos_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data             # <<<<<<<<<<<<<<
  * 
  *         if self.save_SPMR:
  */
-  __Pyx_TraceLine(1407,0,__PYX_ERR(0, 1407, __pyx_L1_error))
+  __Pyx_TraceLine(1409,0,__PYX_ERR(0, 1409, __pyx_L1_error))
   __pyx_v_ctrl_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_ctrl_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1409
+  /* "MACS2/IO/CallPeakUnit.pyx":1411
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  *         if self.save_SPMR:             # <<<<<<<<<<<<<<
  *             if self.treat_scaling_factor == 1:
  *                 # in this case, control has been asked to be scaled to depth of treatment
  */
-  __Pyx_TraceLine(1409,0,__PYX_ERR(0, 1409, __pyx_L1_error))
-  __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_SPMR)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1409, __pyx_L1_error)
+  __Pyx_TraceLine(1411,0,__PYX_ERR(0, 1411, __pyx_L1_error))
+  __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_SPMR)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1411, __pyx_L1_error)
   if (__pyx_t_11) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1410
+    /* "MACS2/IO/CallPeakUnit.pyx":1412
  * 
  *         if self.save_SPMR:
  *             if self.treat_scaling_factor == 1:             # <<<<<<<<<<<<<<
  *                 # in this case, control has been asked to be scaled to depth of treatment
  *                 denominator  = self.treat.total/1e6
  */
-    __Pyx_TraceLine(1410,0,__PYX_ERR(0, 1410, __pyx_L1_error))
+    __Pyx_TraceLine(1412,0,__PYX_ERR(0, 1412, __pyx_L1_error))
     __pyx_t_11 = ((__pyx_v_self->treat_scaling_factor == 1.0) != 0);
     if (__pyx_t_11) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1412
+      /* "MACS2/IO/CallPeakUnit.pyx":1414
  *             if self.treat_scaling_factor == 1:
  *                 # in this case, control has been asked to be scaled to depth of treatment
  *                 denominator  = self.treat.total/1e6             # <<<<<<<<<<<<<<
  *             else:
  *                 # in this case, treatment has been asked to be scaled to depth of control
  */
-      __Pyx_TraceLine(1412,0,__PYX_ERR(0, 1412, __pyx_L1_error))
-      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_total); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1412, __pyx_L1_error)
+      __Pyx_TraceLine(1414,0,__PYX_ERR(0, 1414, __pyx_L1_error))
+      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_total); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1414, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_4 = __Pyx_PyFloat_TrueDivideObjC(__pyx_t_1, __pyx_float_1e6, 1e6, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1412, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyFloat_TrueDivideObjC(__pyx_t_1, __pyx_float_1e6, 1e6, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1414, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-      __pyx_t_12 = __pyx_PyFloat_AsFloat(__pyx_t_4); if (unlikely((__pyx_t_12 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1412, __pyx_L1_error)
+      __pyx_t_12 = __pyx_PyFloat_AsFloat(__pyx_t_4); if (unlikely((__pyx_t_12 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1414, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
       __pyx_v_denominator = __pyx_t_12;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1410
+      /* "MACS2/IO/CallPeakUnit.pyx":1412
  * 
  *         if self.save_SPMR:
  *             if self.treat_scaling_factor == 1:             # <<<<<<<<<<<<<<
@@ -19797,27 +19829,27 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       goto __pyx_L4;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1415
+    /* "MACS2/IO/CallPeakUnit.pyx":1417
  *             else:
  *                 # in this case, treatment has been asked to be scaled to depth of control
  *                 denominator  = self.ctrl.total/1e6             # <<<<<<<<<<<<<<
  *         else:
  *             denominator = 1.0
  */
-    __Pyx_TraceLine(1415,0,__PYX_ERR(0, 1415, __pyx_L1_error))
+    __Pyx_TraceLine(1417,0,__PYX_ERR(0, 1417, __pyx_L1_error))
     /*else*/ {
-      __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->ctrl, __pyx_n_s_total); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1415, __pyx_L1_error)
+      __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->ctrl, __pyx_n_s_total); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1417, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
-      __pyx_t_1 = __Pyx_PyFloat_TrueDivideObjC(__pyx_t_4, __pyx_float_1e6, 1e6, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1415, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyFloat_TrueDivideObjC(__pyx_t_4, __pyx_float_1e6, 1e6, 0, 0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1417, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-      __pyx_t_12 = __pyx_PyFloat_AsFloat(__pyx_t_1); if (unlikely((__pyx_t_12 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1415, __pyx_L1_error)
+      __pyx_t_12 = __pyx_PyFloat_AsFloat(__pyx_t_1); if (unlikely((__pyx_t_12 == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1417, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_v_denominator = __pyx_t_12;
     }
     __pyx_L4:;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1409
+    /* "MACS2/IO/CallPeakUnit.pyx":1411
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  *         if self.save_SPMR:             # <<<<<<<<<<<<<<
@@ -19827,54 +19859,54 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     goto __pyx_L3;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1417
+  /* "MACS2/IO/CallPeakUnit.pyx":1419
  *                 denominator  = self.ctrl.total/1e6
  *         else:
  *             denominator = 1.0             # <<<<<<<<<<<<<<
  * 
  *         l = pos_array.shape[ 0 ]
  */
-  __Pyx_TraceLine(1417,0,__PYX_ERR(0, 1417, __pyx_L1_error))
+  __Pyx_TraceLine(1419,0,__PYX_ERR(0, 1419, __pyx_L1_error))
   /*else*/ {
     __pyx_v_denominator = 1.0;
   }
   __pyx_L3:;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1419
+  /* "MACS2/IO/CallPeakUnit.pyx":1421
  *             denominator = 1.0
  * 
  *         l = pos_array.shape[ 0 ]             # <<<<<<<<<<<<<<
  * 
  *         if l == 0:              # if there is no data, return
  */
-  __Pyx_TraceLine(1419,0,__PYX_ERR(0, 1419, __pyx_L1_error))
+  __Pyx_TraceLine(1421,0,__PYX_ERR(0, 1421, __pyx_L1_error))
   __pyx_v_l = (__pyx_v_pos_array->dimensions[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1421
+  /* "MACS2/IO/CallPeakUnit.pyx":1423
  *         l = pos_array.shape[ 0 ]
  * 
  *         if l == 0:              # if there is no data, return             # <<<<<<<<<<<<<<
  *             return False
  * 
  */
-  __Pyx_TraceLine(1421,0,__PYX_ERR(0, 1421, __pyx_L1_error))
+  __Pyx_TraceLine(1423,0,__PYX_ERR(0, 1423, __pyx_L1_error))
   __pyx_t_11 = ((__pyx_v_l == 0) != 0);
   if (__pyx_t_11) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1422
+    /* "MACS2/IO/CallPeakUnit.pyx":1424
  * 
  *         if l == 0:              # if there is no data, return
  *             return False             # <<<<<<<<<<<<<<
  * 
  *         ft = self.bedGraph_treat_f
  */
-    __Pyx_TraceLine(1422,0,__PYX_ERR(0, 1422, __pyx_L1_error))
+    __Pyx_TraceLine(1424,0,__PYX_ERR(0, 1424, __pyx_L1_error))
     __Pyx_XDECREF(((PyObject *)__pyx_r));
     __Pyx_INCREF(Py_False);
     __pyx_r = ((PyBoolObject *)Py_False);
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1421
+    /* "MACS2/IO/CallPeakUnit.pyx":1423
  *         l = pos_array.shape[ 0 ]
  * 
  *         if l == 0:              # if there is no data, return             # <<<<<<<<<<<<<<
@@ -19883,224 +19915,224 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1424
+  /* "MACS2/IO/CallPeakUnit.pyx":1426
  *             return False
  * 
  *         ft = self.bedGraph_treat_f             # <<<<<<<<<<<<<<
  *         fc = self.bedGraph_ctrl_f
  *         #t_write_func = self.bedGraph_treat.write
  */
-  __Pyx_TraceLine(1424,0,__PYX_ERR(0, 1424, __pyx_L1_error))
+  __Pyx_TraceLine(1426,0,__PYX_ERR(0, 1426, __pyx_L1_error))
   __pyx_t_13 = __pyx_v_self->bedGraph_treat_f;
   __pyx_v_ft = __pyx_t_13;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1425
+  /* "MACS2/IO/CallPeakUnit.pyx":1427
  * 
  *         ft = self.bedGraph_treat_f
  *         fc = self.bedGraph_ctrl_f             # <<<<<<<<<<<<<<
  *         #t_write_func = self.bedGraph_treat.write
  *         #c_write_func = self.bedGraph_ctrl.write
  */
-  __Pyx_TraceLine(1425,0,__PYX_ERR(0, 1425, __pyx_L1_error))
+  __Pyx_TraceLine(1427,0,__PYX_ERR(0, 1427, __pyx_L1_error))
   __pyx_t_13 = __pyx_v_self->bedGraph_ctrl_f;
   __pyx_v_fc = __pyx_t_13;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1429
+  /* "MACS2/IO/CallPeakUnit.pyx":1431
  *         #c_write_func = self.bedGraph_ctrl.write
  * 
  *         pre_p_t = 0             # <<<<<<<<<<<<<<
  *         pre_p_c = 0
  *         pre_v_t = treat_array_ptr[ 0 ]/denominator
  */
-  __Pyx_TraceLine(1429,0,__PYX_ERR(0, 1429, __pyx_L1_error))
+  __Pyx_TraceLine(1431,0,__PYX_ERR(0, 1431, __pyx_L1_error))
   __pyx_v_pre_p_t = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1430
+  /* "MACS2/IO/CallPeakUnit.pyx":1432
  * 
  *         pre_p_t = 0
  *         pre_p_c = 0             # <<<<<<<<<<<<<<
  *         pre_v_t = treat_array_ptr[ 0 ]/denominator
  *         pre_v_c = ctrl_array_ptr [ 0 ]/denominator
  */
-  __Pyx_TraceLine(1430,0,__PYX_ERR(0, 1430, __pyx_L1_error))
+  __Pyx_TraceLine(1432,0,__PYX_ERR(0, 1432, __pyx_L1_error))
   __pyx_v_pre_p_c = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1431
+  /* "MACS2/IO/CallPeakUnit.pyx":1433
  *         pre_p_t = 0
  *         pre_p_c = 0
  *         pre_v_t = treat_array_ptr[ 0 ]/denominator             # <<<<<<<<<<<<<<
  *         pre_v_c = ctrl_array_ptr [ 0 ]/denominator
  *         treat_array_ptr += 1
  */
-  __Pyx_TraceLine(1431,0,__PYX_ERR(0, 1431, __pyx_L1_error))
+  __Pyx_TraceLine(1433,0,__PYX_ERR(0, 1433, __pyx_L1_error))
   if (unlikely(__pyx_v_denominator == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-    __PYX_ERR(0, 1431, __pyx_L1_error)
+    __PYX_ERR(0, 1433, __pyx_L1_error)
   }
   __pyx_v_pre_v_t = ((__pyx_v_treat_array_ptr[0]) / __pyx_v_denominator);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1432
+  /* "MACS2/IO/CallPeakUnit.pyx":1434
  *         pre_p_c = 0
  *         pre_v_t = treat_array_ptr[ 0 ]/denominator
  *         pre_v_c = ctrl_array_ptr [ 0 ]/denominator             # <<<<<<<<<<<<<<
  *         treat_array_ptr += 1
  *         ctrl_array_ptr += 1
  */
-  __Pyx_TraceLine(1432,0,__PYX_ERR(0, 1432, __pyx_L1_error))
+  __Pyx_TraceLine(1434,0,__PYX_ERR(0, 1434, __pyx_L1_error))
   if (unlikely(__pyx_v_denominator == 0)) {
     PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-    __PYX_ERR(0, 1432, __pyx_L1_error)
+    __PYX_ERR(0, 1434, __pyx_L1_error)
   }
   __pyx_v_pre_v_c = ((__pyx_v_ctrl_array_ptr[0]) / __pyx_v_denominator);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1433
+  /* "MACS2/IO/CallPeakUnit.pyx":1435
  *         pre_v_t = treat_array_ptr[ 0 ]/denominator
  *         pre_v_c = ctrl_array_ptr [ 0 ]/denominator
  *         treat_array_ptr += 1             # <<<<<<<<<<<<<<
  *         ctrl_array_ptr += 1
  * 
  */
-  __Pyx_TraceLine(1433,0,__PYX_ERR(0, 1433, __pyx_L1_error))
+  __Pyx_TraceLine(1435,0,__PYX_ERR(0, 1435, __pyx_L1_error))
   __pyx_v_treat_array_ptr = (__pyx_v_treat_array_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1434
+  /* "MACS2/IO/CallPeakUnit.pyx":1436
  *         pre_v_c = ctrl_array_ptr [ 0 ]/denominator
  *         treat_array_ptr += 1
  *         ctrl_array_ptr += 1             # <<<<<<<<<<<<<<
  * 
  *         for i in range( 1, l ):
  */
-  __Pyx_TraceLine(1434,0,__PYX_ERR(0, 1434, __pyx_L1_error))
+  __Pyx_TraceLine(1436,0,__PYX_ERR(0, 1436, __pyx_L1_error))
   __pyx_v_ctrl_array_ptr = (__pyx_v_ctrl_array_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1436
+  /* "MACS2/IO/CallPeakUnit.pyx":1438
  *         ctrl_array_ptr += 1
  * 
  *         for i in range( 1, l ):             # <<<<<<<<<<<<<<
  *             v_t = treat_array_ptr[ 0 ]/denominator
  *             v_c = ctrl_array_ptr [ 0 ]/denominator
  */
-  __Pyx_TraceLine(1436,0,__PYX_ERR(0, 1436, __pyx_L1_error))
+  __Pyx_TraceLine(1438,0,__PYX_ERR(0, 1438, __pyx_L1_error))
   __pyx_t_14 = __pyx_v_l;
   __pyx_t_15 = __pyx_t_14;
   for (__pyx_t_16 = 1; __pyx_t_16 < __pyx_t_15; __pyx_t_16+=1) {
     __pyx_v_i = __pyx_t_16;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1437
+    /* "MACS2/IO/CallPeakUnit.pyx":1439
  * 
  *         for i in range( 1, l ):
  *             v_t = treat_array_ptr[ 0 ]/denominator             # <<<<<<<<<<<<<<
  *             v_c = ctrl_array_ptr [ 0 ]/denominator
  *             p   = pos_array_ptr  [ 0 ]
  */
-    __Pyx_TraceLine(1437,0,__PYX_ERR(0, 1437, __pyx_L1_error))
+    __Pyx_TraceLine(1439,0,__PYX_ERR(0, 1439, __pyx_L1_error))
     if (unlikely(__pyx_v_denominator == 0)) {
       PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-      __PYX_ERR(0, 1437, __pyx_L1_error)
+      __PYX_ERR(0, 1439, __pyx_L1_error)
     }
     __pyx_v_v_t = ((__pyx_v_treat_array_ptr[0]) / __pyx_v_denominator);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1438
+    /* "MACS2/IO/CallPeakUnit.pyx":1440
  *         for i in range( 1, l ):
  *             v_t = treat_array_ptr[ 0 ]/denominator
  *             v_c = ctrl_array_ptr [ 0 ]/denominator             # <<<<<<<<<<<<<<
  *             p   = pos_array_ptr  [ 0 ]
  *             pos_array_ptr += 1
  */
-    __Pyx_TraceLine(1438,0,__PYX_ERR(0, 1438, __pyx_L1_error))
+    __Pyx_TraceLine(1440,0,__PYX_ERR(0, 1440, __pyx_L1_error))
     if (unlikely(__pyx_v_denominator == 0)) {
       PyErr_SetString(PyExc_ZeroDivisionError, "float division");
-      __PYX_ERR(0, 1438, __pyx_L1_error)
+      __PYX_ERR(0, 1440, __pyx_L1_error)
     }
     __pyx_v_v_c = ((__pyx_v_ctrl_array_ptr[0]) / __pyx_v_denominator);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1439
+    /* "MACS2/IO/CallPeakUnit.pyx":1441
  *             v_t = treat_array_ptr[ 0 ]/denominator
  *             v_c = ctrl_array_ptr [ 0 ]/denominator
  *             p   = pos_array_ptr  [ 0 ]             # <<<<<<<<<<<<<<
  *             pos_array_ptr += 1
  *             treat_array_ptr += 1
  */
-    __Pyx_TraceLine(1439,0,__PYX_ERR(0, 1439, __pyx_L1_error))
+    __Pyx_TraceLine(1441,0,__PYX_ERR(0, 1441, __pyx_L1_error))
     __pyx_v_p = (__pyx_v_pos_array_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1440
+    /* "MACS2/IO/CallPeakUnit.pyx":1442
  *             v_c = ctrl_array_ptr [ 0 ]/denominator
  *             p   = pos_array_ptr  [ 0 ]
  *             pos_array_ptr += 1             # <<<<<<<<<<<<<<
  *             treat_array_ptr += 1
  *             ctrl_array_ptr += 1
  */
-    __Pyx_TraceLine(1440,0,__PYX_ERR(0, 1440, __pyx_L1_error))
+    __Pyx_TraceLine(1442,0,__PYX_ERR(0, 1442, __pyx_L1_error))
     __pyx_v_pos_array_ptr = (__pyx_v_pos_array_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1441
+    /* "MACS2/IO/CallPeakUnit.pyx":1443
  *             p   = pos_array_ptr  [ 0 ]
  *             pos_array_ptr += 1
  *             treat_array_ptr += 1             # <<<<<<<<<<<<<<
  *             ctrl_array_ptr += 1
  * 
  */
-    __Pyx_TraceLine(1441,0,__PYX_ERR(0, 1441, __pyx_L1_error))
+    __Pyx_TraceLine(1443,0,__PYX_ERR(0, 1443, __pyx_L1_error))
     __pyx_v_treat_array_ptr = (__pyx_v_treat_array_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1442
+    /* "MACS2/IO/CallPeakUnit.pyx":1444
  *             pos_array_ptr += 1
  *             treat_array_ptr += 1
  *             ctrl_array_ptr += 1             # <<<<<<<<<<<<<<
  * 
  *             if abs(pre_v_t - v_t) > 1e-5: # precision is 5 digits
  */
-    __Pyx_TraceLine(1442,0,__PYX_ERR(0, 1442, __pyx_L1_error))
+    __Pyx_TraceLine(1444,0,__PYX_ERR(0, 1444, __pyx_L1_error))
     __pyx_v_ctrl_array_ptr = (__pyx_v_ctrl_array_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1444
+    /* "MACS2/IO/CallPeakUnit.pyx":1446
  *             ctrl_array_ptr += 1
  * 
  *             if abs(pre_v_t - v_t) > 1e-5: # precision is 5 digits             # <<<<<<<<<<<<<<
  *                 fprintf( ft, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_t, p, pre_v_t )
  *                 pre_v_t = v_t
  */
-    __Pyx_TraceLine(1444,0,__PYX_ERR(0, 1444, __pyx_L1_error))
+    __Pyx_TraceLine(1446,0,__PYX_ERR(0, 1446, __pyx_L1_error))
     __pyx_t_11 = ((fabsf((__pyx_v_pre_v_t - __pyx_v_v_t)) > 1e-5) != 0);
     if (__pyx_t_11) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1445
+      /* "MACS2/IO/CallPeakUnit.pyx":1447
  * 
  *             if abs(pre_v_t - v_t) > 1e-5: # precision is 5 digits
  *                 fprintf( ft, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_t, p, pre_v_t )             # <<<<<<<<<<<<<<
  *                 pre_v_t = v_t
  *                 pre_p_t = p
  */
-      __Pyx_TraceLine(1445,0,__PYX_ERR(0, 1445, __pyx_L1_error))
+      __Pyx_TraceLine(1447,0,__PYX_ERR(0, 1447, __pyx_L1_error))
       if (unlikely(__pyx_v_chrom == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-        __PYX_ERR(0, 1445, __pyx_L1_error)
+        __PYX_ERR(0, 1447, __pyx_L1_error)
       }
-      __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1445, __pyx_L1_error)
+      __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1447, __pyx_L1_error)
       (void)(fprintf(__pyx_v_ft, ((char const *)"%s\t%d\t%d\t%.5f\n"), __pyx_t_17, __pyx_v_pre_p_t, __pyx_v_p, __pyx_v_pre_v_t));
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1446
+      /* "MACS2/IO/CallPeakUnit.pyx":1448
  *             if abs(pre_v_t - v_t) > 1e-5: # precision is 5 digits
  *                 fprintf( ft, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_t, p, pre_v_t )
  *                 pre_v_t = v_t             # <<<<<<<<<<<<<<
  *                 pre_p_t = p
  * 
  */
-      __Pyx_TraceLine(1446,0,__PYX_ERR(0, 1446, __pyx_L1_error))
+      __Pyx_TraceLine(1448,0,__PYX_ERR(0, 1448, __pyx_L1_error))
       __pyx_v_pre_v_t = __pyx_v_v_t;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1447
+      /* "MACS2/IO/CallPeakUnit.pyx":1449
  *                 fprintf( ft, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_t, p, pre_v_t )
  *                 pre_v_t = v_t
  *                 pre_p_t = p             # <<<<<<<<<<<<<<
  * 
  *             if abs(pre_v_c - v_c) > 1e-5: # precision is 5 digits
  */
-      __Pyx_TraceLine(1447,0,__PYX_ERR(0, 1447, __pyx_L1_error))
+      __Pyx_TraceLine(1449,0,__PYX_ERR(0, 1449, __pyx_L1_error))
       __pyx_v_pre_p_t = __pyx_v_p;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1444
+      /* "MACS2/IO/CallPeakUnit.pyx":1446
  *             ctrl_array_ptr += 1
  * 
  *             if abs(pre_v_t - v_t) > 1e-5: # precision is 5 digits             # <<<<<<<<<<<<<<
@@ -20109,53 +20141,53 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
  */
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1449
+    /* "MACS2/IO/CallPeakUnit.pyx":1451
  *                 pre_p_t = p
  * 
  *             if abs(pre_v_c - v_c) > 1e-5: # precision is 5 digits             # <<<<<<<<<<<<<<
  *                 fprintf( fc, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_c, p, pre_v_c )
  *                 pre_v_c = v_c
  */
-    __Pyx_TraceLine(1449,0,__PYX_ERR(0, 1449, __pyx_L1_error))
+    __Pyx_TraceLine(1451,0,__PYX_ERR(0, 1451, __pyx_L1_error))
     __pyx_t_11 = ((fabsf((__pyx_v_pre_v_c - __pyx_v_v_c)) > 1e-5) != 0);
     if (__pyx_t_11) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1450
+      /* "MACS2/IO/CallPeakUnit.pyx":1452
  * 
  *             if abs(pre_v_c - v_c) > 1e-5: # precision is 5 digits
  *                 fprintf( fc, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_c, p, pre_v_c )             # <<<<<<<<<<<<<<
  *                 pre_v_c = v_c
  *                 pre_p_c = p
  */
-      __Pyx_TraceLine(1450,0,__PYX_ERR(0, 1450, __pyx_L1_error))
+      __Pyx_TraceLine(1452,0,__PYX_ERR(0, 1452, __pyx_L1_error))
       if (unlikely(__pyx_v_chrom == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-        __PYX_ERR(0, 1450, __pyx_L1_error)
+        __PYX_ERR(0, 1452, __pyx_L1_error)
       }
-      __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1450, __pyx_L1_error)
+      __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1452, __pyx_L1_error)
       (void)(fprintf(__pyx_v_fc, ((char const *)"%s\t%d\t%d\t%.5f\n"), __pyx_t_17, __pyx_v_pre_p_c, __pyx_v_p, __pyx_v_pre_v_c));
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1451
+      /* "MACS2/IO/CallPeakUnit.pyx":1453
  *             if abs(pre_v_c - v_c) > 1e-5: # precision is 5 digits
  *                 fprintf( fc, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_c, p, pre_v_c )
  *                 pre_v_c = v_c             # <<<<<<<<<<<<<<
  *                 pre_p_c = p
  * 
  */
-      __Pyx_TraceLine(1451,0,__PYX_ERR(0, 1451, __pyx_L1_error))
+      __Pyx_TraceLine(1453,0,__PYX_ERR(0, 1453, __pyx_L1_error))
       __pyx_v_pre_v_c = __pyx_v_v_c;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1452
+      /* "MACS2/IO/CallPeakUnit.pyx":1454
  *                 fprintf( fc, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_c, p, pre_v_c )
  *                 pre_v_c = v_c
  *                 pre_p_c = p             # <<<<<<<<<<<<<<
  * 
  *         p = pos_array_ptr[ 0 ]
  */
-      __Pyx_TraceLine(1452,0,__PYX_ERR(0, 1452, __pyx_L1_error))
+      __Pyx_TraceLine(1454,0,__PYX_ERR(0, 1454, __pyx_L1_error))
       __pyx_v_pre_p_c = __pyx_v_p;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1449
+      /* "MACS2/IO/CallPeakUnit.pyx":1451
  *                 pre_p_t = p
  * 
  *             if abs(pre_v_c - v_c) > 1e-5: # precision is 5 digits             # <<<<<<<<<<<<<<
@@ -20165,60 +20197,60 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     }
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1454
+  /* "MACS2/IO/CallPeakUnit.pyx":1456
  *                 pre_p_c = p
  * 
  *         p = pos_array_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         # last one
  *         fprintf( ft, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_t, p, pre_v_t )
  */
-  __Pyx_TraceLine(1454,0,__PYX_ERR(0, 1454, __pyx_L1_error))
+  __Pyx_TraceLine(1456,0,__PYX_ERR(0, 1456, __pyx_L1_error))
   __pyx_v_p = (__pyx_v_pos_array_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1456
+  /* "MACS2/IO/CallPeakUnit.pyx":1458
  *         p = pos_array_ptr[ 0 ]
  *         # last one
  *         fprintf( ft, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_t, p, pre_v_t )             # <<<<<<<<<<<<<<
  *         fprintf( fc, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_c, p, pre_v_c )
  * 
  */
-  __Pyx_TraceLine(1456,0,__PYX_ERR(0, 1456, __pyx_L1_error))
+  __Pyx_TraceLine(1458,0,__PYX_ERR(0, 1458, __pyx_L1_error))
   if (unlikely(__pyx_v_chrom == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 1456, __pyx_L1_error)
+    __PYX_ERR(0, 1458, __pyx_L1_error)
   }
-  __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1456, __pyx_L1_error)
+  __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1458, __pyx_L1_error)
   (void)(fprintf(__pyx_v_ft, ((char const *)"%s\t%d\t%d\t%.5f\n"), __pyx_t_17, __pyx_v_pre_p_t, __pyx_v_p, __pyx_v_pre_v_t));
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1457
+  /* "MACS2/IO/CallPeakUnit.pyx":1459
  *         # last one
  *         fprintf( ft, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_t, p, pre_v_t )
  *         fprintf( fc, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_c, p, pre_v_c )             # <<<<<<<<<<<<<<
  * 
  *         return True
  */
-  __Pyx_TraceLine(1457,0,__PYX_ERR(0, 1457, __pyx_L1_error))
+  __Pyx_TraceLine(1459,0,__PYX_ERR(0, 1459, __pyx_L1_error))
   if (unlikely(__pyx_v_chrom == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-    __PYX_ERR(0, 1457, __pyx_L1_error)
+    __PYX_ERR(0, 1459, __pyx_L1_error)
   }
-  __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1457, __pyx_L1_error)
+  __pyx_t_17 = __Pyx_PyBytes_AsWritableString(__pyx_v_chrom); if (unlikely((!__pyx_t_17) && PyErr_Occurred())) __PYX_ERR(0, 1459, __pyx_L1_error)
   (void)(fprintf(__pyx_v_fc, ((char const *)"%s\t%d\t%d\t%.5f\n"), __pyx_t_17, __pyx_v_pre_p_c, __pyx_v_p, __pyx_v_pre_v_c));
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1459
+  /* "MACS2/IO/CallPeakUnit.pyx":1461
  *         fprintf( fc, b"%s\t%d\t%d\t%.5f\n", chrom, pre_p_c, p, pre_v_c )
  * 
  *         return True             # <<<<<<<<<<<<<<
  * 
  *     cpdef call_broadpeaks (self, list scoring_function_symbols, list lvl1_cutoff_s, list lvl2_cutoff_s, int32_t min_length=200, int32_t lvl1_max_gap=50, int32_t lvl2_max_gap=400, bool cutoff_analysis = False):
  */
-  __Pyx_TraceLine(1459,0,__PYX_ERR(0, 1459, __pyx_L1_error))
+  __Pyx_TraceLine(1461,0,__PYX_ERR(0, 1461, __pyx_L1_error))
   __Pyx_XDECREF(((PyObject *)__pyx_r));
   __Pyx_INCREF(Py_True);
   __pyx_r = ((PyBoolObject *)Py_True);
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1385
+  /* "MACS2/IO/CallPeakUnit.pyx":1387
  * 
  * 
  *     cdef bool __write_bedGraph_for_a_chromosome ( self, bytes chrom ):             # <<<<<<<<<<<<<<
@@ -20257,7 +20289,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1461
+/* "MACS2/IO/CallPeakUnit.pyx":1463
  *         return True
  * 
  *     cpdef call_broadpeaks (self, list scoring_function_symbols, list lvl1_cutoff_s, list lvl2_cutoff_s, int32_t min_length=200, int32_t lvl1_max_gap=50, int32_t lvl2_max_gap=400, bool cutoff_analysis = False):             # <<<<<<<<<<<<<<
@@ -20313,7 +20345,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   __pyx_t_5numpy_int32_t __pyx_t_23;
   int __pyx_t_24;
   __Pyx_RefNannySetupContext("call_broadpeaks", 0);
-  __Pyx_TraceCall("call_broadpeaks", __pyx_f[0], 1461, 0, __PYX_ERR(0, 1461, __pyx_L1_error));
+  __Pyx_TraceCall("call_broadpeaks", __pyx_f[0], 1463, 0, __PYX_ERR(0, 1463, __pyx_L1_error));
   if (__pyx_optional_args) {
     if (__pyx_optional_args->__pyx_n > 0) {
       __pyx_v_min_length = __pyx_optional_args->min_length;
@@ -20337,15 +20369,15 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     if (unlikely(!__Pyx_object_dict_version_matches(((PyObject *)__pyx_v_self), __pyx_tp_dict_version, __pyx_obj_dict_version))) {
       PY_UINT64_T __pyx_type_dict_guard = __Pyx_get_tp_dict_version(((PyObject *)__pyx_v_self));
       #endif
-      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_call_broadpeaks); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1461, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_call_broadpeaks); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1463, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       if (!PyCFunction_Check(__pyx_t_1) || (PyCFunction_GET_FUNCTION(__pyx_t_1) != (PyCFunction)(void*)__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_11call_broadpeaks)) {
         __Pyx_XDECREF(__pyx_r);
-        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1461, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1463, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl1_max_gap); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1461, __pyx_L1_error)
+        __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl1_max_gap); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1463, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
-        __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl2_max_gap); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1461, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl2_max_gap); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1463, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
         __Pyx_INCREF(__pyx_t_1);
         __pyx_t_6 = __pyx_t_1; __pyx_t_7 = NULL;
@@ -20363,7 +20395,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
         #if CYTHON_FAST_PYCALL
         if (PyFunction_Check(__pyx_t_6)) {
           PyObject *__pyx_temp[8] = {__pyx_t_7, __pyx_v_scoring_function_symbols, __pyx_v_lvl1_cutoff_s, __pyx_v_lvl2_cutoff_s, __pyx_t_3, __pyx_t_4, __pyx_t_5, ((PyObject *)__pyx_v_cutoff_analysis)};
-          __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_6, __pyx_temp+1-__pyx_t_8, 7+__pyx_t_8); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1461, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_6, __pyx_temp+1-__pyx_t_8, 7+__pyx_t_8); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1463, __pyx_L1_error)
           __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -20374,7 +20406,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
         #if CYTHON_FAST_PYCCALL
         if (__Pyx_PyFastCFunction_Check(__pyx_t_6)) {
           PyObject *__pyx_temp[8] = {__pyx_t_7, __pyx_v_scoring_function_symbols, __pyx_v_lvl1_cutoff_s, __pyx_v_lvl2_cutoff_s, __pyx_t_3, __pyx_t_4, __pyx_t_5, ((PyObject *)__pyx_v_cutoff_analysis)};
-          __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_6, __pyx_temp+1-__pyx_t_8, 7+__pyx_t_8); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1461, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_6, __pyx_temp+1-__pyx_t_8, 7+__pyx_t_8); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1463, __pyx_L1_error)
           __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -20383,7 +20415,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
         } else
         #endif
         {
-          __pyx_t_9 = PyTuple_New(7+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1461, __pyx_L1_error)
+          __pyx_t_9 = PyTuple_New(7+__pyx_t_8); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1463, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_9);
           if (__pyx_t_7) {
             __Pyx_GIVEREF(__pyx_t_7); PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_7); __pyx_t_7 = NULL;
@@ -20409,7 +20441,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
           __pyx_t_3 = 0;
           __pyx_t_4 = 0;
           __pyx_t_5 = 0;
-          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_9, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1461, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_9, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1463, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
         }
@@ -20432,15 +20464,15 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     #endif
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1487
+  /* "MACS2/IO/CallPeakUnit.pyx":1489
  *             list tmppeakset
  * 
  *         lvl1peaks = PeakIO()             # <<<<<<<<<<<<<<
  *         lvl2peaks = PeakIO()
  * 
  */
-  __Pyx_TraceLine(1487,0,__PYX_ERR(0, 1487, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1487, __pyx_L1_error)
+  __Pyx_TraceLine(1489,0,__PYX_ERR(0, 1489, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1489, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_2))) {
@@ -20454,21 +20486,21 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   }
   __pyx_t_1 = (__pyx_t_6) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_6) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1487, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1489, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_lvl1peaks = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1488
+  /* "MACS2/IO/CallPeakUnit.pyx":1490
  * 
  *         lvl1peaks = PeakIO()
  *         lvl2peaks = PeakIO()             # <<<<<<<<<<<<<<
  * 
  *         # prepare p-q table
  */
-  __Pyx_TraceLine(1488,0,__PYX_ERR(0, 1488, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1488, __pyx_L1_error)
+  __Pyx_TraceLine(1490,0,__PYX_ERR(0, 1490, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1490, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_2))) {
@@ -20482,35 +20514,35 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   }
   __pyx_t_1 = (__pyx_t_6) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_6) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1488, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1490, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_lvl2peaks = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1491
+  /* "MACS2/IO/CallPeakUnit.pyx":1493
  * 
  *         # prepare p-q table
  *         if not self.pqtable:             # <<<<<<<<<<<<<<
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:
  */
-  __Pyx_TraceLine(1491,0,__PYX_ERR(0, 1491, __pyx_L1_error))
-  __pyx_t_10 = __Pyx_PyObject_IsTrue(__pyx_v_self->pqtable); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 1491, __pyx_L1_error)
+  __Pyx_TraceLine(1493,0,__PYX_ERR(0, 1493, __pyx_L1_error))
+  __pyx_t_10 = __Pyx_PyObject_IsTrue(__pyx_v_self->pqtable); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 1493, __pyx_L1_error)
   __pyx_t_11 = ((!__pyx_t_10) != 0);
   if (__pyx_t_11) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1492
+    /* "MACS2/IO/CallPeakUnit.pyx":1494
  *         # prepare p-q table
  *         if not self.pqtable:
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")             # <<<<<<<<<<<<<<
  *             if cutoff_analysis:
  *                 logging.info("#3 Cutoff value vs broad region calls will be analyzed!")
  */
-    __Pyx_TraceLine(1492,0,__PYX_ERR(0, 1492, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1492, __pyx_L1_error)
+    __Pyx_TraceLine(1494,0,__PYX_ERR(0, 1494, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1494, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1492, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1494, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_2 = NULL;
@@ -20525,33 +20557,33 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     }
     __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_6, __pyx_t_2, __pyx_kp_u_3_Pre_compute_pvalue_qvalue_tab) : __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_kp_u_3_Pre_compute_pvalue_qvalue_tab);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1492, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1494, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1493
+    /* "MACS2/IO/CallPeakUnit.pyx":1495
  *         if not self.pqtable:
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:             # <<<<<<<<<<<<<<
  *                 logging.info("#3 Cutoff value vs broad region calls will be analyzed!")
  *                 self.__pre_computes( max_gap = lvl2_max_gap, min_length = min_length )
  */
-    __Pyx_TraceLine(1493,0,__PYX_ERR(0, 1493, __pyx_L1_error))
-    __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_cutoff_analysis)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1493, __pyx_L1_error)
+    __Pyx_TraceLine(1495,0,__PYX_ERR(0, 1495, __pyx_L1_error))
+    __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_cutoff_analysis)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1495, __pyx_L1_error)
     if (__pyx_t_11) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1494
+      /* "MACS2/IO/CallPeakUnit.pyx":1496
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:
  *                 logging.info("#3 Cutoff value vs broad region calls will be analyzed!")             # <<<<<<<<<<<<<<
  *                 self.__pre_computes( max_gap = lvl2_max_gap, min_length = min_length )
  *             else:
  */
-      __Pyx_TraceLine(1494,0,__PYX_ERR(0, 1494, __pyx_L1_error))
-      __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_logging); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1494, __pyx_L1_error)
+      __Pyx_TraceLine(1496,0,__PYX_ERR(0, 1496, __pyx_L1_error))
+      __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_logging); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1496, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1494, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1496, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
       __pyx_t_6 = NULL;
@@ -20566,25 +20598,25 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
       }
       __pyx_t_1 = (__pyx_t_6) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_6, __pyx_kp_u_3_Cutoff_value_vs_broad_region) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_kp_u_3_Cutoff_value_vs_broad_region);
       __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
-      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1494, __pyx_L1_error)
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1496, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1495
+      /* "MACS2/IO/CallPeakUnit.pyx":1497
  *             if cutoff_analysis:
  *                 logging.info("#3 Cutoff value vs broad region calls will be analyzed!")
  *                 self.__pre_computes( max_gap = lvl2_max_gap, min_length = min_length )             # <<<<<<<<<<<<<<
  *             else:
  *                 self.__cal_pvalue_qvalue_table()
  */
-      __Pyx_TraceLine(1495,0,__PYX_ERR(0, 1495, __pyx_L1_error))
+      __Pyx_TraceLine(1497,0,__PYX_ERR(0, 1497, __pyx_L1_error))
       __pyx_t_12.__pyx_n = 2;
       __pyx_t_12.max_gap = __pyx_v_lvl2_max_gap;
       __pyx_t_12.min_length = __pyx_v_min_length;
       ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___pre_computes(__pyx_v_self, &__pyx_t_12); 
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1493
+      /* "MACS2/IO/CallPeakUnit.pyx":1495
  *         if not self.pqtable:
  *             logging.info("#3 Pre-compute pvalue-qvalue table...")
  *             if cutoff_analysis:             # <<<<<<<<<<<<<<
@@ -20594,20 +20626,20 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
       goto __pyx_L4;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1497
+    /* "MACS2/IO/CallPeakUnit.pyx":1499
  *                 self.__pre_computes( max_gap = lvl2_max_gap, min_length = min_length )
  *             else:
  *                 self.__cal_pvalue_qvalue_table()             # <<<<<<<<<<<<<<
  * 
  *         # prepare bedGraph file
  */
-    __Pyx_TraceLine(1497,0,__PYX_ERR(0, 1497, __pyx_L1_error))
+    __Pyx_TraceLine(1499,0,__PYX_ERR(0, 1499, __pyx_L1_error))
     /*else*/ {
       ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pvalue_qvalue_table(__pyx_v_self);
     }
     __pyx_L4:;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1491
+    /* "MACS2/IO/CallPeakUnit.pyx":1493
  * 
  *         # prepare p-q table
  *         if not self.pqtable:             # <<<<<<<<<<<<<<
@@ -20616,58 +20648,58 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1500
+  /* "MACS2/IO/CallPeakUnit.pyx":1502
  * 
  *         # prepare bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
  * 
  *             self.bedGraph_treat_f = fopen( self.bedGraph_treat_filename, "w" )
  */
-  __Pyx_TraceLine(1500,0,__PYX_ERR(0, 1500, __pyx_L1_error))
-  __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1500, __pyx_L1_error)
+  __Pyx_TraceLine(1502,0,__PYX_ERR(0, 1502, __pyx_L1_error))
+  __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1502, __pyx_L1_error)
   if (__pyx_t_11) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1502
+    /* "MACS2/IO/CallPeakUnit.pyx":1504
  *         if self.save_bedGraph:
  * 
  *             self.bedGraph_treat_f = fopen( self.bedGraph_treat_filename, "w" )             # <<<<<<<<<<<<<<
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")
  */
-    __Pyx_TraceLine(1502,0,__PYX_ERR(0, 1502, __pyx_L1_error))
+    __Pyx_TraceLine(1504,0,__PYX_ERR(0, 1504, __pyx_L1_error))
     if (unlikely(__pyx_v_self->bedGraph_treat_filename == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-      __PYX_ERR(0, 1502, __pyx_L1_error)
+      __PYX_ERR(0, 1504, __pyx_L1_error)
     }
-    __pyx_t_13 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_treat_filename); if (unlikely((!__pyx_t_13) && PyErr_Occurred())) __PYX_ERR(0, 1502, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_treat_filename); if (unlikely((!__pyx_t_13) && PyErr_Occurred())) __PYX_ERR(0, 1504, __pyx_L1_error)
     __pyx_v_self->bedGraph_treat_f = fopen(__pyx_t_13, ((char const *)"w"));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1503
+    /* "MACS2/IO/CallPeakUnit.pyx":1505
  * 
  *             self.bedGraph_treat_f = fopen( self.bedGraph_treat_filename, "w" )
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )             # <<<<<<<<<<<<<<
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")
  *             logging.info ("#3   Write bedGraph files for treatment pileup (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_treat_pileup.bdg")
  */
-    __Pyx_TraceLine(1503,0,__PYX_ERR(0, 1503, __pyx_L1_error))
+    __Pyx_TraceLine(1505,0,__PYX_ERR(0, 1505, __pyx_L1_error))
     if (unlikely(__pyx_v_self->bedGraph_control_filename == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "expected bytes, NoneType found");
-      __PYX_ERR(0, 1503, __pyx_L1_error)
+      __PYX_ERR(0, 1505, __pyx_L1_error)
     }
-    __pyx_t_13 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_control_filename); if (unlikely((!__pyx_t_13) && PyErr_Occurred())) __PYX_ERR(0, 1503, __pyx_L1_error)
+    __pyx_t_13 = __Pyx_PyBytes_AsString(__pyx_v_self->bedGraph_control_filename); if (unlikely((!__pyx_t_13) && PyErr_Occurred())) __PYX_ERR(0, 1505, __pyx_L1_error)
     __pyx_v_self->bedGraph_ctrl_f = fopen(__pyx_t_13, ((char const *)"w"));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1504
+    /* "MACS2/IO/CallPeakUnit.pyx":1506
  *             self.bedGraph_treat_f = fopen( self.bedGraph_treat_filename, "w" )
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")             # <<<<<<<<<<<<<<
  *             logging.info ("#3   Write bedGraph files for treatment pileup (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_treat_pileup.bdg")
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  */
-    __Pyx_TraceLine(1504,0,__PYX_ERR(0, 1504, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1504, __pyx_L1_error)
+    __Pyx_TraceLine(1506,0,__PYX_ERR(0, 1506, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1506, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1504, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1506, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __pyx_t_2 = NULL;
@@ -20682,34 +20714,34 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     }
     __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_6, __pyx_t_2, __pyx_kp_u_3_In_the_peak_calling_step_the) : __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_kp_u_3_In_the_peak_calling_step_the);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1504, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1506, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1505
+    /* "MACS2/IO/CallPeakUnit.pyx":1507
  *             self.bedGraph_ctrl_f = fopen( self.bedGraph_control_filename, "w" )
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")
  *             logging.info ("#3   Write bedGraph files for treatment pileup (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_treat_pileup.bdg")             # <<<<<<<<<<<<<<
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  * 
  */
-    __Pyx_TraceLine(1505,0,__PYX_ERR(0, 1505, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_logging); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1505, __pyx_L1_error)
+    __Pyx_TraceLine(1507,0,__PYX_ERR(0, 1507, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_logging); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1507, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1505, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1507, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     if (unlikely(__pyx_v_self->bedGraph_filename_prefix == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%.30s'", "decode");
-      __PYX_ERR(0, 1505, __pyx_L1_error)
+      __PYX_ERR(0, 1507, __pyx_L1_error)
     }
-    __pyx_t_6 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1505, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1507, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_9 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_trea, __pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1505, __pyx_L1_error)
+    __pyx_t_9 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_trea, __pyx_t_6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1507, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyUnicode_Concat(__pyx_t_9, __pyx_kp_u_treat_pileup_bdg); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1505, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyUnicode_Concat(__pyx_t_9, __pyx_kp_u_treat_pileup_bdg); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1507, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     __pyx_t_9 = NULL;
@@ -20725,34 +20757,34 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_9, __pyx_t_6) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_6);
     __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1505, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1507, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1506
+    /* "MACS2/IO/CallPeakUnit.pyx":1508
  *             logging.info ("#3 In the peak calling step, the following will be performed simultaneously:")
  *             logging.info ("#3   Write bedGraph files for treatment pileup (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_treat_pileup.bdg")
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")             # <<<<<<<<<<<<<<
  * 
  *             if self.trackline:
  */
-    __Pyx_TraceLine(1506,0,__PYX_ERR(0, 1506, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1506, __pyx_L1_error)
+    __Pyx_TraceLine(1508,0,__PYX_ERR(0, 1508, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_logging); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1508, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1506, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_info); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1508, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     if (unlikely(__pyx_v_self->bedGraph_filename_prefix == Py_None)) {
       PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%.30s'", "decode");
-      __PYX_ERR(0, 1506, __pyx_L1_error)
+      __PYX_ERR(0, 1508, __pyx_L1_error)
     }
-    __pyx_t_2 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1506, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_decode_bytes(__pyx_v_self->bedGraph_filename_prefix, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1508, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_9 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_cont, __pyx_t_2); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1506, __pyx_L1_error)
+    __pyx_t_9 = PyUnicode_Format(__pyx_kp_u_3_Write_bedGraph_files_for_cont, __pyx_t_2); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1508, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    __pyx_t_2 = __Pyx_PyUnicode_Concat(__pyx_t_9, __pyx_kp_u_control_lambda_bdg); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1506, __pyx_L1_error)
+    __pyx_t_2 = __Pyx_PyUnicode_Concat(__pyx_t_9, __pyx_kp_u_control_lambda_bdg); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1508, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     __pyx_t_9 = NULL;
@@ -20768,77 +20800,77 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     __pyx_t_1 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_6, __pyx_t_9, __pyx_t_2) : __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_t_2);
     __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1506, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1508, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1508
+    /* "MACS2/IO/CallPeakUnit.pyx":1510
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  * 
  *             if self.trackline:             # <<<<<<<<<<<<<<
  *                 # this line is REQUIRED by the wiggle format for UCSC browser
  *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  */
-    __Pyx_TraceLine(1508,0,__PYX_ERR(0, 1508, __pyx_L1_error))
-    __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->trackline)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1508, __pyx_L1_error)
+    __Pyx_TraceLine(1510,0,__PYX_ERR(0, 1510, __pyx_L1_error))
+    __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->trackline)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1510, __pyx_L1_error)
     if (__pyx_t_11) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1510
+      /* "MACS2/IO/CallPeakUnit.pyx":1512
  *             if self.trackline:
  *                 # this line is REQUIRED by the wiggle format for UCSC browser
  *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()             # <<<<<<<<<<<<<<
  *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
  *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  */
-      __Pyx_TraceLine(1510,0,__PYX_ERR(0, 1510, __pyx_L1_error))
-      __pyx_t_1 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_treatme, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1510, __pyx_L1_error)
+      __Pyx_TraceLine(1512,0,__PYX_ERR(0, 1512, __pyx_L1_error))
+      __pyx_t_1 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_treatme, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1512, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_6 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_1), NULL, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1510, __pyx_L1_error)
+      __pyx_t_6 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_1), NULL, NULL); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1512, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_v_tmp_bytes = __pyx_t_6;
       __pyx_t_6 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1511
+      /* "MACS2/IO/CallPeakUnit.pyx":1513
  *                 # this line is REQUIRED by the wiggle format for UCSC browser
  *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  *                 fprintf( self.bedGraph_treat_f, tmp_bytes )             # <<<<<<<<<<<<<<
  *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )
  */
-      __Pyx_TraceLine(1511,0,__PYX_ERR(0, 1511, __pyx_L1_error))
-      __pyx_t_14 = __Pyx_PyObject_AsString(__pyx_v_tmp_bytes); if (unlikely((!__pyx_t_14) && PyErr_Occurred())) __PYX_ERR(0, 1511, __pyx_L1_error)
+      __Pyx_TraceLine(1513,0,__PYX_ERR(0, 1513, __pyx_L1_error))
+      __pyx_t_14 = __Pyx_PyObject_AsString(__pyx_v_tmp_bytes); if (unlikely((!__pyx_t_14) && PyErr_Occurred())) __PYX_ERR(0, 1513, __pyx_L1_error)
       (void)(fprintf(__pyx_v_self->bedGraph_treat_f, __pyx_t_14));
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1512
+      /* "MACS2/IO/CallPeakUnit.pyx":1514
  *                 tmp_bytes = ("track type=bedGraph name=\"treatment pileup\" description=\"treatment pileup after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
  *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()             # <<<<<<<<<<<<<<
  *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )
  * 
  */
-      __Pyx_TraceLine(1512,0,__PYX_ERR(0, 1512, __pyx_L1_error))
-      __pyx_t_6 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_control, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1512, __pyx_L1_error)
+      __Pyx_TraceLine(1514,0,__PYX_ERR(0, 1514, __pyx_L1_error))
+      __pyx_t_6 = PyUnicode_Format(__pyx_kp_u_track_type_bedGraph_name_control, __pyx_v_self->bedGraph_filename_prefix); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1514, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_1 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_6), NULL, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1512, __pyx_L1_error)
+      __pyx_t_1 = PyUnicode_AsEncodedString(((PyObject*)__pyx_t_6), NULL, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1514, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
       __Pyx_DECREF_SET(__pyx_v_tmp_bytes, __pyx_t_1);
       __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1513
+      /* "MACS2/IO/CallPeakUnit.pyx":1515
  *                 fprintf( self.bedGraph_treat_f, tmp_bytes )
  *                 tmp_bytes = ("track type=bedGraph name=\"control lambda\" description=\"control lambda after possible scaling for \'%s\'\"\n" % self.bedGraph_filename_prefix).encode()
  *                 fprintf( self.bedGraph_ctrl_f, tmp_bytes )             # <<<<<<<<<<<<<<
  * 
  * 
  */
-      __Pyx_TraceLine(1513,0,__PYX_ERR(0, 1513, __pyx_L1_error))
-      __pyx_t_14 = __Pyx_PyObject_AsString(__pyx_v_tmp_bytes); if (unlikely((!__pyx_t_14) && PyErr_Occurred())) __PYX_ERR(0, 1513, __pyx_L1_error)
+      __Pyx_TraceLine(1515,0,__PYX_ERR(0, 1515, __pyx_L1_error))
+      __pyx_t_14 = __Pyx_PyObject_AsString(__pyx_v_tmp_bytes); if (unlikely((!__pyx_t_14) && PyErr_Occurred())) __PYX_ERR(0, 1515, __pyx_L1_error)
       (void)(fprintf(__pyx_v_self->bedGraph_ctrl_f, __pyx_t_14));
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1508
+      /* "MACS2/IO/CallPeakUnit.pyx":1510
  *             logging.info ("#3   Write bedGraph files for control lambda (after scaling if necessary)... %s" % self.bedGraph_filename_prefix.decode() + "_control_lambda.bdg")
  * 
  *             if self.trackline:             # <<<<<<<<<<<<<<
@@ -20847,7 +20879,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
  */
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1500
+    /* "MACS2/IO/CallPeakUnit.pyx":1502
  * 
  *         # prepare bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
@@ -20856,17 +20888,17 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1516
+  /* "MACS2/IO/CallPeakUnit.pyx":1518
  * 
  * 
  *         logging.info("#3 Call peaks for each chromosome...")             # <<<<<<<<<<<<<<
  *         for chrom in self.chromosomes:
  *             self.__chrom_call_broadpeak_using_certain_criteria ( lvl1peaks, lvl2peaks, chrom, scoring_function_symbols, lvl1_cutoff_s, lvl2_cutoff_s, min_length, lvl1_max_gap, lvl2_max_gap, self.save_bedGraph )
  */
-  __Pyx_TraceLine(1516,0,__PYX_ERR(0, 1516, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_logging); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1516, __pyx_L1_error)
+  __Pyx_TraceLine(1518,0,__PYX_ERR(0, 1518, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_logging); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1518, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1516, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_info); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1518, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_6 = NULL;
@@ -20881,106 +20913,106 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   }
   __pyx_t_1 = (__pyx_t_6) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_6, __pyx_kp_u_3_Call_peaks_for_each_chromosom) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_kp_u_3_Call_peaks_for_each_chromosom);
   __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1516, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1518, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1517
+  /* "MACS2/IO/CallPeakUnit.pyx":1519
  * 
  *         logging.info("#3 Call peaks for each chromosome...")
  *         for chrom in self.chromosomes:             # <<<<<<<<<<<<<<
  *             self.__chrom_call_broadpeak_using_certain_criteria ( lvl1peaks, lvl2peaks, chrom, scoring_function_symbols, lvl1_cutoff_s, lvl2_cutoff_s, min_length, lvl1_max_gap, lvl2_max_gap, self.save_bedGraph )
  * 
  */
-  __Pyx_TraceLine(1517,0,__PYX_ERR(0, 1517, __pyx_L1_error))
+  __Pyx_TraceLine(1519,0,__PYX_ERR(0, 1519, __pyx_L1_error))
   if (unlikely(__pyx_v_self->chromosomes == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-    __PYX_ERR(0, 1517, __pyx_L1_error)
+    __PYX_ERR(0, 1519, __pyx_L1_error)
   }
   __pyx_t_1 = __pyx_v_self->chromosomes; __Pyx_INCREF(__pyx_t_1); __pyx_t_15 = 0;
   for (;;) {
     if (__pyx_t_15 >= PyList_GET_SIZE(__pyx_t_1)) break;
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-    __pyx_t_2 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_15); __Pyx_INCREF(__pyx_t_2); __pyx_t_15++; if (unlikely(0 < 0)) __PYX_ERR(0, 1517, __pyx_L1_error)
+    __pyx_t_2 = PyList_GET_ITEM(__pyx_t_1, __pyx_t_15); __Pyx_INCREF(__pyx_t_2); __pyx_t_15++; if (unlikely(0 < 0)) __PYX_ERR(0, 1519, __pyx_L1_error)
     #else
-    __pyx_t_2 = PySequence_ITEM(__pyx_t_1, __pyx_t_15); __pyx_t_15++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1517, __pyx_L1_error)
+    __pyx_t_2 = PySequence_ITEM(__pyx_t_1, __pyx_t_15); __pyx_t_15++; if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1519, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     #endif
-    if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 1517, __pyx_L1_error)
+    if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 1519, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_chrom, ((PyObject*)__pyx_t_2));
     __pyx_t_2 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1518
+    /* "MACS2/IO/CallPeakUnit.pyx":1520
  *         logging.info("#3 Call peaks for each chromosome...")
  *         for chrom in self.chromosomes:
  *             self.__chrom_call_broadpeak_using_certain_criteria ( lvl1peaks, lvl2peaks, chrom, scoring_function_symbols, lvl1_cutoff_s, lvl2_cutoff_s, min_length, lvl1_max_gap, lvl2_max_gap, self.save_bedGraph )             # <<<<<<<<<<<<<<
  * 
  *         # close bedGraph file
  */
-    __Pyx_TraceLine(1518,0,__PYX_ERR(0, 1518, __pyx_L1_error))
+    __Pyx_TraceLine(1520,0,__PYX_ERR(0, 1520, __pyx_L1_error))
     __pyx_t_2 = ((PyObject *)__pyx_v_self->save_bedGraph);
     __Pyx_INCREF(__pyx_t_2);
     ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___chrom_call_broadpeak_using_certain_criteria(__pyx_v_self, __pyx_v_lvl1peaks, __pyx_v_lvl2peaks, __pyx_v_chrom, __pyx_v_scoring_function_symbols, __pyx_v_lvl1_cutoff_s, __pyx_v_lvl2_cutoff_s, __pyx_v_min_length, __pyx_v_lvl1_max_gap, __pyx_v_lvl2_max_gap, ((PyBoolObject *)__pyx_t_2));
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1517
+    /* "MACS2/IO/CallPeakUnit.pyx":1519
  * 
  *         logging.info("#3 Call peaks for each chromosome...")
  *         for chrom in self.chromosomes:             # <<<<<<<<<<<<<<
  *             self.__chrom_call_broadpeak_using_certain_criteria ( lvl1peaks, lvl2peaks, chrom, scoring_function_symbols, lvl1_cutoff_s, lvl2_cutoff_s, min_length, lvl1_max_gap, lvl2_max_gap, self.save_bedGraph )
  * 
  */
-    __Pyx_TraceLine(1517,0,__PYX_ERR(0, 1517, __pyx_L1_error))
+    __Pyx_TraceLine(1519,0,__PYX_ERR(0, 1519, __pyx_L1_error))
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1521
+  /* "MACS2/IO/CallPeakUnit.pyx":1523
  * 
  *         # close bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
  *             fclose( self.bedGraph_treat_f )
  *             fclose( self.bedGraph_ctrl_f )
  */
-  __Pyx_TraceLine(1521,0,__PYX_ERR(0, 1521, __pyx_L1_error))
-  __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1521, __pyx_L1_error)
+  __Pyx_TraceLine(1523,0,__PYX_ERR(0, 1523, __pyx_L1_error))
+  __pyx_t_11 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->save_bedGraph)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1523, __pyx_L1_error)
   if (__pyx_t_11) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1522
+    /* "MACS2/IO/CallPeakUnit.pyx":1524
  *         # close bedGraph file
  *         if self.save_bedGraph:
  *             fclose( self.bedGraph_treat_f )             # <<<<<<<<<<<<<<
  *             fclose( self.bedGraph_ctrl_f )
  *             #self.bedGraph_ctrl.close()
  */
-    __Pyx_TraceLine(1522,0,__PYX_ERR(0, 1522, __pyx_L1_error))
+    __Pyx_TraceLine(1524,0,__PYX_ERR(0, 1524, __pyx_L1_error))
     (void)(fclose(__pyx_v_self->bedGraph_treat_f));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1523
+    /* "MACS2/IO/CallPeakUnit.pyx":1525
  *         if self.save_bedGraph:
  *             fclose( self.bedGraph_treat_f )
  *             fclose( self.bedGraph_ctrl_f )             # <<<<<<<<<<<<<<
  *             #self.bedGraph_ctrl.close()
  *             self.save_bedGraph = False
  */
-    __Pyx_TraceLine(1523,0,__PYX_ERR(0, 1523, __pyx_L1_error))
+    __Pyx_TraceLine(1525,0,__PYX_ERR(0, 1525, __pyx_L1_error))
     (void)(fclose(__pyx_v_self->bedGraph_ctrl_f));
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1525
+    /* "MACS2/IO/CallPeakUnit.pyx":1527
  *             fclose( self.bedGraph_ctrl_f )
  *             #self.bedGraph_ctrl.close()
  *             self.save_bedGraph = False             # <<<<<<<<<<<<<<
  * 
  *         # now combine lvl1 and lvl2 peaks
  */
-    __Pyx_TraceLine(1525,0,__PYX_ERR(0, 1525, __pyx_L1_error))
+    __Pyx_TraceLine(1527,0,__PYX_ERR(0, 1527, __pyx_L1_error))
     __Pyx_INCREF(Py_False);
     __Pyx_GIVEREF(Py_False);
     __Pyx_GOTREF(__pyx_v_self->save_bedGraph);
     __Pyx_DECREF(((PyObject *)__pyx_v_self->save_bedGraph));
     __pyx_v_self->save_bedGraph = ((PyBoolObject *)Py_False);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1521
+    /* "MACS2/IO/CallPeakUnit.pyx":1523
  * 
  *         # close bedGraph file
  *         if self.save_bedGraph:             # <<<<<<<<<<<<<<
@@ -20989,15 +21021,15 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1528
+  /* "MACS2/IO/CallPeakUnit.pyx":1530
  * 
  *         # now combine lvl1 and lvl2 peaks
  *         chrs = lvl1peaks.get_chr_names()             # <<<<<<<<<<<<<<
  *         broadpeaks = BroadPeakIO()
  *         # use lvl2_peaks as linking regions between lvl1_peaks
  */
-  __Pyx_TraceLine(1528,0,__PYX_ERR(0, 1528, __pyx_L1_error))
-  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_lvl1peaks, __pyx_n_s_get_chr_names); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1528, __pyx_L1_error)
+  __Pyx_TraceLine(1530,0,__PYX_ERR(0, 1530, __pyx_L1_error))
+  __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_lvl1peaks, __pyx_n_s_get_chr_names); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1530, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -21011,22 +21043,22 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   }
   __pyx_t_1 = (__pyx_t_6) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_6) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1528, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1530, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (!(likely(PySet_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "set", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1528, __pyx_L1_error)
+  if (!(likely(PySet_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "set", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1530, __pyx_L1_error)
   __pyx_v_chrs = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1529
+  /* "MACS2/IO/CallPeakUnit.pyx":1531
  *         # now combine lvl1 and lvl2 peaks
  *         chrs = lvl1peaks.get_chr_names()
  *         broadpeaks = BroadPeakIO()             # <<<<<<<<<<<<<<
  *         # use lvl2_peaks as linking regions between lvl1_peaks
  *         for chrom in chrs:
  */
-  __Pyx_TraceLine(1529,0,__PYX_ERR(0, 1529, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_BroadPeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1529, __pyx_L1_error)
+  __Pyx_TraceLine(1531,0,__PYX_ERR(0, 1531, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_BroadPeakIO); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1531, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_t_6 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_2))) {
@@ -21040,22 +21072,22 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   }
   __pyx_t_1 = (__pyx_t_6) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_6) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1529, __pyx_L1_error)
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1531, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_v_broadpeaks = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1531
+  /* "MACS2/IO/CallPeakUnit.pyx":1533
  *         broadpeaks = BroadPeakIO()
  *         # use lvl2_peaks as linking regions between lvl1_peaks
  *         for chrom in chrs:             # <<<<<<<<<<<<<<
  *             lvl1peakschrom = lvl1peaks.get_data_from_chrom(chrom)
  *             lvl2peakschrom = lvl2peaks.get_data_from_chrom(chrom)
  */
-  __Pyx_TraceLine(1531,0,__PYX_ERR(0, 1531, __pyx_L1_error))
+  __Pyx_TraceLine(1533,0,__PYX_ERR(0, 1533, __pyx_L1_error))
   __pyx_t_15 = 0;
-  __pyx_t_2 = __Pyx_set_iterator(__pyx_v_chrs, 1, (&__pyx_t_16), (&__pyx_t_8)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1531, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_set_iterator(__pyx_v_chrs, 1, (&__pyx_t_16), (&__pyx_t_8)); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1533, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_XDECREF(__pyx_t_1);
   __pyx_t_1 = __pyx_t_2;
@@ -21063,21 +21095,21 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   while (1) {
     __pyx_t_17 = __Pyx_set_iter_next(__pyx_t_1, __pyx_t_16, &__pyx_t_15, &__pyx_t_2, __pyx_t_8);
     if (unlikely(__pyx_t_17 == 0)) break;
-    if (unlikely(__pyx_t_17 == -1)) __PYX_ERR(0, 1531, __pyx_L1_error)
+    if (unlikely(__pyx_t_17 == -1)) __PYX_ERR(0, 1533, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 1531, __pyx_L1_error)
+    if (!(likely(PyBytes_CheckExact(__pyx_t_2))||((__pyx_t_2) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_2)->tp_name), 0))) __PYX_ERR(0, 1533, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_chrom, ((PyObject*)__pyx_t_2));
     __pyx_t_2 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1532
+    /* "MACS2/IO/CallPeakUnit.pyx":1534
  *         # use lvl2_peaks as linking regions between lvl1_peaks
  *         for chrom in chrs:
  *             lvl1peakschrom = lvl1peaks.get_data_from_chrom(chrom)             # <<<<<<<<<<<<<<
  *             lvl2peakschrom = lvl2peaks.get_data_from_chrom(chrom)
  *             lvl1peakschrom_next = iter(lvl1peakschrom).__next__
  */
-    __Pyx_TraceLine(1532,0,__PYX_ERR(0, 1532, __pyx_L1_error))
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_lvl1peaks, __pyx_n_s_get_data_from_chrom); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1532, __pyx_L1_error)
+    __Pyx_TraceLine(1534,0,__PYX_ERR(0, 1534, __pyx_L1_error))
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_lvl1peaks, __pyx_n_s_get_data_from_chrom); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1534, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_t_9 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_6))) {
@@ -21091,21 +21123,21 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     }
     __pyx_t_2 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_6, __pyx_t_9, __pyx_v_chrom) : __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_v_chrom);
     __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
-    if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1532, __pyx_L1_error)
+    if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1534, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_XDECREF_SET(__pyx_v_lvl1peakschrom, __pyx_t_2);
     __pyx_t_2 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1533
+    /* "MACS2/IO/CallPeakUnit.pyx":1535
  *         for chrom in chrs:
  *             lvl1peakschrom = lvl1peaks.get_data_from_chrom(chrom)
  *             lvl2peakschrom = lvl2peaks.get_data_from_chrom(chrom)             # <<<<<<<<<<<<<<
  *             lvl1peakschrom_next = iter(lvl1peakschrom).__next__
  *             tmppeakset = []             # to temporarily store lvl1 region inside a lvl2 region
  */
-    __Pyx_TraceLine(1533,0,__PYX_ERR(0, 1533, __pyx_L1_error))
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_lvl2peaks, __pyx_n_s_get_data_from_chrom); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1533, __pyx_L1_error)
+    __Pyx_TraceLine(1535,0,__PYX_ERR(0, 1535, __pyx_L1_error))
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_lvl2peaks, __pyx_n_s_get_data_from_chrom); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1535, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __pyx_t_9 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_6))) {
@@ -21119,49 +21151,49 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
     }
     __pyx_t_2 = (__pyx_t_9) ? __Pyx_PyObject_Call2Args(__pyx_t_6, __pyx_t_9, __pyx_v_chrom) : __Pyx_PyObject_CallOneArg(__pyx_t_6, __pyx_v_chrom);
     __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
-    if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1533, __pyx_L1_error)
+    if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1535, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_XDECREF_SET(__pyx_v_lvl2peakschrom, __pyx_t_2);
     __pyx_t_2 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1534
+    /* "MACS2/IO/CallPeakUnit.pyx":1536
  *             lvl1peakschrom = lvl1peaks.get_data_from_chrom(chrom)
  *             lvl2peakschrom = lvl2peaks.get_data_from_chrom(chrom)
  *             lvl1peakschrom_next = iter(lvl1peakschrom).__next__             # <<<<<<<<<<<<<<
  *             tmppeakset = []             # to temporarily store lvl1 region inside a lvl2 region
  *             # our assumption is lvl1 regions should be included in lvl2 regions
  */
-    __Pyx_TraceLine(1534,0,__PYX_ERR(0, 1534, __pyx_L1_error))
-    __pyx_t_2 = PyObject_GetIter(__pyx_v_lvl1peakschrom); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1534, __pyx_L1_error)
+    __Pyx_TraceLine(1536,0,__PYX_ERR(0, 1536, __pyx_L1_error))
+    __pyx_t_2 = PyObject_GetIter(__pyx_v_lvl1peakschrom); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1536, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
-    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_next); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1534, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_next); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1536, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
     __Pyx_XDECREF_SET(__pyx_v_lvl1peakschrom_next, __pyx_t_6);
     __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1535
+    /* "MACS2/IO/CallPeakUnit.pyx":1537
  *             lvl2peakschrom = lvl2peaks.get_data_from_chrom(chrom)
  *             lvl1peakschrom_next = iter(lvl1peakschrom).__next__
  *             tmppeakset = []             # to temporarily store lvl1 region inside a lvl2 region             # <<<<<<<<<<<<<<
  *             # our assumption is lvl1 regions should be included in lvl2 regions
  *             try:
  */
-    __Pyx_TraceLine(1535,0,__PYX_ERR(0, 1535, __pyx_L1_error))
-    __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1535, __pyx_L1_error)
+    __Pyx_TraceLine(1537,0,__PYX_ERR(0, 1537, __pyx_L1_error))
+    __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1537, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_XDECREF_SET(__pyx_v_tmppeakset, ((PyObject*)__pyx_t_6));
     __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1537
+    /* "MACS2/IO/CallPeakUnit.pyx":1539
  *             tmppeakset = []             # to temporarily store lvl1 region inside a lvl2 region
  *             # our assumption is lvl1 regions should be included in lvl2 regions
  *             try:             # <<<<<<<<<<<<<<
  *                 lvl1 = lvl1peakschrom_next()
  *                 for i in range( len(lvl2peakschrom) ):
  */
-    __Pyx_TraceLine(1537,0,__PYX_ERR(0, 1537, __pyx_L1_error))
+    __Pyx_TraceLine(1539,0,__PYX_ERR(0, 1539, __pyx_L1_error))
     {
       __Pyx_PyThreadState_declare
       __Pyx_PyThreadState_assign
@@ -21171,14 +21203,14 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
       __Pyx_XGOTREF(__pyx_t_20);
       /*try:*/ {
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1538
+        /* "MACS2/IO/CallPeakUnit.pyx":1540
  *             # our assumption is lvl1 regions should be included in lvl2 regions
  *             try:
  *                 lvl1 = lvl1peakschrom_next()             # <<<<<<<<<<<<<<
  *                 for i in range( len(lvl2peakschrom) ):
  *                     # for each lvl2 peak, find all lvl1 peaks inside
  */
-        __Pyx_TraceLine(1538,0,__PYX_ERR(0, 1538, __pyx_L12_error))
+        __Pyx_TraceLine(1540,0,__PYX_ERR(0, 1540, __pyx_L12_error))
         __Pyx_INCREF(__pyx_v_lvl1peakschrom_next);
         __pyx_t_2 = __pyx_v_lvl1peakschrom_next; __pyx_t_9 = NULL;
         if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -21192,101 +21224,101 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
         }
         __pyx_t_6 = (__pyx_t_9) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_9) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
         __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
-        if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1538, __pyx_L12_error)
+        if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1540, __pyx_L12_error)
         __Pyx_GOTREF(__pyx_t_6);
         __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
         __Pyx_XDECREF_SET(__pyx_v_lvl1, __pyx_t_6);
         __pyx_t_6 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1539
+        /* "MACS2/IO/CallPeakUnit.pyx":1541
  *             try:
  *                 lvl1 = lvl1peakschrom_next()
  *                 for i in range( len(lvl2peakschrom) ):             # <<<<<<<<<<<<<<
  *                     # for each lvl2 peak, find all lvl1 peaks inside
  *                     # I assume lvl1 peaks can be ALL covered by lvl2 peaks.
  */
-        __Pyx_TraceLine(1539,0,__PYX_ERR(0, 1539, __pyx_L12_error))
-        __pyx_t_21 = PyObject_Length(__pyx_v_lvl2peakschrom); if (unlikely(__pyx_t_21 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1539, __pyx_L12_error)
+        __Pyx_TraceLine(1541,0,__PYX_ERR(0, 1541, __pyx_L12_error))
+        __pyx_t_21 = PyObject_Length(__pyx_v_lvl2peakschrom); if (unlikely(__pyx_t_21 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1541, __pyx_L12_error)
         __pyx_t_22 = __pyx_t_21;
         for (__pyx_t_23 = 0; __pyx_t_23 < __pyx_t_22; __pyx_t_23+=1) {
           __pyx_v_i = __pyx_t_23;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1542
+          /* "MACS2/IO/CallPeakUnit.pyx":1544
  *                     # for each lvl2 peak, find all lvl1 peaks inside
  *                     # I assume lvl1 peaks can be ALL covered by lvl2 peaks.
  *                     lvl2 = lvl2peakschrom[i]             # <<<<<<<<<<<<<<
  * 
  *                     while True:
  */
-          __Pyx_TraceLine(1542,0,__PYX_ERR(0, 1542, __pyx_L12_error))
-          __pyx_t_6 = __Pyx_GetItemInt(__pyx_v_lvl2peakschrom, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1542, __pyx_L12_error)
+          __Pyx_TraceLine(1544,0,__PYX_ERR(0, 1544, __pyx_L12_error))
+          __pyx_t_6 = __Pyx_GetItemInt(__pyx_v_lvl2peakschrom, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1544, __pyx_L12_error)
           __Pyx_GOTREF(__pyx_t_6);
           __Pyx_XDECREF_SET(__pyx_v_lvl2, __pyx_t_6);
           __pyx_t_6 = 0;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1544
+          /* "MACS2/IO/CallPeakUnit.pyx":1546
  *                     lvl2 = lvl2peakschrom[i]
  * 
  *                     while True:             # <<<<<<<<<<<<<<
  *                         if lvl2["start"] <= lvl1["start"]  and lvl1["end"] <= lvl2["end"]:
  *                             tmppeakset.append(lvl1)
  */
-          __Pyx_TraceLine(1544,0,__PYX_ERR(0, 1544, __pyx_L12_error))
+          __Pyx_TraceLine(1546,0,__PYX_ERR(0, 1546, __pyx_L12_error))
           while (1) {
 
-            /* "MACS2/IO/CallPeakUnit.pyx":1545
+            /* "MACS2/IO/CallPeakUnit.pyx":1547
  * 
  *                     while True:
  *                         if lvl2["start"] <= lvl1["start"]  and lvl1["end"] <= lvl2["end"]:             # <<<<<<<<<<<<<<
  *                             tmppeakset.append(lvl1)
  *                             lvl1 = lvl1peakschrom_next()
  */
-            __Pyx_TraceLine(1545,0,__PYX_ERR(0, 1545, __pyx_L12_error))
-            __pyx_t_6 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2, __pyx_n_u_start); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __Pyx_TraceLine(1547,0,__PYX_ERR(0, 1547, __pyx_L12_error))
+            __pyx_t_6 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2, __pyx_n_u_start); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_GOTREF(__pyx_t_6);
-            __pyx_t_2 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl1, __pyx_n_u_start); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __pyx_t_2 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl1, __pyx_n_u_start); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_GOTREF(__pyx_t_2);
-            __pyx_t_9 = PyObject_RichCompare(__pyx_t_6, __pyx_t_2, Py_LE); __Pyx_XGOTREF(__pyx_t_9); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __pyx_t_9 = PyObject_RichCompare(__pyx_t_6, __pyx_t_2, Py_LE); __Pyx_XGOTREF(__pyx_t_9); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-            __pyx_t_10 = __Pyx_PyObject_IsTrue(__pyx_t_9); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __pyx_t_10 = __Pyx_PyObject_IsTrue(__pyx_t_9); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
             if (__pyx_t_10) {
             } else {
               __pyx_t_11 = __pyx_t_10;
               goto __pyx_L25_bool_binop_done;
             }
-            __pyx_t_9 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl1, __pyx_n_u_end); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __pyx_t_9 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl1, __pyx_n_u_end); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_GOTREF(__pyx_t_9);
-            __pyx_t_2 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2, __pyx_n_u_end); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __pyx_t_2 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2, __pyx_n_u_end); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_GOTREF(__pyx_t_2);
-            __pyx_t_6 = PyObject_RichCompare(__pyx_t_9, __pyx_t_2, Py_LE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __pyx_t_6 = PyObject_RichCompare(__pyx_t_9, __pyx_t_2, Py_LE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
             __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-            __pyx_t_10 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 1545, __pyx_L12_error)
+            __pyx_t_10 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_10 < 0)) __PYX_ERR(0, 1547, __pyx_L12_error)
             __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
             __pyx_t_11 = __pyx_t_10;
             __pyx_L25_bool_binop_done:;
             if (__pyx_t_11) {
 
-              /* "MACS2/IO/CallPeakUnit.pyx":1546
+              /* "MACS2/IO/CallPeakUnit.pyx":1548
  *                     while True:
  *                         if lvl2["start"] <= lvl1["start"]  and lvl1["end"] <= lvl2["end"]:
  *                             tmppeakset.append(lvl1)             # <<<<<<<<<<<<<<
  *                             lvl1 = lvl1peakschrom_next()
  *                         else:
  */
-              __Pyx_TraceLine(1546,0,__PYX_ERR(0, 1546, __pyx_L12_error))
-              __pyx_t_24 = __Pyx_PyList_Append(__pyx_v_tmppeakset, __pyx_v_lvl1); if (unlikely(__pyx_t_24 == ((int)-1))) __PYX_ERR(0, 1546, __pyx_L12_error)
+              __Pyx_TraceLine(1548,0,__PYX_ERR(0, 1548, __pyx_L12_error))
+              __pyx_t_24 = __Pyx_PyList_Append(__pyx_v_tmppeakset, __pyx_v_lvl1); if (unlikely(__pyx_t_24 == ((int)-1))) __PYX_ERR(0, 1548, __pyx_L12_error)
 
-              /* "MACS2/IO/CallPeakUnit.pyx":1547
+              /* "MACS2/IO/CallPeakUnit.pyx":1549
  *                         if lvl2["start"] <= lvl1["start"]  and lvl1["end"] <= lvl2["end"]:
  *                             tmppeakset.append(lvl1)
  *                             lvl1 = lvl1peakschrom_next()             # <<<<<<<<<<<<<<
  *                         else:
  *                             # make a hierarchical broad peak
  */
-              __Pyx_TraceLine(1547,0,__PYX_ERR(0, 1547, __pyx_L12_error))
+              __Pyx_TraceLine(1549,0,__PYX_ERR(0, 1549, __pyx_L12_error))
               __Pyx_INCREF(__pyx_v_lvl1peakschrom_next);
               __pyx_t_2 = __pyx_v_lvl1peakschrom_next; __pyx_t_9 = NULL;
               if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -21300,13 +21332,13 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
               }
               __pyx_t_6 = (__pyx_t_9) ? __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_t_9) : __Pyx_PyObject_CallNoArg(__pyx_t_2);
               __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
-              if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1547, __pyx_L12_error)
+              if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1549, __pyx_L12_error)
               __Pyx_GOTREF(__pyx_t_6);
               __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
               __Pyx_DECREF_SET(__pyx_v_lvl1, __pyx_t_6);
               __pyx_t_6 = 0;
 
-              /* "MACS2/IO/CallPeakUnit.pyx":1545
+              /* "MACS2/IO/CallPeakUnit.pyx":1547
  * 
  *                     while True:
  *                         if lvl2["start"] <= lvl1["start"]  and lvl1["end"] <= lvl2["end"]:             # <<<<<<<<<<<<<<
@@ -21316,40 +21348,40 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
               goto __pyx_L24;
             }
 
-            /* "MACS2/IO/CallPeakUnit.pyx":1551
+            /* "MACS2/IO/CallPeakUnit.pyx":1553
  *                             # make a hierarchical broad peak
  *                             #print lvl2["start"], lvl2["end"], lvl2["score"]
  *                             self.__add_broadpeak ( broadpeaks, chrom, lvl2, tmppeakset)             # <<<<<<<<<<<<<<
  *                             tmppeakset = []
  *                             break
  */
-            __Pyx_TraceLine(1551,0,__PYX_ERR(0, 1551, __pyx_L12_error))
+            __Pyx_TraceLine(1553,0,__PYX_ERR(0, 1553, __pyx_L12_error))
             /*else*/ {
-              __pyx_t_6 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___add_broadpeak(__pyx_v_self, __pyx_v_broadpeaks, __pyx_v_chrom, __pyx_v_lvl2, __pyx_v_tmppeakset); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1551, __pyx_L12_error)
+              __pyx_t_6 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___add_broadpeak(__pyx_v_self, __pyx_v_broadpeaks, __pyx_v_chrom, __pyx_v_lvl2, __pyx_v_tmppeakset); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1553, __pyx_L12_error)
               __Pyx_GOTREF(__pyx_t_6);
               __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-              /* "MACS2/IO/CallPeakUnit.pyx":1552
+              /* "MACS2/IO/CallPeakUnit.pyx":1554
  *                             #print lvl2["start"], lvl2["end"], lvl2["score"]
  *                             self.__add_broadpeak ( broadpeaks, chrom, lvl2, tmppeakset)
  *                             tmppeakset = []             # <<<<<<<<<<<<<<
  *                             break
  *             except StopIteration:
  */
-              __Pyx_TraceLine(1552,0,__PYX_ERR(0, 1552, __pyx_L12_error))
-              __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1552, __pyx_L12_error)
+              __Pyx_TraceLine(1554,0,__PYX_ERR(0, 1554, __pyx_L12_error))
+              __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1554, __pyx_L12_error)
               __Pyx_GOTREF(__pyx_t_6);
               __Pyx_DECREF_SET(__pyx_v_tmppeakset, ((PyObject*)__pyx_t_6));
               __pyx_t_6 = 0;
 
-              /* "MACS2/IO/CallPeakUnit.pyx":1553
+              /* "MACS2/IO/CallPeakUnit.pyx":1555
  *                             self.__add_broadpeak ( broadpeaks, chrom, lvl2, tmppeakset)
  *                             tmppeakset = []
  *                             break             # <<<<<<<<<<<<<<
  *             except StopIteration:
  *                 # no more strong (aka lvl1) peaks left
  */
-              __Pyx_TraceLine(1553,0,__PYX_ERR(0, 1553, __pyx_L12_error))
+              __Pyx_TraceLine(1555,0,__PYX_ERR(0, 1555, __pyx_L12_error))
               goto __pyx_L23_break;
             }
             __pyx_L24:;
@@ -21357,7 +21389,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
           __pyx_L23_break:;
         }
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1537
+        /* "MACS2/IO/CallPeakUnit.pyx":1539
  *             tmppeakset = []             # to temporarily store lvl1 region inside a lvl2 region
  *             # our assumption is lvl1 regions should be included in lvl2 regions
  *             try:             # <<<<<<<<<<<<<<
@@ -21378,72 +21410,72 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
       __Pyx_XDECREF(__pyx_t_7); __pyx_t_7 = 0;
       __Pyx_XDECREF(__pyx_t_9); __pyx_t_9 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1554
+      /* "MACS2/IO/CallPeakUnit.pyx":1556
  *                             tmppeakset = []
  *                             break
  *             except StopIteration:             # <<<<<<<<<<<<<<
  *                 # no more strong (aka lvl1) peaks left
  *                 self.__add_broadpeak ( broadpeaks, chrom, lvl2, tmppeakset)
  */
-      __Pyx_TraceLine(1554,0,__PYX_ERR(0, 1554, __pyx_L14_except_error))
+      __Pyx_TraceLine(1556,0,__PYX_ERR(0, 1556, __pyx_L14_except_error))
       __pyx_t_17 = __Pyx_PyErr_ExceptionMatches(__pyx_builtin_StopIteration);
       if (__pyx_t_17) {
         __Pyx_AddTraceback("MACS2.IO.CallPeakUnit.CallerFromAlignments.call_broadpeaks", __pyx_clineno, __pyx_lineno, __pyx_filename);
-        if (__Pyx_GetException(&__pyx_t_6, &__pyx_t_2, &__pyx_t_9) < 0) __PYX_ERR(0, 1554, __pyx_L14_except_error)
+        if (__Pyx_GetException(&__pyx_t_6, &__pyx_t_2, &__pyx_t_9) < 0) __PYX_ERR(0, 1556, __pyx_L14_except_error)
         __Pyx_GOTREF(__pyx_t_6);
         __Pyx_GOTREF(__pyx_t_2);
         __Pyx_GOTREF(__pyx_t_9);
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1556
+        /* "MACS2/IO/CallPeakUnit.pyx":1558
  *             except StopIteration:
  *                 # no more strong (aka lvl1) peaks left
  *                 self.__add_broadpeak ( broadpeaks, chrom, lvl2, tmppeakset)             # <<<<<<<<<<<<<<
  *                 tmppeakset = []
  *                 # add the rest lvl2 peaks
  */
-        __Pyx_TraceLine(1556,0,__PYX_ERR(0, 1556, __pyx_L14_except_error))
-        if (unlikely(!__pyx_v_lvl2)) { __Pyx_RaiseUnboundLocalError("lvl2"); __PYX_ERR(0, 1556, __pyx_L14_except_error) }
-        __pyx_t_5 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___add_broadpeak(__pyx_v_self, __pyx_v_broadpeaks, __pyx_v_chrom, __pyx_v_lvl2, __pyx_v_tmppeakset); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1556, __pyx_L14_except_error)
+        __Pyx_TraceLine(1558,0,__PYX_ERR(0, 1558, __pyx_L14_except_error))
+        if (unlikely(!__pyx_v_lvl2)) { __Pyx_RaiseUnboundLocalError("lvl2"); __PYX_ERR(0, 1558, __pyx_L14_except_error) }
+        __pyx_t_5 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___add_broadpeak(__pyx_v_self, __pyx_v_broadpeaks, __pyx_v_chrom, __pyx_v_lvl2, __pyx_v_tmppeakset); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1558, __pyx_L14_except_error)
         __Pyx_GOTREF(__pyx_t_5);
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1557
+        /* "MACS2/IO/CallPeakUnit.pyx":1559
  *                 # no more strong (aka lvl1) peaks left
  *                 self.__add_broadpeak ( broadpeaks, chrom, lvl2, tmppeakset)
  *                 tmppeakset = []             # <<<<<<<<<<<<<<
  *                 # add the rest lvl2 peaks
  *                 for j in range( i+1, len(lvl2peakschrom) ):
  */
-        __Pyx_TraceLine(1557,0,__PYX_ERR(0, 1557, __pyx_L14_except_error))
-        __pyx_t_5 = PyList_New(0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1557, __pyx_L14_except_error)
+        __Pyx_TraceLine(1559,0,__PYX_ERR(0, 1559, __pyx_L14_except_error))
+        __pyx_t_5 = PyList_New(0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1559, __pyx_L14_except_error)
         __Pyx_GOTREF(__pyx_t_5);
         __Pyx_DECREF_SET(__pyx_v_tmppeakset, ((PyObject*)__pyx_t_5));
         __pyx_t_5 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1559
+        /* "MACS2/IO/CallPeakUnit.pyx":1561
  *                 tmppeakset = []
  *                 # add the rest lvl2 peaks
  *                 for j in range( i+1, len(lvl2peakschrom) ):             # <<<<<<<<<<<<<<
  *                     self.__add_broadpeak( broadpeaks, chrom, lvl2peakschrom[j], tmppeakset )
  * 
  */
-        __Pyx_TraceLine(1559,0,__PYX_ERR(0, 1559, __pyx_L14_except_error))
-        __pyx_t_21 = PyObject_Length(__pyx_v_lvl2peakschrom); if (unlikely(__pyx_t_21 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1559, __pyx_L14_except_error)
+        __Pyx_TraceLine(1561,0,__PYX_ERR(0, 1561, __pyx_L14_except_error))
+        __pyx_t_21 = PyObject_Length(__pyx_v_lvl2peakschrom); if (unlikely(__pyx_t_21 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1561, __pyx_L14_except_error)
         __pyx_t_22 = __pyx_t_21;
         for (__pyx_t_23 = (__pyx_v_i + 1); __pyx_t_23 < __pyx_t_22; __pyx_t_23+=1) {
           __pyx_v_j = __pyx_t_23;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1560
+          /* "MACS2/IO/CallPeakUnit.pyx":1562
  *                 # add the rest lvl2 peaks
  *                 for j in range( i+1, len(lvl2peakschrom) ):
  *                     self.__add_broadpeak( broadpeaks, chrom, lvl2peakschrom[j], tmppeakset )             # <<<<<<<<<<<<<<
  * 
  *         return broadpeaks
  */
-          __Pyx_TraceLine(1560,0,__PYX_ERR(0, 1560, __pyx_L14_except_error))
-          __pyx_t_5 = __Pyx_GetItemInt(__pyx_v_lvl2peakschrom, __pyx_v_j, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1560, __pyx_L14_except_error)
+          __Pyx_TraceLine(1562,0,__PYX_ERR(0, 1562, __pyx_L14_except_error))
+          __pyx_t_5 = __Pyx_GetItemInt(__pyx_v_lvl2peakschrom, __pyx_v_j, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1562, __pyx_L14_except_error)
           __Pyx_GOTREF(__pyx_t_5);
-          __pyx_t_4 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___add_broadpeak(__pyx_v_self, __pyx_v_broadpeaks, __pyx_v_chrom, __pyx_t_5, __pyx_v_tmppeakset); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1560, __pyx_L14_except_error)
+          __pyx_t_4 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___add_broadpeak(__pyx_v_self, __pyx_v_broadpeaks, __pyx_v_chrom, __pyx_t_5, __pyx_v_tmppeakset); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1562, __pyx_L14_except_error)
           __Pyx_GOTREF(__pyx_t_4);
           __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
           __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
@@ -21456,7 +21488,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
       goto __pyx_L14_except_error;
       __pyx_L14_except_error:;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1537
+      /* "MACS2/IO/CallPeakUnit.pyx":1539
  *             tmppeakset = []             # to temporarily store lvl1 region inside a lvl2 region
  *             # our assumption is lvl1 regions should be included in lvl2 regions
  *             try:             # <<<<<<<<<<<<<<
@@ -21478,20 +21510,20 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_b
   }
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1562
+  /* "MACS2/IO/CallPeakUnit.pyx":1564
  *                     self.__add_broadpeak( broadpeaks, chrom, lvl2peakschrom[j], tmppeakset )
  * 
  *         return broadpeaks             # <<<<<<<<<<<<<<
  * 
  *     cdef void  __chrom_call_broadpeak_using_certain_criteria ( self, lvl1peaks, lvl2peaks, bytes chrom, list scoring_function_s, list lvl1_cutoff_s, list lvl2_cutoff_s,
  */
-  __Pyx_TraceLine(1562,0,__PYX_ERR(0, 1562, __pyx_L1_error))
+  __Pyx_TraceLine(1564,0,__PYX_ERR(0, 1564, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(__pyx_v_broadpeaks);
   __pyx_r = __pyx_v_broadpeaks;
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1461
+  /* "MACS2/IO/CallPeakUnit.pyx":1463
  *         return True
  * 
  *     cpdef call_broadpeaks (self, list scoring_function_symbols, list lvl1_cutoff_s, list lvl2_cutoff_s, int32_t min_length=200, int32_t lvl1_max_gap=50, int32_t lvl2_max_gap=400, bool cutoff_analysis = False):             # <<<<<<<<<<<<<<
@@ -21578,13 +21610,13 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_11cal
         case  1:
         if (likely((values[1] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_lvl1_cutoff_s)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("call_broadpeaks", 0, 3, 7, 1); __PYX_ERR(0, 1461, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("call_broadpeaks", 0, 3, 7, 1); __PYX_ERR(0, 1463, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  2:
         if (likely((values[2] = __Pyx_PyDict_GetItemStr(__pyx_kwds, __pyx_n_s_lvl2_cutoff_s)) != 0)) kw_args--;
         else {
-          __Pyx_RaiseArgtupleInvalid("call_broadpeaks", 0, 3, 7, 2); __PYX_ERR(0, 1461, __pyx_L3_error)
+          __Pyx_RaiseArgtupleInvalid("call_broadpeaks", 0, 3, 7, 2); __PYX_ERR(0, 1463, __pyx_L3_error)
         }
         CYTHON_FALLTHROUGH;
         case  3:
@@ -21612,7 +21644,7 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_11cal
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "call_broadpeaks") < 0)) __PYX_ERR(0, 1461, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "call_broadpeaks") < 0)) __PYX_ERR(0, 1463, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -21635,17 +21667,17 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_11cal
     __pyx_v_lvl1_cutoff_s = ((PyObject*)values[1]);
     __pyx_v_lvl2_cutoff_s = ((PyObject*)values[2]);
     if (values[3]) {
-      __pyx_v_min_length = __Pyx_PyInt_As_npy_int32(values[3]); if (unlikely((__pyx_v_min_length == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1461, __pyx_L3_error)
+      __pyx_v_min_length = __Pyx_PyInt_As_npy_int32(values[3]); if (unlikely((__pyx_v_min_length == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1463, __pyx_L3_error)
     } else {
       __pyx_v_min_length = ((__pyx_t_5numpy_int32_t)0xC8);
     }
     if (values[4]) {
-      __pyx_v_lvl1_max_gap = __Pyx_PyInt_As_npy_int32(values[4]); if (unlikely((__pyx_v_lvl1_max_gap == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1461, __pyx_L3_error)
+      __pyx_v_lvl1_max_gap = __Pyx_PyInt_As_npy_int32(values[4]); if (unlikely((__pyx_v_lvl1_max_gap == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1463, __pyx_L3_error)
     } else {
       __pyx_v_lvl1_max_gap = ((__pyx_t_5numpy_int32_t)50);
     }
     if (values[5]) {
-      __pyx_v_lvl2_max_gap = __Pyx_PyInt_As_npy_int32(values[5]); if (unlikely((__pyx_v_lvl2_max_gap == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1461, __pyx_L3_error)
+      __pyx_v_lvl2_max_gap = __Pyx_PyInt_As_npy_int32(values[5]); if (unlikely((__pyx_v_lvl2_max_gap == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1463, __pyx_L3_error)
     } else {
       __pyx_v_lvl2_max_gap = ((__pyx_t_5numpy_int32_t)0x190);
     }
@@ -21653,16 +21685,16 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_11cal
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("call_broadpeaks", 0, 3, 7, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 1461, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("call_broadpeaks", 0, 3, 7, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 1463, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("MACS2.IO.CallPeakUnit.CallerFromAlignments.call_broadpeaks", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
   return NULL;
   __pyx_L4_argument_unpacking_done:;
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_scoring_function_symbols), (&PyList_Type), 1, "scoring_function_symbols", 1))) __PYX_ERR(0, 1461, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_lvl1_cutoff_s), (&PyList_Type), 1, "lvl1_cutoff_s", 1))) __PYX_ERR(0, 1461, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_lvl2_cutoff_s), (&PyList_Type), 1, "lvl2_cutoff_s", 1))) __PYX_ERR(0, 1461, __pyx_L1_error)
-  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_cutoff_analysis), __pyx_ptype_7cpython_4bool_bool, 1, "cutoff_analysis", 0))) __PYX_ERR(0, 1461, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_scoring_function_symbols), (&PyList_Type), 1, "scoring_function_symbols", 1))) __PYX_ERR(0, 1463, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_lvl1_cutoff_s), (&PyList_Type), 1, "lvl1_cutoff_s", 1))) __PYX_ERR(0, 1463, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_lvl2_cutoff_s), (&PyList_Type), 1, "lvl2_cutoff_s", 1))) __PYX_ERR(0, 1463, __pyx_L1_error)
+  if (unlikely(!__Pyx_ArgTypeTest(((PyObject *)__pyx_v_cutoff_analysis), __pyx_ptype_7cpython_4bool_bool, 1, "cutoff_analysis", 0))) __PYX_ERR(0, 1463, __pyx_L1_error)
   __pyx_r = __pyx_pf_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_10call_broadpeaks(((struct __pyx_obj_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self), __pyx_v_scoring_function_symbols, __pyx_v_lvl1_cutoff_s, __pyx_v_lvl2_cutoff_s, __pyx_v_min_length, __pyx_v_lvl1_max_gap, __pyx_v_lvl2_max_gap, __pyx_v_cutoff_analysis);
 
   /* function exit code */
@@ -21681,14 +21713,14 @@ static PyObject *__pyx_pf_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_10cal
   PyObject *__pyx_t_1 = NULL;
   struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_call_broadpeaks __pyx_t_2;
   __Pyx_RefNannySetupContext("call_broadpeaks", 0);
-  __Pyx_TraceCall("call_broadpeaks (wrapper)", __pyx_f[0], 1461, 0, __PYX_ERR(0, 1461, __pyx_L1_error));
+  __Pyx_TraceCall("call_broadpeaks (wrapper)", __pyx_f[0], 1463, 0, __PYX_ERR(0, 1463, __pyx_L1_error));
   __Pyx_XDECREF(__pyx_r);
   __pyx_t_2.__pyx_n = 4;
   __pyx_t_2.min_length = __pyx_v_min_length;
   __pyx_t_2.lvl1_max_gap = __pyx_v_lvl1_max_gap;
   __pyx_t_2.lvl2_max_gap = __pyx_v_lvl2_max_gap;
   __pyx_t_2.cutoff_analysis = __pyx_v_cutoff_analysis;
-  __pyx_t_1 = __pyx_vtabptr_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments->call_broadpeaks(__pyx_v_self, __pyx_v_scoring_function_symbols, __pyx_v_lvl1_cutoff_s, __pyx_v_lvl2_cutoff_s, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1461, __pyx_L1_error)
+  __pyx_t_1 = __pyx_vtabptr_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments->call_broadpeaks(__pyx_v_self, __pyx_v_scoring_function_symbols, __pyx_v_lvl1_cutoff_s, __pyx_v_lvl2_cutoff_s, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1463, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -21706,7 +21738,7 @@ static PyObject *__pyx_pf_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_10cal
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1564
+/* "MACS2/IO/CallPeakUnit.pyx":1566
  *         return broadpeaks
  * 
  *     cdef void  __chrom_call_broadpeak_using_certain_criteria ( self, lvl1peaks, lvl2peaks, bytes chrom, list scoring_function_s, list lvl1_cutoff_s, list lvl2_cutoff_s,             # <<<<<<<<<<<<<<
@@ -21753,82 +21785,82 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   long __pyx_t_11;
   long __pyx_t_12;
   __Pyx_RefNannySetupContext("__chrom_call_broadpeak_using_certain_criteria", 0);
-  __Pyx_TraceCall("__chrom_call_broadpeak_using_certain_criteria", __pyx_f[0], 1564, 0, __PYX_ERR(0, 1564, __pyx_L1_error));
+  __Pyx_TraceCall("__chrom_call_broadpeak_using_certain_criteria", __pyx_f[0], 1566, 0, __PYX_ERR(0, 1566, __pyx_L1_error));
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1588
+  /* "MACS2/IO/CallPeakUnit.pyx":1590
  *             float32_t * ctrl_array_ptr
  * 
  *         assert len(scoring_function_s) == len(lvl1_cutoff_s), "number of functions and cutoffs should be the same!"             # <<<<<<<<<<<<<<
  *         assert len(scoring_function_s) == len(lvl2_cutoff_s), "number of functions and cutoffs should be the same!"
  * 
  */
-  __Pyx_TraceLine(1588,0,__PYX_ERR(0, 1588, __pyx_L1_error))
+  __Pyx_TraceLine(1590,0,__PYX_ERR(0, 1590, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(__pyx_v_scoring_function_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1588, __pyx_L1_error)
+      __PYX_ERR(0, 1590, __pyx_L1_error)
     }
-    __pyx_t_1 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1588, __pyx_L1_error)
+    __pyx_t_1 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1590, __pyx_L1_error)
     if (unlikely(__pyx_v_lvl1_cutoff_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1588, __pyx_L1_error)
+      __PYX_ERR(0, 1590, __pyx_L1_error)
     }
-    __pyx_t_2 = PyList_GET_SIZE(__pyx_v_lvl1_cutoff_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1588, __pyx_L1_error)
+    __pyx_t_2 = PyList_GET_SIZE(__pyx_v_lvl1_cutoff_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1590, __pyx_L1_error)
     if (unlikely(!((__pyx_t_1 == __pyx_t_2) != 0))) {
       PyErr_SetObject(PyExc_AssertionError, __pyx_kp_u_number_of_functions_and_cutoffs);
-      __PYX_ERR(0, 1588, __pyx_L1_error)
+      __PYX_ERR(0, 1590, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1589
+  /* "MACS2/IO/CallPeakUnit.pyx":1591
  * 
  *         assert len(scoring_function_s) == len(lvl1_cutoff_s), "number of functions and cutoffs should be the same!"
  *         assert len(scoring_function_s) == len(lvl2_cutoff_s), "number of functions and cutoffs should be the same!"             # <<<<<<<<<<<<<<
  * 
  *         # first, build pileup, self.chr_pos_treat_ctrl
  */
-  __Pyx_TraceLine(1589,0,__PYX_ERR(0, 1589, __pyx_L1_error))
+  __Pyx_TraceLine(1591,0,__PYX_ERR(0, 1591, __pyx_L1_error))
   #ifndef CYTHON_WITHOUT_ASSERTIONS
   if (unlikely(!Py_OptimizeFlag)) {
     if (unlikely(__pyx_v_scoring_function_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1589, __pyx_L1_error)
+      __PYX_ERR(0, 1591, __pyx_L1_error)
     }
-    __pyx_t_2 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1589, __pyx_L1_error)
+    __pyx_t_2 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_2 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1591, __pyx_L1_error)
     if (unlikely(__pyx_v_lvl2_cutoff_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1589, __pyx_L1_error)
+      __PYX_ERR(0, 1591, __pyx_L1_error)
     }
-    __pyx_t_1 = PyList_GET_SIZE(__pyx_v_lvl2_cutoff_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1589, __pyx_L1_error)
+    __pyx_t_1 = PyList_GET_SIZE(__pyx_v_lvl2_cutoff_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1591, __pyx_L1_error)
     if (unlikely(!((__pyx_t_2 == __pyx_t_1) != 0))) {
       PyErr_SetObject(PyExc_AssertionError, __pyx_kp_u_number_of_functions_and_cutoffs);
-      __PYX_ERR(0, 1589, __pyx_L1_error)
+      __PYX_ERR(0, 1591, __pyx_L1_error)
     }
   }
   #endif
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1592
+  /* "MACS2/IO/CallPeakUnit.pyx":1594
  * 
  *         # first, build pileup, self.chr_pos_treat_ctrl
  *         self.__pileup_treat_ctrl_a_chromosome( chrom )             # <<<<<<<<<<<<<<
  *         [pos_array, treat_array, ctrl_array] = self.chr_pos_treat_ctrl
  * 
  */
-  __Pyx_TraceLine(1592,0,__PYX_ERR(0, 1592, __pyx_L1_error))
-  __pyx_t_3 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___pileup_treat_ctrl_a_chromosome(__pyx_v_self, __pyx_v_chrom); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1592, __pyx_L1_error)
+  __Pyx_TraceLine(1594,0,__PYX_ERR(0, 1594, __pyx_L1_error))
+  __pyx_t_3 = ((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___pileup_treat_ctrl_a_chromosome(__pyx_v_self, __pyx_v_chrom); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1594, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1593
+  /* "MACS2/IO/CallPeakUnit.pyx":1595
  *         # first, build pileup, self.chr_pos_treat_ctrl
  *         self.__pileup_treat_ctrl_a_chromosome( chrom )
  *         [pos_array, treat_array, ctrl_array] = self.chr_pos_treat_ctrl             # <<<<<<<<<<<<<<
  * 
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  */
-  __Pyx_TraceLine(1593,0,__PYX_ERR(0, 1593, __pyx_L1_error))
+  __Pyx_TraceLine(1595,0,__PYX_ERR(0, 1595, __pyx_L1_error))
   __pyx_t_3 = __pyx_v_self->chr_pos_treat_ctrl;
   __Pyx_INCREF(__pyx_t_3);
   if (likely(__pyx_t_3 != Py_None)) {
@@ -21837,7 +21869,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     if (unlikely(size != 3)) {
       if (size > 3) __Pyx_RaiseTooManyValuesError(3);
       else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-      __PYX_ERR(0, 1593, __pyx_L1_error)
+      __PYX_ERR(0, 1595, __pyx_L1_error)
     }
     #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
     __pyx_t_4 = PyList_GET_ITEM(sequence, 0); 
@@ -21847,20 +21879,20 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     __Pyx_INCREF(__pyx_t_5);
     __Pyx_INCREF(__pyx_t_6);
     #else
-    __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1593, __pyx_L1_error)
+    __pyx_t_4 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1595, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_4);
-    __pyx_t_5 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1593, __pyx_L1_error)
+    __pyx_t_5 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1595, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_6 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1593, __pyx_L1_error)
+    __pyx_t_6 = PySequence_ITEM(sequence, 2); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1595, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     #endif
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   } else {
-    __Pyx_RaiseNoneNotIterableError(); __PYX_ERR(0, 1593, __pyx_L1_error)
+    __Pyx_RaiseNoneNotIterableError(); __PYX_ERR(0, 1595, __pyx_L1_error)
   }
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1593, __pyx_L1_error)
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1593, __pyx_L1_error)
-  if (!(likely(((__pyx_t_6) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1593, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1595, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1595, __pyx_L1_error)
+  if (!(likely(((__pyx_t_6) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_6, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1595, __pyx_L1_error)
   __pyx_v_pos_array = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
   __pyx_v_treat_array = ((PyArrayObject *)__pyx_t_5);
@@ -21868,30 +21900,30 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __pyx_v_ctrl_array = ((PyArrayObject *)__pyx_t_6);
   __pyx_t_6 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1596
+  /* "MACS2/IO/CallPeakUnit.pyx":1598
  * 
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  *         if save_bedGraph:             # <<<<<<<<<<<<<<
  *             self.__write_bedGraph_for_a_chromosome ( chrom )
  * 
  */
-  __Pyx_TraceLine(1596,0,__PYX_ERR(0, 1596, __pyx_L1_error))
-  __pyx_t_7 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_save_bedGraph)); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1596, __pyx_L1_error)
+  __Pyx_TraceLine(1598,0,__PYX_ERR(0, 1598, __pyx_L1_error))
+  __pyx_t_7 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_save_bedGraph)); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1598, __pyx_L1_error)
   if (__pyx_t_7) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1597
+    /* "MACS2/IO/CallPeakUnit.pyx":1599
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  *         if save_bedGraph:
  *             self.__write_bedGraph_for_a_chromosome ( chrom )             # <<<<<<<<<<<<<<
  * 
  *         # keep all types of scores needed
  */
-    __Pyx_TraceLine(1597,0,__PYX_ERR(0, 1597, __pyx_L1_error))
-    __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___write_bedGraph_for_a_chromosome(__pyx_v_self, __pyx_v_chrom)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1597, __pyx_L1_error)
+    __Pyx_TraceLine(1599,0,__PYX_ERR(0, 1599, __pyx_L1_error))
+    __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___write_bedGraph_for_a_chromosome(__pyx_v_self, __pyx_v_chrom)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1599, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1596
+    /* "MACS2/IO/CallPeakUnit.pyx":1598
  * 
  *         # while save_bedGraph is true, invoke __write_bedGraph_for_a_chromosome
  *         if save_bedGraph:             # <<<<<<<<<<<<<<
@@ -21900,80 +21932,80 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1600
+  /* "MACS2/IO/CallPeakUnit.pyx":1602
  * 
  *         # keep all types of scores needed
  *         score_array_s = []             # <<<<<<<<<<<<<<
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]
  */
-  __Pyx_TraceLine(1600,0,__PYX_ERR(0, 1600, __pyx_L1_error))
-  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1600, __pyx_L1_error)
+  __Pyx_TraceLine(1602,0,__PYX_ERR(0, 1602, __pyx_L1_error))
+  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1602, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_v_score_array_s = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1601
+  /* "MACS2/IO/CallPeakUnit.pyx":1603
  *         # keep all types of scores needed
  *         score_array_s = []
  *         for i in range(len(scoring_function_s)):             # <<<<<<<<<<<<<<
  *             s = scoring_function_s[i]
  *             if s == 'p':
  */
-  __Pyx_TraceLine(1601,0,__PYX_ERR(0, 1601, __pyx_L1_error))
+  __Pyx_TraceLine(1603,0,__PYX_ERR(0, 1603, __pyx_L1_error))
   if (unlikely(__pyx_v_scoring_function_s == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 1601, __pyx_L1_error)
+    __PYX_ERR(0, 1603, __pyx_L1_error)
   }
-  __pyx_t_1 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1601, __pyx_L1_error)
+  __pyx_t_1 = PyList_GET_SIZE(__pyx_v_scoring_function_s); if (unlikely(__pyx_t_1 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1603, __pyx_L1_error)
   __pyx_t_2 = __pyx_t_1;
   for (__pyx_t_8 = 0; __pyx_t_8 < __pyx_t_2; __pyx_t_8+=1) {
     __pyx_v_i = __pyx_t_8;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1602
+    /* "MACS2/IO/CallPeakUnit.pyx":1604
  *         score_array_s = []
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]             # <<<<<<<<<<<<<<
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  */
-    __Pyx_TraceLine(1602,0,__PYX_ERR(0, 1602, __pyx_L1_error))
+    __Pyx_TraceLine(1604,0,__PYX_ERR(0, 1604, __pyx_L1_error))
     if (unlikely(__pyx_v_scoring_function_s == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1602, __pyx_L1_error)
+      __PYX_ERR(0, 1604, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_scoring_function_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1602, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_scoring_function_s, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1604, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    if (!(likely(PyUnicode_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "unicode", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 1602, __pyx_L1_error)
+    if (!(likely(PyUnicode_CheckExact(__pyx_t_3))||((__pyx_t_3) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "unicode", Py_TYPE(__pyx_t_3)->tp_name), 0))) __PYX_ERR(0, 1604, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_s, ((PyObject*)__pyx_t_3));
     __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1603
+    /* "MACS2/IO/CallPeakUnit.pyx":1605
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]
  *             if s == 'p':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':
  */
-    __Pyx_TraceLine(1603,0,__PYX_ERR(0, 1603, __pyx_L1_error))
-    __pyx_t_7 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_p, Py_EQ)); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1603, __pyx_L1_error)
+    __Pyx_TraceLine(1605,0,__PYX_ERR(0, 1605, __pyx_L1_error))
+    __pyx_t_7 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_p, Py_EQ)); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1605, __pyx_L1_error)
     __pyx_t_9 = (__pyx_t_7 != 0);
     if (__pyx_t_9) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1604
+      /* "MACS2/IO/CallPeakUnit.pyx":1606
  *             s = scoring_function_s[i]
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  */
-      __Pyx_TraceLine(1604,0,__PYX_ERR(0, 1604, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1604, __pyx_L1_error)
+      __Pyx_TraceLine(1606,0,__PYX_ERR(0, 1606, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1606, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1604, __pyx_L1_error)
+      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1606, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1603
+      /* "MACS2/IO/CallPeakUnit.pyx":1605
  *         for i in range(len(scoring_function_s)):
  *             s = scoring_function_s[i]
  *             if s == 'p':             # <<<<<<<<<<<<<<
@@ -21983,32 +22015,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1605
+    /* "MACS2/IO/CallPeakUnit.pyx":1607
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':
  */
-    __Pyx_TraceLine(1605,0,__PYX_ERR(0, 1605, __pyx_L1_error))
-    __pyx_t_9 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_q, Py_EQ)); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1605, __pyx_L1_error)
+    __Pyx_TraceLine(1607,0,__PYX_ERR(0, 1607, __pyx_L1_error))
+    __pyx_t_9 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_q, Py_EQ)); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1607, __pyx_L1_error)
     __pyx_t_7 = (__pyx_t_9 != 0);
     if (__pyx_t_7) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1606
+      /* "MACS2/IO/CallPeakUnit.pyx":1608
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  */
-      __Pyx_TraceLine(1606,0,__PYX_ERR(0, 1606, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_qscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1606, __pyx_L1_error)
+      __Pyx_TraceLine(1608,0,__PYX_ERR(0, 1608, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_qscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1608, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1606, __pyx_L1_error)
+      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1608, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1605
+      /* "MACS2/IO/CallPeakUnit.pyx":1607
  *             if s == 'p':
  *                 score_array_s.append( self.__cal_pscore( treat_array, ctrl_array ) )
  *             elif s == 'q':             # <<<<<<<<<<<<<<
@@ -22018,32 +22050,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1607
+    /* "MACS2/IO/CallPeakUnit.pyx":1609
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':
  */
-    __Pyx_TraceLine(1607,0,__PYX_ERR(0, 1607, __pyx_L1_error))
-    __pyx_t_7 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_f, Py_EQ)); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1607, __pyx_L1_error)
+    __Pyx_TraceLine(1609,0,__PYX_ERR(0, 1609, __pyx_L1_error))
+    __pyx_t_7 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_f, Py_EQ)); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1609, __pyx_L1_error)
     __pyx_t_9 = (__pyx_t_7 != 0);
     if (__pyx_t_9) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1608
+      /* "MACS2/IO/CallPeakUnit.pyx":1610
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  *             elif s == 's':
  *                 score_array_s.append( self.__cal_subtraction( treat_array, ctrl_array ) )
  */
-      __Pyx_TraceLine(1608,0,__PYX_ERR(0, 1608, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_FE(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1608, __pyx_L1_error)
+      __Pyx_TraceLine(1610,0,__PYX_ERR(0, 1610, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_FE(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1610, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1608, __pyx_L1_error)
+      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1610, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1607
+      /* "MACS2/IO/CallPeakUnit.pyx":1609
  *             elif s == 'q':
  *                 score_array_s.append( self.__cal_qscore( treat_array, ctrl_array ) )
  *             elif s == 'f':             # <<<<<<<<<<<<<<
@@ -22053,32 +22085,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L6;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1609
+    /* "MACS2/IO/CallPeakUnit.pyx":1611
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':             # <<<<<<<<<<<<<<
  *                 score_array_s.append( self.__cal_subtraction( treat_array, ctrl_array ) )
  * 
  */
-    __Pyx_TraceLine(1609,0,__PYX_ERR(0, 1609, __pyx_L1_error))
-    __pyx_t_9 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_s, Py_EQ)); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1609, __pyx_L1_error)
+    __Pyx_TraceLine(1611,0,__PYX_ERR(0, 1611, __pyx_L1_error))
+    __pyx_t_9 = (__Pyx_PyUnicode_Equals(__pyx_v_s, __pyx_n_u_s, Py_EQ)); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1611, __pyx_L1_error)
     __pyx_t_7 = (__pyx_t_9 != 0);
     if (__pyx_t_7) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1610
+      /* "MACS2/IO/CallPeakUnit.pyx":1612
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':
  *                 score_array_s.append( self.__cal_subtraction( treat_array, ctrl_array ) )             # <<<<<<<<<<<<<<
  * 
  *         # lvl1 : strong peaks
  */
-      __Pyx_TraceLine(1610,0,__PYX_ERR(0, 1610, __pyx_L1_error))
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_subtraction(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1610, __pyx_L1_error)
+      __Pyx_TraceLine(1612,0,__PYX_ERR(0, 1612, __pyx_L1_error))
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_subtraction(__pyx_v_self, ((PyArrayObject *)__pyx_v_treat_array), ((PyArrayObject *)__pyx_v_ctrl_array))); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1612, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1610, __pyx_L1_error)
+      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_score_array_s, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1612, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1609
+      /* "MACS2/IO/CallPeakUnit.pyx":1611
  *             elif s == 'f':
  *                 score_array_s.append( self.__cal_FE( treat_array, ctrl_array ) )
  *             elif s == 's':             # <<<<<<<<<<<<<<
@@ -22089,33 +22121,33 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     __pyx_L6:;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1613
+  /* "MACS2/IO/CallPeakUnit.pyx":1615
  * 
  *         # lvl1 : strong peaks
  *         peak_content = []           # to store points above cutoff             # <<<<<<<<<<<<<<
  * 
  *         # get the regions with scores above cutoffs
  */
-  __Pyx_TraceLine(1613,0,__PYX_ERR(0, 1613, __pyx_L1_error))
-  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1613, __pyx_L1_error)
+  __Pyx_TraceLine(1615,0,__PYX_ERR(0, 1615, __pyx_L1_error))
+  __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1615, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __pyx_v_peak_content = ((PyObject*)__pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1616
+  /* "MACS2/IO/CallPeakUnit.pyx":1618
  * 
  *         # get the regions with scores above cutoffs
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,lvl1_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?             # <<<<<<<<<<<<<<
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  */
-  __Pyx_TraceLine(1616,0,__PYX_ERR(0, 1616, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1616, __pyx_L1_error)
+  __Pyx_TraceLine(1618,0,__PYX_ERR(0, 1618, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_6, __pyx_n_s_np); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1618, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_nonzero); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1616, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_nonzero); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1618, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = ((PyObject *)__pyx_f_5MACS2_2IO_12CallPeakUnit_apply_multiple_cutoffs(__pyx_v_score_array_s, __pyx_v_lvl1_cutoff_s)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1616, __pyx_L1_error)
+  __pyx_t_6 = ((PyObject *)__pyx_f_5MACS2_2IO_12CallPeakUnit_apply_multiple_cutoffs(__pyx_v_score_array_s, __pyx_v_lvl1_cutoff_s)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1618, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_t_4 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -22130,110 +22162,110 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __pyx_t_3 = (__pyx_t_4) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_4, __pyx_t_6) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_6);
   __Pyx_XDECREF(__pyx_t_4); __pyx_t_4 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1616, __pyx_L1_error)
+  if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1618, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1616, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1618, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1616, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1618, __pyx_L1_error)
   __pyx_v_above_cutoff = ((PyArrayObject *)__pyx_t_5);
   __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1617
+  /* "MACS2/IO/CallPeakUnit.pyx":1619
  *         # get the regions with scores above cutoffs
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,lvl1_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices             # <<<<<<<<<<<<<<
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  */
-  __Pyx_TraceLine(1617,0,__PYX_ERR(0, 1617, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1617, __pyx_L1_error)
+  __Pyx_TraceLine(1619,0,__PYX_ERR(0, 1619, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1619, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_arange); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1617, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_arange); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1619, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_pos_array->dimensions[0])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1617, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_pos_array->dimensions[0])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1619, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1617, __pyx_L1_error)
+  __pyx_t_6 = PyTuple_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1619, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_GIVEREF(__pyx_t_5);
   PyTuple_SET_ITEM(__pyx_t_6, 0, __pyx_t_5);
   __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1617, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1619, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1617, __pyx_L1_error)
-  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_6, __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1617, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_5, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1619, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_6, __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1619, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = __Pyx_PyObject_GetItem(__pyx_t_4, ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1617, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetItem(__pyx_t_4, ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1619, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1617, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1619, __pyx_L1_error)
   __pyx_v_above_cutoff_index_array = ((PyArrayObject *)__pyx_t_5);
   __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1618
+  /* "MACS2/IO/CallPeakUnit.pyx":1620
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,lvl1_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff             # <<<<<<<<<<<<<<
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  */
-  __Pyx_TraceLine(1618,0,__PYX_ERR(0, 1618, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1618, __pyx_L1_error)
+  __Pyx_TraceLine(1620,0,__PYX_ERR(0, 1620, __pyx_L1_error))
+  __pyx_t_5 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1620, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1618, __pyx_L1_error)
+  if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1620, __pyx_L1_error)
   __pyx_v_above_cutoff_endpos = ((PyArrayObject *)__pyx_t_5);
   __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1619
+  /* "MACS2/IO/CallPeakUnit.pyx":1621
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff             # <<<<<<<<<<<<<<
  * 
  *         if above_cutoff.size == 0:
  */
-  __Pyx_TraceLine(1619,0,__PYX_ERR(0, 1619, __pyx_L1_error))
-  __pyx_t_5 = PyNumber_Subtract(((PyObject *)__pyx_v_above_cutoff), __pyx_int_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1619, __pyx_L1_error)
+  __Pyx_TraceLine(1621,0,__PYX_ERR(0, 1621, __pyx_L1_error))
+  __pyx_t_5 = PyNumber_Subtract(((PyObject *)__pyx_v_above_cutoff), __pyx_int_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1621, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1619, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), __pyx_t_5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1621, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1619, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1621, __pyx_L1_error)
   __pyx_v_above_cutoff_startpos = ((PyArrayObject *)__pyx_t_4);
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1621
+  /* "MACS2/IO/CallPeakUnit.pyx":1623
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  *         if above_cutoff.size == 0:             # <<<<<<<<<<<<<<
  *             # nothing above cutoff
  *             return
  */
-  __Pyx_TraceLine(1621,0,__PYX_ERR(0, 1621, __pyx_L1_error))
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff), __pyx_n_s_size); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1621, __pyx_L1_error)
+  __Pyx_TraceLine(1623,0,__PYX_ERR(0, 1623, __pyx_L1_error))
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff), __pyx_n_s_size); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1623, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyInt_EqObjC(__pyx_t_4, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1621, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_EqObjC(__pyx_t_4, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1623, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1621, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1623, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   if (__pyx_t_7) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1623
+    /* "MACS2/IO/CallPeakUnit.pyx":1625
  *         if above_cutoff.size == 0:
  *             # nothing above cutoff
  *             return             # <<<<<<<<<<<<<<
  * 
  *         if above_cutoff[0] == 0:
  */
-    __Pyx_TraceLine(1623,0,__PYX_ERR(0, 1623, __pyx_L1_error))
+    __Pyx_TraceLine(1625,0,__PYX_ERR(0, 1625, __pyx_L1_error))
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1621
+    /* "MACS2/IO/CallPeakUnit.pyx":1623
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  *         if above_cutoff.size == 0:             # <<<<<<<<<<<<<<
@@ -22242,34 +22274,34 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1625
+  /* "MACS2/IO/CallPeakUnit.pyx":1627
  *             return
  * 
  *         if above_cutoff[0] == 0:             # <<<<<<<<<<<<<<
  *             # first element > cutoff, fix the first point as 0. otherwise it would be the last item in data[chrom]['pos']
  *             above_cutoff_startpos[0] = 0
  */
-  __Pyx_TraceLine(1625,0,__PYX_ERR(0, 1625, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_above_cutoff), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1625, __pyx_L1_error)
+  __Pyx_TraceLine(1627,0,__PYX_ERR(0, 1627, __pyx_L1_error))
+  __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_above_cutoff), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1627, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_5, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1625, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_5, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1627, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1625, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1627, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   if (__pyx_t_7) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1627
+    /* "MACS2/IO/CallPeakUnit.pyx":1629
  *         if above_cutoff[0] == 0:
  *             # first element > cutoff, fix the first point as 0. otherwise it would be the last item in data[chrom]['pos']
  *             above_cutoff_startpos[0] = 0             # <<<<<<<<<<<<<<
  * 
  *         # first bit of region above cutoff
  */
-    __Pyx_TraceLine(1627,0,__PYX_ERR(0, 1627, __pyx_L1_error))
-    if (unlikely(__Pyx_SetItemInt(((PyObject *)__pyx_v_above_cutoff_startpos), 0, __pyx_int_0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1) < 0)) __PYX_ERR(0, 1627, __pyx_L1_error)
+    __Pyx_TraceLine(1629,0,__PYX_ERR(0, 1629, __pyx_L1_error))
+    if (unlikely(__Pyx_SetItemInt(((PyObject *)__pyx_v_above_cutoff_startpos), 0, __pyx_int_0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1) < 0)) __PYX_ERR(0, 1629, __pyx_L1_error)
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1625
+    /* "MACS2/IO/CallPeakUnit.pyx":1627
  *             return
  * 
  *         if above_cutoff[0] == 0:             # <<<<<<<<<<<<<<
@@ -22278,128 +22310,128 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1630
+  /* "MACS2/IO/CallPeakUnit.pyx":1632
  * 
  *         # first bit of region above cutoff
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data             # <<<<<<<<<<<<<<
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  */
-  __Pyx_TraceLine(1630,0,__PYX_ERR(0, 1630, __pyx_L1_error))
+  __Pyx_TraceLine(1632,0,__PYX_ERR(0, 1632, __pyx_L1_error))
   __pyx_v_acs_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_startpos->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1631
+  /* "MACS2/IO/CallPeakUnit.pyx":1633
  *         # first bit of region above cutoff
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data             # <<<<<<<<<<<<<<
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  */
-  __Pyx_TraceLine(1631,0,__PYX_ERR(0, 1631, __pyx_L1_error))
+  __Pyx_TraceLine(1633,0,__PYX_ERR(0, 1633, __pyx_L1_error))
   __pyx_v_ace_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_endpos->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1632
+  /* "MACS2/IO/CallPeakUnit.pyx":1634
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data             # <<<<<<<<<<<<<<
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  */
-  __Pyx_TraceLine(1632,0,__PYX_ERR(0, 1632, __pyx_L1_error))
+  __Pyx_TraceLine(1634,0,__PYX_ERR(0, 1634, __pyx_L1_error))
   __pyx_v_acia_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_index_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1633
+  /* "MACS2/IO/CallPeakUnit.pyx":1635
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data             # <<<<<<<<<<<<<<
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  */
-  __Pyx_TraceLine(1633,0,__PYX_ERR(0, 1633, __pyx_L1_error))
+  __Pyx_TraceLine(1635,0,__PYX_ERR(0, 1635, __pyx_L1_error))
   __pyx_v_treat_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_treat_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1634
+  /* "MACS2/IO/CallPeakUnit.pyx":1636
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data             # <<<<<<<<<<<<<<
  * 
  *         ts = acs_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1634,0,__PYX_ERR(0, 1634, __pyx_L1_error))
+  __Pyx_TraceLine(1636,0,__PYX_ERR(0, 1636, __pyx_L1_error))
   __pyx_v_ctrl_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_ctrl_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1636
+  /* "MACS2/IO/CallPeakUnit.pyx":1638
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  *         ts = acs_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1636,0,__PYX_ERR(0, 1636, __pyx_L1_error))
-  __pyx_t_4 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1636, __pyx_L1_error)
+  __Pyx_TraceLine(1638,0,__PYX_ERR(0, 1638, __pyx_L1_error))
+  __pyx_t_4 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1638, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_v_ts = __pyx_t_4;
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1637
+  /* "MACS2/IO/CallPeakUnit.pyx":1639
  * 
  *         ts = acs_ptr[ 0 ]
  *         te = ace_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]
  */
-  __Pyx_TraceLine(1637,0,__PYX_ERR(0, 1637, __pyx_L1_error))
+  __Pyx_TraceLine(1639,0,__PYX_ERR(0, 1639, __pyx_L1_error))
   __pyx_v_te = (__pyx_v_ace_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1638
+  /* "MACS2/IO/CallPeakUnit.pyx":1640
  *         ts = acs_ptr[ 0 ]
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         tp = treat_array_ptr[ ti ]
  *         cp = ctrl_array_ptr[ ti ]
  */
-  __Pyx_TraceLine(1638,0,__PYX_ERR(0, 1638, __pyx_L1_error))
+  __Pyx_TraceLine(1640,0,__PYX_ERR(0, 1640, __pyx_L1_error))
   __pyx_v_ti = (__pyx_v_acia_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1639
+  /* "MACS2/IO/CallPeakUnit.pyx":1641
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *         cp = ctrl_array_ptr[ ti ]
  * 
  */
-  __Pyx_TraceLine(1639,0,__PYX_ERR(0, 1639, __pyx_L1_error))
-  __pyx_t_4 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1639, __pyx_L1_error)
+  __Pyx_TraceLine(1641,0,__PYX_ERR(0, 1641, __pyx_L1_error))
+  __pyx_t_4 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1641, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_v_tp = __pyx_t_4;
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1640
+  /* "MACS2/IO/CallPeakUnit.pyx":1642
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]
  *         cp = ctrl_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  * 
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  */
-  __Pyx_TraceLine(1640,0,__PYX_ERR(0, 1640, __pyx_L1_error))
-  __pyx_t_4 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1640, __pyx_L1_error)
+  __Pyx_TraceLine(1642,0,__PYX_ERR(0, 1642, __pyx_L1_error))
+  __pyx_t_4 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1642, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __pyx_v_cp = __pyx_t_4;
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1642
+  /* "MACS2/IO/CallPeakUnit.pyx":1644
  *         cp = ctrl_array_ptr[ ti ]
  * 
  *         peak_content.append( ( ts, te, tp, cp, ti ) )             # <<<<<<<<<<<<<<
  *         acs_ptr += 1 # move ptr
  *         ace_ptr += 1
  */
-  __Pyx_TraceLine(1642,0,__PYX_ERR(0, 1642, __pyx_L1_error))
-  __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1642, __pyx_L1_error)
+  __Pyx_TraceLine(1644,0,__PYX_ERR(0, 1644, __pyx_L1_error))
+  __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1644, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1642, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1644, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_6 = PyTuple_New(5); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1642, __pyx_L1_error)
+  __pyx_t_6 = PyTuple_New(5); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1644, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_INCREF(__pyx_v_ts);
   __Pyx_GIVEREF(__pyx_v_ts);
@@ -22416,199 +22448,199 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   PyTuple_SET_ITEM(__pyx_t_6, 4, __pyx_t_5);
   __pyx_t_4 = 0;
   __pyx_t_5 = 0;
-  __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_6); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1642, __pyx_L1_error)
+  __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_6); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1644, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1643
+  /* "MACS2/IO/CallPeakUnit.pyx":1645
  * 
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  *         acs_ptr += 1 # move ptr             # <<<<<<<<<<<<<<
  *         ace_ptr += 1
  *         acia_ptr+= 1
  */
-  __Pyx_TraceLine(1643,0,__PYX_ERR(0, 1643, __pyx_L1_error))
+  __Pyx_TraceLine(1645,0,__PYX_ERR(0, 1645, __pyx_L1_error))
   __pyx_v_acs_ptr = (__pyx_v_acs_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1644
+  /* "MACS2/IO/CallPeakUnit.pyx":1646
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  *         acs_ptr += 1 # move ptr
  *         ace_ptr += 1             # <<<<<<<<<<<<<<
  *         acia_ptr+= 1
  *         lastp = te
  */
-  __Pyx_TraceLine(1644,0,__PYX_ERR(0, 1644, __pyx_L1_error))
+  __Pyx_TraceLine(1646,0,__PYX_ERR(0, 1646, __pyx_L1_error))
   __pyx_v_ace_ptr = (__pyx_v_ace_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1645
+  /* "MACS2/IO/CallPeakUnit.pyx":1647
  *         acs_ptr += 1 # move ptr
  *         ace_ptr += 1
  *         acia_ptr+= 1             # <<<<<<<<<<<<<<
  *         lastp = te
  * 
  */
-  __Pyx_TraceLine(1645,0,__PYX_ERR(0, 1645, __pyx_L1_error))
+  __Pyx_TraceLine(1647,0,__PYX_ERR(0, 1647, __pyx_L1_error))
   __pyx_v_acia_ptr = (__pyx_v_acia_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1646
+  /* "MACS2/IO/CallPeakUnit.pyx":1648
  *         ace_ptr += 1
  *         acia_ptr+= 1
  *         lastp = te             # <<<<<<<<<<<<<<
  * 
  *         #peak_content.append( (above_cutoff_startpos[0], above_cutoff_endpos[0], treat_array[above_cutoff_index_array[0]], ctrl_array[above_cutoff_index_array[0]], score_array_s, above_cutoff_index_array[0] ) )
  */
-  __Pyx_TraceLine(1646,0,__PYX_ERR(0, 1646, __pyx_L1_error))
-  __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1646, __pyx_L1_error)
+  __Pyx_TraceLine(1648,0,__PYX_ERR(0, 1648, __pyx_L1_error))
+  __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1648, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __pyx_v_lastp = __pyx_t_6;
   __pyx_t_6 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1649
+  /* "MACS2/IO/CallPeakUnit.pyx":1651
  * 
  *         #peak_content.append( (above_cutoff_startpos[0], above_cutoff_endpos[0], treat_array[above_cutoff_index_array[0]], ctrl_array[above_cutoff_index_array[0]], score_array_s, above_cutoff_index_array[0] ) )
  *         for i in range( 1, above_cutoff_startpos.size ):             # <<<<<<<<<<<<<<
  *             ts = acs_ptr[ 0 ]
  *             te = ace_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1649,0,__PYX_ERR(0, 1649, __pyx_L1_error))
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff_startpos), __pyx_n_s_size); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1649, __pyx_L1_error)
+  __Pyx_TraceLine(1651,0,__PYX_ERR(0, 1651, __pyx_L1_error))
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff_startpos), __pyx_n_s_size); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1651, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_11 = __Pyx_PyInt_As_long(__pyx_t_6); if (unlikely((__pyx_t_11 == (long)-1) && PyErr_Occurred())) __PYX_ERR(0, 1649, __pyx_L1_error)
+  __pyx_t_11 = __Pyx_PyInt_As_long(__pyx_t_6); if (unlikely((__pyx_t_11 == (long)-1) && PyErr_Occurred())) __PYX_ERR(0, 1651, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_12 = __pyx_t_11;
   for (__pyx_t_8 = 1; __pyx_t_8 < __pyx_t_12; __pyx_t_8+=1) {
     __pyx_v_i = __pyx_t_8;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1650
+    /* "MACS2/IO/CallPeakUnit.pyx":1652
  *         #peak_content.append( (above_cutoff_startpos[0], above_cutoff_endpos[0], treat_array[above_cutoff_index_array[0]], ctrl_array[above_cutoff_index_array[0]], score_array_s, above_cutoff_index_array[0] ) )
  *         for i in range( 1, above_cutoff_startpos.size ):
  *             ts = acs_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *             te = ace_ptr[ 0 ]
  *             ti = acia_ptr[ 0 ]
  */
-    __Pyx_TraceLine(1650,0,__PYX_ERR(0, 1650, __pyx_L1_error))
-    __pyx_t_6 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1650, __pyx_L1_error)
+    __Pyx_TraceLine(1652,0,__PYX_ERR(0, 1652, __pyx_L1_error))
+    __pyx_t_6 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1652, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF_SET(__pyx_v_ts, __pyx_t_6);
     __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1651
+    /* "MACS2/IO/CallPeakUnit.pyx":1653
  *         for i in range( 1, above_cutoff_startpos.size ):
  *             ts = acs_ptr[ 0 ]
  *             te = ace_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *             ti = acia_ptr[ 0 ]
  *             acs_ptr += 1
  */
-    __Pyx_TraceLine(1651,0,__PYX_ERR(0, 1651, __pyx_L1_error))
+    __Pyx_TraceLine(1653,0,__PYX_ERR(0, 1653, __pyx_L1_error))
     __pyx_v_te = (__pyx_v_ace_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1652
+    /* "MACS2/IO/CallPeakUnit.pyx":1654
  *             ts = acs_ptr[ 0 ]
  *             te = ace_ptr[ 0 ]
  *             ti = acia_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *             acs_ptr += 1
  *             ace_ptr += 1
  */
-    __Pyx_TraceLine(1652,0,__PYX_ERR(0, 1652, __pyx_L1_error))
+    __Pyx_TraceLine(1654,0,__PYX_ERR(0, 1654, __pyx_L1_error))
     __pyx_v_ti = (__pyx_v_acia_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1653
+    /* "MACS2/IO/CallPeakUnit.pyx":1655
  *             te = ace_ptr[ 0 ]
  *             ti = acia_ptr[ 0 ]
  *             acs_ptr += 1             # <<<<<<<<<<<<<<
  *             ace_ptr += 1
  *             acia_ptr+= 1
  */
-    __Pyx_TraceLine(1653,0,__PYX_ERR(0, 1653, __pyx_L1_error))
+    __Pyx_TraceLine(1655,0,__PYX_ERR(0, 1655, __pyx_L1_error))
     __pyx_v_acs_ptr = (__pyx_v_acs_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1654
+    /* "MACS2/IO/CallPeakUnit.pyx":1656
  *             ti = acia_ptr[ 0 ]
  *             acs_ptr += 1
  *             ace_ptr += 1             # <<<<<<<<<<<<<<
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ]
  */
-    __Pyx_TraceLine(1654,0,__PYX_ERR(0, 1654, __pyx_L1_error))
+    __Pyx_TraceLine(1656,0,__PYX_ERR(0, 1656, __pyx_L1_error))
     __pyx_v_ace_ptr = (__pyx_v_ace_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1655
+    /* "MACS2/IO/CallPeakUnit.pyx":1657
  *             acs_ptr += 1
  *             ace_ptr += 1
  *             acia_ptr+= 1             # <<<<<<<<<<<<<<
  *             tp = treat_array_ptr[ ti ]
  *             cp = ctrl_array_ptr[ ti ]
  */
-    __Pyx_TraceLine(1655,0,__PYX_ERR(0, 1655, __pyx_L1_error))
+    __Pyx_TraceLine(1657,0,__PYX_ERR(0, 1657, __pyx_L1_error))
     __pyx_v_acia_ptr = (__pyx_v_acia_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1656
+    /* "MACS2/IO/CallPeakUnit.pyx":1658
  *             ace_ptr += 1
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp
  */
-    __Pyx_TraceLine(1656,0,__PYX_ERR(0, 1656, __pyx_L1_error))
-    __pyx_t_6 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1656, __pyx_L1_error)
+    __Pyx_TraceLine(1658,0,__PYX_ERR(0, 1658, __pyx_L1_error))
+    __pyx_t_6 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1658, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF_SET(__pyx_v_tp, __pyx_t_6);
     __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1657
+    /* "MACS2/IO/CallPeakUnit.pyx":1659
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ]
  *             cp = ctrl_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *             tl = ts - lastp
  *             if tl <= lvl1_max_gap:
  */
-    __Pyx_TraceLine(1657,0,__PYX_ERR(0, 1657, __pyx_L1_error))
-    __pyx_t_6 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1657, __pyx_L1_error)
+    __Pyx_TraceLine(1659,0,__PYX_ERR(0, 1659, __pyx_L1_error))
+    __pyx_t_6 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1659, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF_SET(__pyx_v_cp, __pyx_t_6);
     __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1658
+    /* "MACS2/IO/CallPeakUnit.pyx":1660
  *             tp = treat_array_ptr[ ti ]
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp             # <<<<<<<<<<<<<<
  *             if tl <= lvl1_max_gap:
  *                 # append
  */
-    __Pyx_TraceLine(1658,0,__PYX_ERR(0, 1658, __pyx_L1_error))
-    __pyx_t_6 = PyNumber_Subtract(__pyx_v_ts, __pyx_v_lastp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1658, __pyx_L1_error)
+    __Pyx_TraceLine(1660,0,__PYX_ERR(0, 1660, __pyx_L1_error))
+    __pyx_t_6 = PyNumber_Subtract(__pyx_v_ts, __pyx_v_lastp); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1660, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_XDECREF_SET(__pyx_v_tl, __pyx_t_6);
     __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1659
+    /* "MACS2/IO/CallPeakUnit.pyx":1661
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp
  *             if tl <= lvl1_max_gap:             # <<<<<<<<<<<<<<
  *                 # append
  *                 #peak_content.append( (above_cutoff_startpos[i], above_cutoff_endpos[i], treat_array[above_cutoff_index_array[i]], ctrl_array[above_cutoff_index_array[i]], score_array_s, above_cutoff_index_array[i] ) )
  */
-    __Pyx_TraceLine(1659,0,__PYX_ERR(0, 1659, __pyx_L1_error))
-    __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl1_max_gap); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1659, __pyx_L1_error)
+    __Pyx_TraceLine(1661,0,__PYX_ERR(0, 1661, __pyx_L1_error))
+    __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl1_max_gap); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1661, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_v_tl, __pyx_t_6, Py_LE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1659, __pyx_L1_error)
+    __pyx_t_5 = PyObject_RichCompare(__pyx_v_tl, __pyx_t_6, Py_LE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1661, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1659, __pyx_L1_error)
+    __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1661, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     if (__pyx_t_7) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1662
+      /* "MACS2/IO/CallPeakUnit.pyx":1664
  *                 # append
  *                 #peak_content.append( (above_cutoff_startpos[i], above_cutoff_endpos[i], treat_array[above_cutoff_index_array[i]], ctrl_array[above_cutoff_index_array[i]], score_array_s, above_cutoff_index_array[i] ) )
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )             # <<<<<<<<<<<<<<
  *                 lastp = te
  *             else:
  */
-      __Pyx_TraceLine(1662,0,__PYX_ERR(0, 1662, __pyx_L1_error))
-      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1662, __pyx_L1_error)
+      __Pyx_TraceLine(1664,0,__PYX_ERR(0, 1664, __pyx_L1_error))
+      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1664, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1662, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1664, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_4 = PyTuple_New(5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1662, __pyx_L1_error)
+      __pyx_t_4 = PyTuple_New(5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1664, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_INCREF(__pyx_v_ts);
       __Pyx_GIVEREF(__pyx_v_ts);
@@ -22625,23 +22657,23 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       PyTuple_SET_ITEM(__pyx_t_4, 4, __pyx_t_6);
       __pyx_t_5 = 0;
       __pyx_t_6 = 0;
-      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_4); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1662, __pyx_L1_error)
+      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_4); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1664, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1663
+      /* "MACS2/IO/CallPeakUnit.pyx":1665
  *                 #peak_content.append( (above_cutoff_startpos[i], above_cutoff_endpos[i], treat_array[above_cutoff_index_array[i]], ctrl_array[above_cutoff_index_array[i]], score_array_s, above_cutoff_index_array[i] ) )
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )
  *                 lastp = te             # <<<<<<<<<<<<<<
  *             else:
  *                 # close
  */
-      __Pyx_TraceLine(1663,0,__PYX_ERR(0, 1663, __pyx_L1_error))
-      __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1663, __pyx_L1_error)
+      __Pyx_TraceLine(1665,0,__PYX_ERR(0, 1665, __pyx_L1_error))
+      __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1665, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_DECREF_SET(__pyx_v_lastp, __pyx_t_4);
       __pyx_t_4 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1659
+      /* "MACS2/IO/CallPeakUnit.pyx":1661
  *             cp = ctrl_array_ptr[ ti ]
  *             tl = ts - lastp
  *             if tl <= lvl1_max_gap:             # <<<<<<<<<<<<<<
@@ -22651,32 +22683,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L11;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1666
+    /* "MACS2/IO/CallPeakUnit.pyx":1668
  *             else:
  *                 # close
  *                 self.__close_peak_for_broad_region (peak_content, lvl1peaks, min_length, chrom, lvl1_max_gap//2, score_array_s )             # <<<<<<<<<<<<<<
  *                 #peak_content = [ (above_cutoff_startpos[i], above_cutoff_endpos[i], treat_array[above_cutoff_index_array[i]], ctrl_array[above_cutoff_index_array[i]], score_array_s, above_cutoff_index_array[i]) , ]
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]
  */
-    __Pyx_TraceLine(1666,0,__PYX_ERR(0, 1666, __pyx_L1_error))
+    __Pyx_TraceLine(1668,0,__PYX_ERR(0, 1668, __pyx_L1_error))
     /*else*/ {
-      __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl1peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl1_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1666, __pyx_L1_error)
+      __pyx_t_4 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl1peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl1_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1668, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1668
+      /* "MACS2/IO/CallPeakUnit.pyx":1670
  *                 self.__close_peak_for_broad_region (peak_content, lvl1peaks, min_length, chrom, lvl1_max_gap//2, score_array_s )
  *                 #peak_content = [ (above_cutoff_startpos[i], above_cutoff_endpos[i], treat_array[above_cutoff_index_array[i]], ctrl_array[above_cutoff_index_array[i]], score_array_s, above_cutoff_index_array[i]) , ]
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]             # <<<<<<<<<<<<<<
  *                 lastp = te #above_cutoff_endpos[i]
  * 
  */
-      __Pyx_TraceLine(1668,0,__PYX_ERR(0, 1668, __pyx_L1_error))
-      __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1668, __pyx_L1_error)
+      __Pyx_TraceLine(1670,0,__PYX_ERR(0, 1670, __pyx_L1_error))
+      __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1670, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
-      __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1668, __pyx_L1_error)
+      __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1670, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
-      __pyx_t_5 = PyTuple_New(5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1668, __pyx_L1_error)
+      __pyx_t_5 = PyTuple_New(5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1670, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_INCREF(__pyx_v_ts);
       __Pyx_GIVEREF(__pyx_v_ts);
@@ -22693,7 +22725,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       PyTuple_SET_ITEM(__pyx_t_5, 4, __pyx_t_6);
       __pyx_t_4 = 0;
       __pyx_t_6 = 0;
-      __pyx_t_6 = PyList_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1668, __pyx_L1_error)
+      __pyx_t_6 = PyList_New(1); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1670, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_GIVEREF(__pyx_t_5);
       PyList_SET_ITEM(__pyx_t_6, 0, __pyx_t_5);
@@ -22701,15 +22733,15 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __Pyx_DECREF_SET(__pyx_v_peak_content, ((PyObject*)__pyx_t_6));
       __pyx_t_6 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1669
+      /* "MACS2/IO/CallPeakUnit.pyx":1671
  *                 #peak_content = [ (above_cutoff_startpos[i], above_cutoff_endpos[i], treat_array[above_cutoff_index_array[i]], ctrl_array[above_cutoff_index_array[i]], score_array_s, above_cutoff_index_array[i]) , ]
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]
  *                 lastp = te #above_cutoff_endpos[i]             # <<<<<<<<<<<<<<
  * 
  *         # save the last peak
  */
-      __Pyx_TraceLine(1669,0,__PYX_ERR(0, 1669, __pyx_L1_error))
-      __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1669, __pyx_L1_error)
+      __Pyx_TraceLine(1671,0,__PYX_ERR(0, 1671, __pyx_L1_error))
+      __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1671, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF_SET(__pyx_v_lastp, __pyx_t_6);
       __pyx_t_6 = 0;
@@ -22717,30 +22749,30 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     __pyx_L11:;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1672
+  /* "MACS2/IO/CallPeakUnit.pyx":1674
  * 
  *         # save the last peak
  *         if peak_content:             # <<<<<<<<<<<<<<
  *             self.__close_peak_for_broad_region (peak_content, lvl1peaks, min_length, chrom, lvl1_max_gap//2, score_array_s )
  * 
  */
-  __Pyx_TraceLine(1672,0,__PYX_ERR(0, 1672, __pyx_L1_error))
+  __Pyx_TraceLine(1674,0,__PYX_ERR(0, 1674, __pyx_L1_error))
   __pyx_t_7 = (PyList_GET_SIZE(__pyx_v_peak_content) != 0);
   if (__pyx_t_7) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1673
+    /* "MACS2/IO/CallPeakUnit.pyx":1675
  *         # save the last peak
  *         if peak_content:
  *             self.__close_peak_for_broad_region (peak_content, lvl1peaks, min_length, chrom, lvl1_max_gap//2, score_array_s )             # <<<<<<<<<<<<<<
  * 
  *         # lvl2 : weak peaks
  */
-    __Pyx_TraceLine(1673,0,__PYX_ERR(0, 1673, __pyx_L1_error))
-    __pyx_t_6 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl1peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl1_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1673, __pyx_L1_error)
+    __Pyx_TraceLine(1675,0,__PYX_ERR(0, 1675, __pyx_L1_error))
+    __pyx_t_6 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl1peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl1_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1675, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1672
+    /* "MACS2/IO/CallPeakUnit.pyx":1674
  * 
  *         # save the last peak
  *         if peak_content:             # <<<<<<<<<<<<<<
@@ -22749,33 +22781,33 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1676
+  /* "MACS2/IO/CallPeakUnit.pyx":1678
  * 
  *         # lvl2 : weak peaks
  *         peak_content = []           # to store points above cutoff             # <<<<<<<<<<<<<<
  * 
  *         # get the regions with scores above cutoffs
  */
-  __Pyx_TraceLine(1676,0,__PYX_ERR(0, 1676, __pyx_L1_error))
-  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1676, __pyx_L1_error)
+  __Pyx_TraceLine(1678,0,__PYX_ERR(0, 1678, __pyx_L1_error))
+  __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1678, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF_SET(__pyx_v_peak_content, ((PyObject*)__pyx_t_6));
   __pyx_t_6 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1679
+  /* "MACS2/IO/CallPeakUnit.pyx":1681
  * 
  *         # get the regions with scores above cutoffs
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,lvl2_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?             # <<<<<<<<<<<<<<
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  */
-  __Pyx_TraceLine(1679,0,__PYX_ERR(0, 1679, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1679, __pyx_L1_error)
+  __Pyx_TraceLine(1681,0,__PYX_ERR(0, 1681, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1681, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_nonzero); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1679, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_nonzero); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1681, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = ((PyObject *)__pyx_f_5MACS2_2IO_12CallPeakUnit_apply_multiple_cutoffs(__pyx_v_score_array_s, __pyx_v_lvl2_cutoff_s)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1679, __pyx_L1_error)
+  __pyx_t_5 = ((PyObject *)__pyx_f_5MACS2_2IO_12CallPeakUnit_apply_multiple_cutoffs(__pyx_v_score_array_s, __pyx_v_lvl2_cutoff_s)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1681, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_3 = NULL;
   if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_4))) {
@@ -22790,110 +22822,110 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __pyx_t_6 = (__pyx_t_3) ? __Pyx_PyObject_Call2Args(__pyx_t_4, __pyx_t_3, __pyx_t_5) : __Pyx_PyObject_CallOneArg(__pyx_t_4, __pyx_t_5);
   __Pyx_XDECREF(__pyx_t_3); __pyx_t_3 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1679, __pyx_L1_error)
+  if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1681, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_GetItemInt(__pyx_t_6, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1679, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_GetItemInt(__pyx_t_6, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1681, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1679, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1681, __pyx_L1_error)
   __Pyx_DECREF_SET(__pyx_v_above_cutoff, ((PyArrayObject *)__pyx_t_4));
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1680
+  /* "MACS2/IO/CallPeakUnit.pyx":1682
  *         # get the regions with scores above cutoffs
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,lvl2_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices             # <<<<<<<<<<<<<<
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  */
-  __Pyx_TraceLine(1680,0,__PYX_ERR(0, 1680, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_4, __pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1680, __pyx_L1_error)
+  __Pyx_TraceLine(1682,0,__PYX_ERR(0, 1682, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_4, __pyx_n_s_np); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_arange); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1680, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_4, __pyx_n_s_arange); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_pos_array->dimensions[0])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1680, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_Py_intptr_t((__pyx_v_pos_array->dimensions[0])); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1680, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_New(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_GIVEREF(__pyx_t_4);
   PyTuple_SET_ITEM(__pyx_t_5, 0, __pyx_t_4);
   __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1680, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1680, __pyx_L1_error)
-  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1680, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_4, __pyx_n_s_dtype, __pyx_n_u_int32) < 0) __PYX_ERR(0, 1682, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_5, __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_4 = __Pyx_PyObject_GetItem(__pyx_t_3, ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1680, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_GetItem(__pyx_t_3, ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1680, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1682, __pyx_L1_error)
   __Pyx_DECREF_SET(__pyx_v_above_cutoff_index_array, ((PyArrayObject *)__pyx_t_4));
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1681
+  /* "MACS2/IO/CallPeakUnit.pyx":1683
  *         above_cutoff = np.nonzero( apply_multiple_cutoffs(score_array_s,lvl2_cutoff_s) )[0] # this is not an optimized method. It would be better to store score array in a 2-D ndarray?
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff             # <<<<<<<<<<<<<<
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  */
-  __Pyx_TraceLine(1681,0,__PYX_ERR(0, 1681, __pyx_L1_error))
-  __pyx_t_4 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1681, __pyx_L1_error)
+  __Pyx_TraceLine(1683,0,__PYX_ERR(0, 1683, __pyx_L1_error))
+  __pyx_t_4 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), ((PyObject *)__pyx_v_above_cutoff)); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1683, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1681, __pyx_L1_error)
+  if (!(likely(((__pyx_t_4) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_4, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1683, __pyx_L1_error)
   __Pyx_DECREF_SET(__pyx_v_above_cutoff_endpos, ((PyArrayObject *)__pyx_t_4));
   __pyx_t_4 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1682
+  /* "MACS2/IO/CallPeakUnit.pyx":1684
  *         above_cutoff_index_array = np.arange(pos_array.shape[0],dtype="int32")[above_cutoff] # indices
  *         above_cutoff_endpos = pos_array[above_cutoff] # end positions of regions where score is above cutoff
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff             # <<<<<<<<<<<<<<
  * 
  *         if above_cutoff.size == 0:
  */
-  __Pyx_TraceLine(1682,0,__PYX_ERR(0, 1682, __pyx_L1_error))
-  __pyx_t_4 = PyNumber_Subtract(((PyObject *)__pyx_v_above_cutoff), __pyx_int_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1682, __pyx_L1_error)
+  __Pyx_TraceLine(1684,0,__PYX_ERR(0, 1684, __pyx_L1_error))
+  __pyx_t_4 = PyNumber_Subtract(((PyObject *)__pyx_v_above_cutoff), __pyx_int_1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1684, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1682, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyObject_GetItem(((PyObject *)__pyx_v_pos_array), __pyx_t_4); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1684, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1682, __pyx_L1_error)
+  if (!(likely(((__pyx_t_3) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_3, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1684, __pyx_L1_error)
   __Pyx_DECREF_SET(__pyx_v_above_cutoff_startpos, ((PyArrayObject *)__pyx_t_3));
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1684
+  /* "MACS2/IO/CallPeakUnit.pyx":1686
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  *         if above_cutoff.size == 0:             # <<<<<<<<<<<<<<
  *             # nothing above cutoff
  *             return
  */
-  __Pyx_TraceLine(1684,0,__PYX_ERR(0, 1684, __pyx_L1_error))
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff), __pyx_n_s_size); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1684, __pyx_L1_error)
+  __Pyx_TraceLine(1686,0,__PYX_ERR(0, 1686, __pyx_L1_error))
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff), __pyx_n_s_size); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1686, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1684, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_EqObjC(__pyx_t_3, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1686, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1684, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1686, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
   if (__pyx_t_7) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1686
+    /* "MACS2/IO/CallPeakUnit.pyx":1688
  *         if above_cutoff.size == 0:
  *             # nothing above cutoff
  *             return             # <<<<<<<<<<<<<<
  * 
  *         if above_cutoff[0] == 0:
  */
-    __Pyx_TraceLine(1686,0,__PYX_ERR(0, 1686, __pyx_L1_error))
+    __Pyx_TraceLine(1688,0,__PYX_ERR(0, 1688, __pyx_L1_error))
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1684
+    /* "MACS2/IO/CallPeakUnit.pyx":1686
  *         above_cutoff_startpos = pos_array[above_cutoff-1] # start positions of regions where score is above cutoff
  * 
  *         if above_cutoff.size == 0:             # <<<<<<<<<<<<<<
@@ -22902,34 +22934,34 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1688
+  /* "MACS2/IO/CallPeakUnit.pyx":1690
  *             return
  * 
  *         if above_cutoff[0] == 0:             # <<<<<<<<<<<<<<
  *             # first element > cutoff, fix the first point as 0. otherwise it would be the last item in data[chrom]['pos']
  *             above_cutoff_startpos[0] = 0
  */
-  __Pyx_TraceLine(1688,0,__PYX_ERR(0, 1688, __pyx_L1_error))
-  __pyx_t_4 = __Pyx_GetItemInt(((PyObject *)__pyx_v_above_cutoff), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1688, __pyx_L1_error)
+  __Pyx_TraceLine(1690,0,__PYX_ERR(0, 1690, __pyx_L1_error))
+  __pyx_t_4 = __Pyx_GetItemInt(((PyObject *)__pyx_v_above_cutoff), 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1690, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_3 = __Pyx_PyInt_EqObjC(__pyx_t_4, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1688, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_PyInt_EqObjC(__pyx_t_4, __pyx_int_0, 0, 0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1690, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
-  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1688, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1690, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   if (__pyx_t_7) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1690
+    /* "MACS2/IO/CallPeakUnit.pyx":1692
  *         if above_cutoff[0] == 0:
  *             # first element > cutoff, fix the first point as 0. otherwise it would be the last item in data[chrom]['pos']
  *             above_cutoff_startpos[0] = 0             # <<<<<<<<<<<<<<
  * 
  *         # first bit of region above cutoff
  */
-    __Pyx_TraceLine(1690,0,__PYX_ERR(0, 1690, __pyx_L1_error))
-    if (unlikely(__Pyx_SetItemInt(((PyObject *)__pyx_v_above_cutoff_startpos), 0, __pyx_int_0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1) < 0)) __PYX_ERR(0, 1690, __pyx_L1_error)
+    __Pyx_TraceLine(1692,0,__PYX_ERR(0, 1692, __pyx_L1_error))
+    if (unlikely(__Pyx_SetItemInt(((PyObject *)__pyx_v_above_cutoff_startpos), 0, __pyx_int_0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1) < 0)) __PYX_ERR(0, 1692, __pyx_L1_error)
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1688
+    /* "MACS2/IO/CallPeakUnit.pyx":1690
  *             return
  * 
  *         if above_cutoff[0] == 0:             # <<<<<<<<<<<<<<
@@ -22938,128 +22970,128 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1693
+  /* "MACS2/IO/CallPeakUnit.pyx":1695
  * 
  *         # first bit of region above cutoff
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data             # <<<<<<<<<<<<<<
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  */
-  __Pyx_TraceLine(1693,0,__PYX_ERR(0, 1693, __pyx_L1_error))
+  __Pyx_TraceLine(1695,0,__PYX_ERR(0, 1695, __pyx_L1_error))
   __pyx_v_acs_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_startpos->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1694
+  /* "MACS2/IO/CallPeakUnit.pyx":1696
  *         # first bit of region above cutoff
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data             # <<<<<<<<<<<<<<
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  */
-  __Pyx_TraceLine(1694,0,__PYX_ERR(0, 1694, __pyx_L1_error))
+  __Pyx_TraceLine(1696,0,__PYX_ERR(0, 1696, __pyx_L1_error))
   __pyx_v_ace_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_endpos->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1695
+  /* "MACS2/IO/CallPeakUnit.pyx":1697
  *         acs_ptr = <int32_t *>above_cutoff_startpos.data
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data             # <<<<<<<<<<<<<<
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  */
-  __Pyx_TraceLine(1695,0,__PYX_ERR(0, 1695, __pyx_L1_error))
+  __Pyx_TraceLine(1697,0,__PYX_ERR(0, 1697, __pyx_L1_error))
   __pyx_v_acia_ptr = ((__pyx_t_5numpy_int32_t *)__pyx_v_above_cutoff_index_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1696
+  /* "MACS2/IO/CallPeakUnit.pyx":1698
  *         ace_ptr = <int32_t *>above_cutoff_endpos.data
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data             # <<<<<<<<<<<<<<
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  */
-  __Pyx_TraceLine(1696,0,__PYX_ERR(0, 1696, __pyx_L1_error))
+  __Pyx_TraceLine(1698,0,__PYX_ERR(0, 1698, __pyx_L1_error))
   __pyx_v_treat_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_treat_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1697
+  /* "MACS2/IO/CallPeakUnit.pyx":1699
  *         acia_ptr= <int32_t *>above_cutoff_index_array.data
  *         treat_array_ptr = <float32_t *> treat_array.data
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data             # <<<<<<<<<<<<<<
  * 
  *         ts = acs_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1697,0,__PYX_ERR(0, 1697, __pyx_L1_error))
+  __Pyx_TraceLine(1699,0,__PYX_ERR(0, 1699, __pyx_L1_error))
   __pyx_v_ctrl_array_ptr = ((__pyx_t_5numpy_float32_t *)__pyx_v_ctrl_array->data);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1699
+  /* "MACS2/IO/CallPeakUnit.pyx":1701
  *         ctrl_array_ptr = <float32_t *> ctrl_array.data
  * 
  *         ts = acs_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]
  */
-  __Pyx_TraceLine(1699,0,__PYX_ERR(0, 1699, __pyx_L1_error))
-  __pyx_t_3 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1699, __pyx_L1_error)
+  __Pyx_TraceLine(1701,0,__PYX_ERR(0, 1701, __pyx_L1_error))
+  __pyx_t_3 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1701, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF_SET(__pyx_v_ts, __pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1700
+  /* "MACS2/IO/CallPeakUnit.pyx":1702
  * 
  *         ts = acs_ptr[ 0 ]
  *         te = ace_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]
  */
-  __Pyx_TraceLine(1700,0,__PYX_ERR(0, 1700, __pyx_L1_error))
+  __Pyx_TraceLine(1702,0,__PYX_ERR(0, 1702, __pyx_L1_error))
   __pyx_v_te = (__pyx_v_ace_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1701
+  /* "MACS2/IO/CallPeakUnit.pyx":1703
  *         ts = acs_ptr[ 0 ]
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]             # <<<<<<<<<<<<<<
  *         tp = treat_array_ptr[ ti ]
  *         cp = ctrl_array_ptr[ ti ]
  */
-  __Pyx_TraceLine(1701,0,__PYX_ERR(0, 1701, __pyx_L1_error))
+  __Pyx_TraceLine(1703,0,__PYX_ERR(0, 1703, __pyx_L1_error))
   __pyx_v_ti = (__pyx_v_acia_ptr[0]);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1702
+  /* "MACS2/IO/CallPeakUnit.pyx":1704
  *         te = ace_ptr[ 0 ]
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *         cp = ctrl_array_ptr[ ti ]
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  */
-  __Pyx_TraceLine(1702,0,__PYX_ERR(0, 1702, __pyx_L1_error))
-  __pyx_t_3 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1702, __pyx_L1_error)
+  __Pyx_TraceLine(1704,0,__PYX_ERR(0, 1704, __pyx_L1_error))
+  __pyx_t_3 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1704, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF_SET(__pyx_v_tp, __pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1703
+  /* "MACS2/IO/CallPeakUnit.pyx":1705
  *         ti = acia_ptr[ 0 ]
  *         tp = treat_array_ptr[ ti ]
  *         cp = ctrl_array_ptr[ ti ]             # <<<<<<<<<<<<<<
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  *         acs_ptr += 1 # move ptr
  */
-  __Pyx_TraceLine(1703,0,__PYX_ERR(0, 1703, __pyx_L1_error))
-  __pyx_t_3 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1703, __pyx_L1_error)
+  __Pyx_TraceLine(1705,0,__PYX_ERR(0, 1705, __pyx_L1_error))
+  __pyx_t_3 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1705, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF_SET(__pyx_v_cp, __pyx_t_3);
   __pyx_t_3 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1704
+  /* "MACS2/IO/CallPeakUnit.pyx":1706
  *         tp = treat_array_ptr[ ti ]
  *         cp = ctrl_array_ptr[ ti ]
  *         peak_content.append( ( ts, te, tp, cp, ti ) )             # <<<<<<<<<<<<<<
  *         acs_ptr += 1 # move ptr
  *         ace_ptr += 1
  */
-  __Pyx_TraceLine(1704,0,__PYX_ERR(0, 1704, __pyx_L1_error))
-  __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1704, __pyx_L1_error)
+  __Pyx_TraceLine(1706,0,__PYX_ERR(0, 1706, __pyx_L1_error))
+  __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1706, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1704, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1706, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_4);
-  __pyx_t_5 = PyTuple_New(5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1704, __pyx_L1_error)
+  __pyx_t_5 = PyTuple_New(5); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1706, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_INCREF(__pyx_v_ts);
   __Pyx_GIVEREF(__pyx_v_ts);
@@ -23076,199 +23108,199 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   PyTuple_SET_ITEM(__pyx_t_5, 4, __pyx_t_4);
   __pyx_t_3 = 0;
   __pyx_t_4 = 0;
-  __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_5); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1704, __pyx_L1_error)
+  __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_5); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1706, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1705
+  /* "MACS2/IO/CallPeakUnit.pyx":1707
  *         cp = ctrl_array_ptr[ ti ]
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  *         acs_ptr += 1 # move ptr             # <<<<<<<<<<<<<<
  *         ace_ptr += 1
  *         acia_ptr+= 1
  */
-  __Pyx_TraceLine(1705,0,__PYX_ERR(0, 1705, __pyx_L1_error))
+  __Pyx_TraceLine(1707,0,__PYX_ERR(0, 1707, __pyx_L1_error))
   __pyx_v_acs_ptr = (__pyx_v_acs_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1706
+  /* "MACS2/IO/CallPeakUnit.pyx":1708
  *         peak_content.append( ( ts, te, tp, cp, ti ) )
  *         acs_ptr += 1 # move ptr
  *         ace_ptr += 1             # <<<<<<<<<<<<<<
  *         acia_ptr+= 1
  * 
  */
-  __Pyx_TraceLine(1706,0,__PYX_ERR(0, 1706, __pyx_L1_error))
+  __Pyx_TraceLine(1708,0,__PYX_ERR(0, 1708, __pyx_L1_error))
   __pyx_v_ace_ptr = (__pyx_v_ace_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1707
+  /* "MACS2/IO/CallPeakUnit.pyx":1709
  *         acs_ptr += 1 # move ptr
  *         ace_ptr += 1
  *         acia_ptr+= 1             # <<<<<<<<<<<<<<
  * 
  *         lastp = te
  */
-  __Pyx_TraceLine(1707,0,__PYX_ERR(0, 1707, __pyx_L1_error))
+  __Pyx_TraceLine(1709,0,__PYX_ERR(0, 1709, __pyx_L1_error))
   __pyx_v_acia_ptr = (__pyx_v_acia_ptr + 1);
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1709
+  /* "MACS2/IO/CallPeakUnit.pyx":1711
  *         acia_ptr+= 1
  * 
  *         lastp = te             # <<<<<<<<<<<<<<
  *         for i in range( 1, above_cutoff_startpos.size ):
  *             # for everything above cutoff
  */
-  __Pyx_TraceLine(1709,0,__PYX_ERR(0, 1709, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1709, __pyx_L1_error)
+  __Pyx_TraceLine(1711,0,__PYX_ERR(0, 1711, __pyx_L1_error))
+  __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1711, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF_SET(__pyx_v_lastp, __pyx_t_5);
   __pyx_t_5 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1710
+  /* "MACS2/IO/CallPeakUnit.pyx":1712
  * 
  *         lastp = te
  *         for i in range( 1, above_cutoff_startpos.size ):             # <<<<<<<<<<<<<<
  *             # for everything above cutoff
  *             ts = acs_ptr[ 0 ] # get the start
  */
-  __Pyx_TraceLine(1710,0,__PYX_ERR(0, 1710, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff_startpos), __pyx_n_s_size); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1710, __pyx_L1_error)
+  __Pyx_TraceLine(1712,0,__PYX_ERR(0, 1712, __pyx_L1_error))
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_above_cutoff_startpos), __pyx_n_s_size); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1712, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_11 = __Pyx_PyInt_As_long(__pyx_t_5); if (unlikely((__pyx_t_11 == (long)-1) && PyErr_Occurred())) __PYX_ERR(0, 1710, __pyx_L1_error)
+  __pyx_t_11 = __Pyx_PyInt_As_long(__pyx_t_5); if (unlikely((__pyx_t_11 == (long)-1) && PyErr_Occurred())) __PYX_ERR(0, 1712, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
   __pyx_t_12 = __pyx_t_11;
   for (__pyx_t_8 = 1; __pyx_t_8 < __pyx_t_12; __pyx_t_8+=1) {
     __pyx_v_i = __pyx_t_8;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1712
+    /* "MACS2/IO/CallPeakUnit.pyx":1714
  *         for i in range( 1, above_cutoff_startpos.size ):
  *             # for everything above cutoff
  *             ts = acs_ptr[ 0 ] # get the start             # <<<<<<<<<<<<<<
  *             te = ace_ptr[ 0 ] # get the end
  *             ti = acia_ptr[ 0 ]# get the index
  */
-    __Pyx_TraceLine(1712,0,__PYX_ERR(0, 1712, __pyx_L1_error))
-    __pyx_t_5 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1712, __pyx_L1_error)
+    __Pyx_TraceLine(1714,0,__PYX_ERR(0, 1714, __pyx_L1_error))
+    __pyx_t_5 = __Pyx_PyInt_From_npy_int32((__pyx_v_acs_ptr[0])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1714, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF_SET(__pyx_v_ts, __pyx_t_5);
     __pyx_t_5 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1713
+    /* "MACS2/IO/CallPeakUnit.pyx":1715
  *             # for everything above cutoff
  *             ts = acs_ptr[ 0 ] # get the start
  *             te = ace_ptr[ 0 ] # get the end             # <<<<<<<<<<<<<<
  *             ti = acia_ptr[ 0 ]# get the index
  * 
  */
-    __Pyx_TraceLine(1713,0,__PYX_ERR(0, 1713, __pyx_L1_error))
+    __Pyx_TraceLine(1715,0,__PYX_ERR(0, 1715, __pyx_L1_error))
     __pyx_v_te = (__pyx_v_ace_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1714
+    /* "MACS2/IO/CallPeakUnit.pyx":1716
  *             ts = acs_ptr[ 0 ] # get the start
  *             te = ace_ptr[ 0 ] # get the end
  *             ti = acia_ptr[ 0 ]# get the index             # <<<<<<<<<<<<<<
  * 
  *             acs_ptr += 1 # move ptr
  */
-    __Pyx_TraceLine(1714,0,__PYX_ERR(0, 1714, __pyx_L1_error))
+    __Pyx_TraceLine(1716,0,__PYX_ERR(0, 1716, __pyx_L1_error))
     __pyx_v_ti = (__pyx_v_acia_ptr[0]);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1716
+    /* "MACS2/IO/CallPeakUnit.pyx":1718
  *             ti = acia_ptr[ 0 ]# get the index
  * 
  *             acs_ptr += 1 # move ptr             # <<<<<<<<<<<<<<
  *             ace_ptr += 1
  *             acia_ptr+= 1
  */
-    __Pyx_TraceLine(1716,0,__PYX_ERR(0, 1716, __pyx_L1_error))
+    __Pyx_TraceLine(1718,0,__PYX_ERR(0, 1718, __pyx_L1_error))
     __pyx_v_acs_ptr = (__pyx_v_acs_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1717
+    /* "MACS2/IO/CallPeakUnit.pyx":1719
  * 
  *             acs_ptr += 1 # move ptr
  *             ace_ptr += 1             # <<<<<<<<<<<<<<
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ] # get the treatment pileup
  */
-    __Pyx_TraceLine(1717,0,__PYX_ERR(0, 1717, __pyx_L1_error))
+    __Pyx_TraceLine(1719,0,__PYX_ERR(0, 1719, __pyx_L1_error))
     __pyx_v_ace_ptr = (__pyx_v_ace_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1718
+    /* "MACS2/IO/CallPeakUnit.pyx":1720
  *             acs_ptr += 1 # move ptr
  *             ace_ptr += 1
  *             acia_ptr+= 1             # <<<<<<<<<<<<<<
  *             tp = treat_array_ptr[ ti ] # get the treatment pileup
  *             cp = ctrl_array_ptr[ ti ]  # get the control pileup
  */
-    __Pyx_TraceLine(1718,0,__PYX_ERR(0, 1718, __pyx_L1_error))
+    __Pyx_TraceLine(1720,0,__PYX_ERR(0, 1720, __pyx_L1_error))
     __pyx_v_acia_ptr = (__pyx_v_acia_ptr + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1719
+    /* "MACS2/IO/CallPeakUnit.pyx":1721
  *             ace_ptr += 1
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ] # get the treatment pileup             # <<<<<<<<<<<<<<
  *             cp = ctrl_array_ptr[ ti ]  # get the control pileup
  *             tl = ts - lastp # get the distance from the current point to last position of existing peak_content
  */
-    __Pyx_TraceLine(1719,0,__PYX_ERR(0, 1719, __pyx_L1_error))
-    __pyx_t_5 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1719, __pyx_L1_error)
+    __Pyx_TraceLine(1721,0,__PYX_ERR(0, 1721, __pyx_L1_error))
+    __pyx_t_5 = PyFloat_FromDouble((__pyx_v_treat_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1721, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF_SET(__pyx_v_tp, __pyx_t_5);
     __pyx_t_5 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1720
+    /* "MACS2/IO/CallPeakUnit.pyx":1722
  *             acia_ptr+= 1
  *             tp = treat_array_ptr[ ti ] # get the treatment pileup
  *             cp = ctrl_array_ptr[ ti ]  # get the control pileup             # <<<<<<<<<<<<<<
  *             tl = ts - lastp # get the distance from the current point to last position of existing peak_content
  * 
  */
-    __Pyx_TraceLine(1720,0,__PYX_ERR(0, 1720, __pyx_L1_error))
-    __pyx_t_5 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1720, __pyx_L1_error)
+    __Pyx_TraceLine(1722,0,__PYX_ERR(0, 1722, __pyx_L1_error))
+    __pyx_t_5 = PyFloat_FromDouble((__pyx_v_ctrl_array_ptr[__pyx_v_ti])); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1722, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF_SET(__pyx_v_cp, __pyx_t_5);
     __pyx_t_5 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1721
+    /* "MACS2/IO/CallPeakUnit.pyx":1723
  *             tp = treat_array_ptr[ ti ] # get the treatment pileup
  *             cp = ctrl_array_ptr[ ti ]  # get the control pileup
  *             tl = ts - lastp # get the distance from the current point to last position of existing peak_content             # <<<<<<<<<<<<<<
  * 
  *             if tl <= lvl2_max_gap:
  */
-    __Pyx_TraceLine(1721,0,__PYX_ERR(0, 1721, __pyx_L1_error))
-    __pyx_t_5 = PyNumber_Subtract(__pyx_v_ts, __pyx_v_lastp); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1721, __pyx_L1_error)
+    __Pyx_TraceLine(1723,0,__PYX_ERR(0, 1723, __pyx_L1_error))
+    __pyx_t_5 = PyNumber_Subtract(__pyx_v_ts, __pyx_v_lastp); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1723, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_XDECREF_SET(__pyx_v_tl, __pyx_t_5);
     __pyx_t_5 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1723
+    /* "MACS2/IO/CallPeakUnit.pyx":1725
  *             tl = ts - lastp # get the distance from the current point to last position of existing peak_content
  * 
  *             if tl <= lvl2_max_gap:             # <<<<<<<<<<<<<<
  *                 # append
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )
  */
-    __Pyx_TraceLine(1723,0,__PYX_ERR(0, 1723, __pyx_L1_error))
-    __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl2_max_gap); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1723, __pyx_L1_error)
+    __Pyx_TraceLine(1725,0,__PYX_ERR(0, 1725, __pyx_L1_error))
+    __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_lvl2_max_gap); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1725, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_4 = PyObject_RichCompare(__pyx_v_tl, __pyx_t_5, Py_LE); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1723, __pyx_L1_error)
+    __pyx_t_4 = PyObject_RichCompare(__pyx_v_tl, __pyx_t_5, Py_LE); __Pyx_XGOTREF(__pyx_t_4); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1725, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1723, __pyx_L1_error)
+    __pyx_t_7 = __Pyx_PyObject_IsTrue(__pyx_t_4); if (unlikely(__pyx_t_7 < 0)) __PYX_ERR(0, 1725, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_4); __pyx_t_4 = 0;
     if (__pyx_t_7) {
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1725
+      /* "MACS2/IO/CallPeakUnit.pyx":1727
  *             if tl <= lvl2_max_gap:
  *                 # append
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )             # <<<<<<<<<<<<<<
  *                 lastp = te
  *             else:
  */
-      __Pyx_TraceLine(1725,0,__PYX_ERR(0, 1725, __pyx_L1_error))
-      __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1725, __pyx_L1_error)
+      __Pyx_TraceLine(1727,0,__PYX_ERR(0, 1727, __pyx_L1_error))
+      __pyx_t_4 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1727, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
-      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1725, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1727, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_3 = PyTuple_New(5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1725, __pyx_L1_error)
+      __pyx_t_3 = PyTuple_New(5); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1727, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_INCREF(__pyx_v_ts);
       __Pyx_GIVEREF(__pyx_v_ts);
@@ -23285,23 +23317,23 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       PyTuple_SET_ITEM(__pyx_t_3, 4, __pyx_t_5);
       __pyx_t_4 = 0;
       __pyx_t_5 = 0;
-      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1725, __pyx_L1_error)
+      __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_peak_content, __pyx_t_3); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1727, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1726
+      /* "MACS2/IO/CallPeakUnit.pyx":1728
  *                 # append
  *                 peak_content.append( ( ts, te, tp, cp, ti ) )
  *                 lastp = te             # <<<<<<<<<<<<<<
  *             else:
  *                 # close
  */
-      __Pyx_TraceLine(1726,0,__PYX_ERR(0, 1726, __pyx_L1_error))
-      __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1726, __pyx_L1_error)
+      __Pyx_TraceLine(1728,0,__PYX_ERR(0, 1728, __pyx_L1_error))
+      __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1728, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF_SET(__pyx_v_lastp, __pyx_t_3);
       __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1723
+      /* "MACS2/IO/CallPeakUnit.pyx":1725
  *             tl = ts - lastp # get the distance from the current point to last position of existing peak_content
  * 
  *             if tl <= lvl2_max_gap:             # <<<<<<<<<<<<<<
@@ -23311,32 +23343,32 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       goto __pyx_L17;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1729
+    /* "MACS2/IO/CallPeakUnit.pyx":1731
  *             else:
  *                 # close
  *                 self.__close_peak_for_broad_region (peak_content, lvl2peaks, min_length, chrom, lvl2_max_gap//2, score_array_s )             # <<<<<<<<<<<<<<
  * 
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]
  */
-    __Pyx_TraceLine(1729,0,__PYX_ERR(0, 1729, __pyx_L1_error))
+    __Pyx_TraceLine(1731,0,__PYX_ERR(0, 1731, __pyx_L1_error))
     /*else*/ {
-      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl2peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl2_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1729, __pyx_L1_error)
+      __pyx_t_3 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl2peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl2_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1731, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1731
+      /* "MACS2/IO/CallPeakUnit.pyx":1733
  *                 self.__close_peak_for_broad_region (peak_content, lvl2peaks, min_length, chrom, lvl2_max_gap//2, score_array_s )
  * 
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]             # <<<<<<<<<<<<<<
  *                 lastp = te
  * 
  */
-      __Pyx_TraceLine(1731,0,__PYX_ERR(0, 1731, __pyx_L1_error))
-      __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1731, __pyx_L1_error)
+      __Pyx_TraceLine(1733,0,__PYX_ERR(0, 1733, __pyx_L1_error))
+      __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1733, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1731, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_ti); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1733, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_4 = PyTuple_New(5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1731, __pyx_L1_error)
+      __pyx_t_4 = PyTuple_New(5); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1733, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_4);
       __Pyx_INCREF(__pyx_v_ts);
       __Pyx_GIVEREF(__pyx_v_ts);
@@ -23353,7 +23385,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       PyTuple_SET_ITEM(__pyx_t_4, 4, __pyx_t_5);
       __pyx_t_3 = 0;
       __pyx_t_5 = 0;
-      __pyx_t_5 = PyList_New(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1731, __pyx_L1_error)
+      __pyx_t_5 = PyList_New(1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1733, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_GIVEREF(__pyx_t_4);
       PyList_SET_ITEM(__pyx_t_5, 0, __pyx_t_4);
@@ -23361,15 +23393,15 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
       __Pyx_DECREF_SET(__pyx_v_peak_content, ((PyObject*)__pyx_t_5));
       __pyx_t_5 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1732
+      /* "MACS2/IO/CallPeakUnit.pyx":1734
  * 
  *                 peak_content = [ ( ts, te, tp, cp, ti ), ]
  *                 lastp = te             # <<<<<<<<<<<<<<
  * 
  *         # save the last peak
  */
-      __Pyx_TraceLine(1732,0,__PYX_ERR(0, 1732, __pyx_L1_error))
-      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1732, __pyx_L1_error)
+      __Pyx_TraceLine(1734,0,__PYX_ERR(0, 1734, __pyx_L1_error))
+      __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_te); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1734, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_DECREF_SET(__pyx_v_lastp, __pyx_t_5);
       __pyx_t_5 = 0;
@@ -23377,30 +23409,30 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
     __pyx_L17:;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1735
+  /* "MACS2/IO/CallPeakUnit.pyx":1737
  * 
  *         # save the last peak
  *         if peak_content:             # <<<<<<<<<<<<<<
  *             self.__close_peak_for_broad_region (peak_content, lvl2peaks, min_length, chrom, lvl2_max_gap//2, score_array_s )
  * 
  */
-  __Pyx_TraceLine(1735,0,__PYX_ERR(0, 1735, __pyx_L1_error))
+  __Pyx_TraceLine(1737,0,__PYX_ERR(0, 1737, __pyx_L1_error))
   __pyx_t_7 = (PyList_GET_SIZE(__pyx_v_peak_content) != 0);
   if (__pyx_t_7) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1736
+    /* "MACS2/IO/CallPeakUnit.pyx":1738
  *         # save the last peak
  *         if peak_content:
  *             self.__close_peak_for_broad_region (peak_content, lvl2peaks, min_length, chrom, lvl2_max_gap//2, score_array_s )             # <<<<<<<<<<<<<<
  * 
  *         return
  */
-    __Pyx_TraceLine(1736,0,__PYX_ERR(0, 1736, __pyx_L1_error))
-    __pyx_t_5 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl2peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl2_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1736, __pyx_L1_error)
+    __Pyx_TraceLine(1738,0,__PYX_ERR(0, 1738, __pyx_L1_error))
+    __pyx_t_5 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___close_peak_for_broad_region(__pyx_v_self, __pyx_v_peak_content, __pyx_v_lvl2peaks, __pyx_v_min_length, __pyx_v_chrom, __Pyx_div_long(__pyx_v_lvl2_max_gap, 2), __pyx_v_score_array_s, NULL)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1738, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1735
+    /* "MACS2/IO/CallPeakUnit.pyx":1737
  * 
  *         # save the last peak
  *         if peak_content:             # <<<<<<<<<<<<<<
@@ -23409,17 +23441,17 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1738
+  /* "MACS2/IO/CallPeakUnit.pyx":1740
  *             self.__close_peak_for_broad_region (peak_content, lvl2peaks, min_length, chrom, lvl2_max_gap//2, score_array_s )
  * 
  *         return             # <<<<<<<<<<<<<<
  * 
  *     cdef bool __close_peak_for_broad_region (self, list peak_content, peaks, int32_t min_length,
  */
-  __Pyx_TraceLine(1738,0,__PYX_ERR(0, 1738, __pyx_L1_error))
+  __Pyx_TraceLine(1740,0,__PYX_ERR(0, 1740, __pyx_L1_error))
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1564
+  /* "MACS2/IO/CallPeakUnit.pyx":1566
  *         return broadpeaks
  * 
  *     cdef void  __chrom_call_broadpeak_using_certain_criteria ( self, lvl1peaks, lvl2peaks, bytes chrom, list scoring_function_s, list lvl1_cutoff_s, list lvl2_cutoff_s,             # <<<<<<<<<<<<<<
@@ -23454,7 +23486,7 @@ static void __pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___chrom_cal
   __Pyx_RefNannyFinishContext();
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1740
+/* "MACS2/IO/CallPeakUnit.pyx":1742
  *         return
  * 
  *     cdef bool __close_peak_for_broad_region (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -23500,128 +23532,128 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   __pyx_t_5numpy_int32_t __pyx_t_17;
   int __pyx_t_18;
   __Pyx_RefNannySetupContext("__close_peak_for_broad_region", 0);
-  __Pyx_TraceCall("__close_peak_for_broad_region", __pyx_f[0], 1740, 0, __PYX_ERR(0, 1740, __pyx_L1_error));
+  __Pyx_TraceCall("__close_peak_for_broad_region", __pyx_f[0], 1742, 0, __PYX_ERR(0, 1742, __pyx_L1_error));
   if (__pyx_optional_args) {
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1757
+  /* "MACS2/IO/CallPeakUnit.pyx":1759
  *             np.ndarray tarray_pileup, tarray_control, tarray_pscore, tarray_qscore, tarray_fc
  * 
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]             # <<<<<<<<<<<<<<
  *         if peak_length >= min_length: # if the peak is too small, reject it
  *             tlist_pileup = []
  */
-  __Pyx_TraceLine(1757,0,__PYX_ERR(0, 1757, __pyx_L1_error))
+  __Pyx_TraceLine(1759,0,__PYX_ERR(0, 1759, __pyx_L1_error))
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1757, __pyx_L1_error)
+    __PYX_ERR(0, 1759, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1757, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1759, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1757, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_GetItemInt(__pyx_t_1, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1759, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   if (unlikely(__pyx_v_peak_content == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1757, __pyx_L1_error)
+    __PYX_ERR(0, 1759, __pyx_L1_error)
   }
-  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1757, __pyx_L1_error)
+  __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1759, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1757, __pyx_L1_error)
+  __pyx_t_3 = __Pyx_GetItemInt(__pyx_t_1, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1759, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_3);
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_1 = PyNumber_Subtract(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1757, __pyx_L1_error)
+  __pyx_t_1 = PyNumber_Subtract(__pyx_t_2, __pyx_t_3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1759, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   __pyx_v_peak_length = __pyx_t_1;
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1758
+  /* "MACS2/IO/CallPeakUnit.pyx":1760
  * 
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]
  *         if peak_length >= min_length: # if the peak is too small, reject it             # <<<<<<<<<<<<<<
  *             tlist_pileup = []
  *             tlist_control= []
  */
-  __Pyx_TraceLine(1758,0,__PYX_ERR(0, 1758, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1758, __pyx_L1_error)
+  __Pyx_TraceLine(1760,0,__PYX_ERR(0, 1760, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_min_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1760, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_3 = PyObject_RichCompare(__pyx_v_peak_length, __pyx_t_1, Py_GE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1758, __pyx_L1_error)
+  __pyx_t_3 = PyObject_RichCompare(__pyx_v_peak_length, __pyx_t_1, Py_GE); __Pyx_XGOTREF(__pyx_t_3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1760, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1758, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_3); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1760, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1759
+    /* "MACS2/IO/CallPeakUnit.pyx":1761
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]
  *         if peak_length >= min_length: # if the peak is too small, reject it
  *             tlist_pileup = []             # <<<<<<<<<<<<<<
  *             tlist_control= []
  *             tlist_length = []
  */
-    __Pyx_TraceLine(1759,0,__PYX_ERR(0, 1759, __pyx_L1_error))
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1759, __pyx_L1_error)
+    __Pyx_TraceLine(1761,0,__PYX_ERR(0, 1761, __pyx_L1_error))
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1761, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_v_tlist_pileup = ((PyObject*)__pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1760
+    /* "MACS2/IO/CallPeakUnit.pyx":1762
  *         if peak_length >= min_length: # if the peak is too small, reject it
  *             tlist_pileup = []
  *             tlist_control= []             # <<<<<<<<<<<<<<
  *             tlist_length = []
  *             for i in range(len(peak_content)): # each position in broad peak
  */
-    __Pyx_TraceLine(1760,0,__PYX_ERR(0, 1760, __pyx_L1_error))
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1760, __pyx_L1_error)
+    __Pyx_TraceLine(1762,0,__PYX_ERR(0, 1762, __pyx_L1_error))
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1762, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_v_tlist_control = ((PyObject*)__pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1761
+    /* "MACS2/IO/CallPeakUnit.pyx":1763
  *             tlist_pileup = []
  *             tlist_control= []
  *             tlist_length = []             # <<<<<<<<<<<<<<
  *             for i in range(len(peak_content)): # each position in broad peak
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  */
-    __Pyx_TraceLine(1761,0,__PYX_ERR(0, 1761, __pyx_L1_error))
-    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1761, __pyx_L1_error)
+    __Pyx_TraceLine(1763,0,__PYX_ERR(0, 1763, __pyx_L1_error))
+    __pyx_t_3 = PyList_New(0); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1763, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __pyx_v_tlist_length = ((PyObject*)__pyx_t_3);
     __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1762
+    /* "MACS2/IO/CallPeakUnit.pyx":1764
  *             tlist_control= []
  *             tlist_length = []
  *             for i in range(len(peak_content)): # each position in broad peak             # <<<<<<<<<<<<<<
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *                 #tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  */
-    __Pyx_TraceLine(1762,0,__PYX_ERR(0, 1762, __pyx_L1_error))
+    __Pyx_TraceLine(1764,0,__PYX_ERR(0, 1764, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1762, __pyx_L1_error)
+      __PYX_ERR(0, 1764, __pyx_L1_error)
     }
-    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_peak_content); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1762, __pyx_L1_error)
+    __pyx_t_5 = PyList_GET_SIZE(__pyx_v_peak_content); if (unlikely(__pyx_t_5 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1764, __pyx_L1_error)
     __pyx_t_6 = __pyx_t_5;
     for (__pyx_t_7 = 0; __pyx_t_7 < __pyx_t_6; __pyx_t_7+=1) {
       __pyx_v_i = __pyx_t_7;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1763
+      /* "MACS2/IO/CallPeakUnit.pyx":1765
  *             tlist_length = []
  *             for i in range(len(peak_content)): # each position in broad peak
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]             # <<<<<<<<<<<<<<
  *                 #tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *                 tlist_pileup.append( ttreat_p )
  */
-      __Pyx_TraceLine(1763,0,__PYX_ERR(0, 1763, __pyx_L1_error))
+      __Pyx_TraceLine(1765,0,__PYX_ERR(0, 1765, __pyx_L1_error))
       if (unlikely(__pyx_v_peak_content == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1763, __pyx_L1_error)
+        __PYX_ERR(0, 1765, __pyx_L1_error)
       }
-      __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1763, __pyx_L1_error)
+      __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1765, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
       if ((likely(PyTuple_CheckExact(__pyx_t_3))) || (PyList_CheckExact(__pyx_t_3))) {
         PyObject* sequence = __pyx_t_3;
@@ -23629,7 +23661,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         if (unlikely(size != 5)) {
           if (size > 5) __Pyx_RaiseTooManyValuesError(5);
           else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-          __PYX_ERR(0, 1763, __pyx_L1_error)
+          __PYX_ERR(0, 1765, __pyx_L1_error)
         }
         #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
         if (likely(PyTuple_CheckExact(sequence))) {
@@ -23655,7 +23687,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
           Py_ssize_t i;
           PyObject** temps[5] = {&__pyx_t_1,&__pyx_t_2,&__pyx_t_8,&__pyx_t_9,&__pyx_t_10};
           for (i=0; i < 5; i++) {
-            PyObject* item = PySequence_ITEM(sequence, i); if (unlikely(!item)) __PYX_ERR(0, 1763, __pyx_L1_error)
+            PyObject* item = PySequence_ITEM(sequence, i); if (unlikely(!item)) __PYX_ERR(0, 1765, __pyx_L1_error)
             __Pyx_GOTREF(item);
             *(temps[i]) = item;
           }
@@ -23665,7 +23697,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       } else {
         Py_ssize_t index = -1;
         PyObject** temps[5] = {&__pyx_t_1,&__pyx_t_2,&__pyx_t_8,&__pyx_t_9,&__pyx_t_10};
-        __pyx_t_11 = PyObject_GetIter(__pyx_t_3); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 1763, __pyx_L1_error)
+        __pyx_t_11 = PyObject_GetIter(__pyx_t_3); if (unlikely(!__pyx_t_11)) __PYX_ERR(0, 1765, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_11);
         __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
         __pyx_t_12 = Py_TYPE(__pyx_t_11)->tp_iternext;
@@ -23674,7 +23706,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
           __Pyx_GOTREF(item);
           *(temps[index]) = item;
         }
-        if (__Pyx_IternextUnpackEndCheck(__pyx_t_12(__pyx_t_11), 5) < 0) __PYX_ERR(0, 1763, __pyx_L1_error)
+        if (__Pyx_IternextUnpackEndCheck(__pyx_t_12(__pyx_t_11), 5) < 0) __PYX_ERR(0, 1765, __pyx_L1_error)
         __pyx_t_12 = NULL;
         __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
         goto __pyx_L7_unpacking_done;
@@ -23682,18 +23714,18 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
         __Pyx_DECREF(__pyx_t_11); __pyx_t_11 = 0;
         __pyx_t_12 = NULL;
         if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-        __PYX_ERR(0, 1763, __pyx_L1_error)
+        __PYX_ERR(0, 1765, __pyx_L1_error)
         __pyx_L7_unpacking_done:;
       }
-      __pyx_t_13 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_13 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1763, __pyx_L1_error)
+      __pyx_t_13 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_13 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1765, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-      __pyx_t_14 = __Pyx_PyInt_As_npy_int32(__pyx_t_2); if (unlikely((__pyx_t_14 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1763, __pyx_L1_error)
+      __pyx_t_14 = __Pyx_PyInt_As_npy_int32(__pyx_t_2); if (unlikely((__pyx_t_14 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1765, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      __pyx_t_15 = __pyx_PyFloat_AsDouble(__pyx_t_8); if (unlikely((__pyx_t_15 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1763, __pyx_L1_error)
+      __pyx_t_15 = __pyx_PyFloat_AsDouble(__pyx_t_8); if (unlikely((__pyx_t_15 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1765, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-      __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_9); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1763, __pyx_L1_error)
+      __pyx_t_16 = __pyx_PyFloat_AsDouble(__pyx_t_9); if (unlikely((__pyx_t_16 == ((npy_float64)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1765, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-      __pyx_t_17 = __Pyx_PyInt_As_npy_int32(__pyx_t_10); if (unlikely((__pyx_t_17 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1763, __pyx_L1_error)
+      __pyx_t_17 = __Pyx_PyInt_As_npy_int32(__pyx_t_10); if (unlikely((__pyx_t_17 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1765, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
       __pyx_v_tstart = __pyx_t_13;
       __pyx_v_tend = __pyx_t_14;
@@ -23701,201 +23733,201 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
       __pyx_v_tctrl_p = __pyx_t_16;
       __pyx_v_tlist_scores_p = __pyx_t_17;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1765
+      /* "MACS2/IO/CallPeakUnit.pyx":1767
  *                 (tstart, tend, ttreat_p, tctrl_p, tlist_scores_p) = peak_content[i]
  *                 #tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *                 tlist_pileup.append( ttreat_p )             # <<<<<<<<<<<<<<
  *                 tlist_control.append( tctrl_p )
  *                 tlist_length.append( tend - tstart )
  */
-      __Pyx_TraceLine(1765,0,__PYX_ERR(0, 1765, __pyx_L1_error))
-      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_ttreat_p); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1765, __pyx_L1_error)
+      __Pyx_TraceLine(1767,0,__PYX_ERR(0, 1767, __pyx_L1_error))
+      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_ttreat_p); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1767, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_tlist_pileup, __pyx_t_3); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 1765, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_tlist_pileup, __pyx_t_3); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 1767, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1766
+      /* "MACS2/IO/CallPeakUnit.pyx":1768
  *                 #tscore = ttreat_p #self.pqtable[ get_pscore(int(ttreat_p), tctrl_p) ] # use qscore as general score to find summit
  *                 tlist_pileup.append( ttreat_p )
  *                 tlist_control.append( tctrl_p )             # <<<<<<<<<<<<<<
  *                 tlist_length.append( tend - tstart )
  * 
  */
-      __Pyx_TraceLine(1766,0,__PYX_ERR(0, 1766, __pyx_L1_error))
-      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_tctrl_p); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1766, __pyx_L1_error)
+      __Pyx_TraceLine(1768,0,__PYX_ERR(0, 1768, __pyx_L1_error))
+      __pyx_t_3 = PyFloat_FromDouble(__pyx_v_tctrl_p); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1768, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_tlist_control, __pyx_t_3); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 1766, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_tlist_control, __pyx_t_3); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 1768, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1767
+      /* "MACS2/IO/CallPeakUnit.pyx":1769
  *                 tlist_pileup.append( ttreat_p )
  *                 tlist_control.append( tctrl_p )
  *                 tlist_length.append( tend - tstart )             # <<<<<<<<<<<<<<
  * 
  *             tarray_pileup = np.array( tlist_pileup, dtype="float32")
  */
-      __Pyx_TraceLine(1767,0,__PYX_ERR(0, 1767, __pyx_L1_error))
-      __pyx_t_3 = __Pyx_PyInt_From_npy_int32((__pyx_v_tend - __pyx_v_tstart)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1767, __pyx_L1_error)
+      __Pyx_TraceLine(1769,0,__PYX_ERR(0, 1769, __pyx_L1_error))
+      __pyx_t_3 = __Pyx_PyInt_From_npy_int32((__pyx_v_tend - __pyx_v_tstart)); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1769, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_tlist_length, __pyx_t_3); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 1767, __pyx_L1_error)
+      __pyx_t_18 = __Pyx_PyList_Append(__pyx_v_tlist_length, __pyx_t_3); if (unlikely(__pyx_t_18 == ((int)-1))) __PYX_ERR(0, 1769, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     }
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1769
+    /* "MACS2/IO/CallPeakUnit.pyx":1771
  *                 tlist_length.append( tend - tstart )
  * 
  *             tarray_pileup = np.array( tlist_pileup, dtype="float32")             # <<<<<<<<<<<<<<
  *             tarray_control = np.array( tlist_control, dtype="float32")
  *             tarray_pscore = self.__cal_pscore( tarray_pileup, tarray_control )
  */
-    __Pyx_TraceLine(1769,0,__PYX_ERR(0, 1769, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1769, __pyx_L1_error)
+    __Pyx_TraceLine(1771,0,__PYX_ERR(0, 1771, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_3, __pyx_n_s_np); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1771, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_10 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_array); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1769, __pyx_L1_error)
+    __pyx_t_10 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_array); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1771, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1769, __pyx_L1_error)
+    __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1771, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_v_tlist_pileup);
     __Pyx_GIVEREF(__pyx_v_tlist_pileup);
     PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_tlist_pileup);
-    __pyx_t_9 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1769, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1771, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
-    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1769, __pyx_L1_error)
-    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_10, __pyx_t_3, __pyx_t_9); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1769, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1771, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_10, __pyx_t_3, __pyx_t_9); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1771, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
-    if (!(likely(((__pyx_t_8) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_8, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1769, __pyx_L1_error)
+    if (!(likely(((__pyx_t_8) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_8, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1771, __pyx_L1_error)
     __pyx_v_tarray_pileup = ((PyArrayObject *)__pyx_t_8);
     __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1770
+    /* "MACS2/IO/CallPeakUnit.pyx":1772
  * 
  *             tarray_pileup = np.array( tlist_pileup, dtype="float32")
  *             tarray_control = np.array( tlist_control, dtype="float32")             # <<<<<<<<<<<<<<
  *             tarray_pscore = self.__cal_pscore( tarray_pileup, tarray_control )
  *             tarray_qscore = self.__cal_qscore( tarray_pileup, tarray_control )
  */
-    __Pyx_TraceLine(1770,0,__PYX_ERR(0, 1770, __pyx_L1_error))
-    __Pyx_GetModuleGlobalName(__pyx_t_8, __pyx_n_s_np); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1770, __pyx_L1_error)
+    __Pyx_TraceLine(1772,0,__PYX_ERR(0, 1772, __pyx_L1_error))
+    __Pyx_GetModuleGlobalName(__pyx_t_8, __pyx_n_s_np); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1772, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_t_8, __pyx_n_s_array); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1770, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_PyObject_GetAttrStr(__pyx_t_8, __pyx_n_s_array); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1772, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-    __pyx_t_8 = PyTuple_New(1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1770, __pyx_L1_error)
+    __pyx_t_8 = PyTuple_New(1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1772, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_INCREF(__pyx_v_tlist_control);
     __Pyx_GIVEREF(__pyx_v_tlist_control);
     PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_v_tlist_control);
-    __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1770, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_PyDict_NewPresized(1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1772, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1770, __pyx_L1_error)
-    __pyx_t_10 = __Pyx_PyObject_Call(__pyx_t_9, __pyx_t_8, __pyx_t_3); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1770, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_3, __pyx_n_s_dtype, __pyx_n_u_float32) < 0) __PYX_ERR(0, 1772, __pyx_L1_error)
+    __pyx_t_10 = __Pyx_PyObject_Call(__pyx_t_9, __pyx_t_8, __pyx_t_3); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1772, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    if (!(likely(((__pyx_t_10) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_10, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1770, __pyx_L1_error)
+    if (!(likely(((__pyx_t_10) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_10, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1772, __pyx_L1_error)
     __pyx_v_tarray_control = ((PyArrayObject *)__pyx_t_10);
     __pyx_t_10 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1771
+    /* "MACS2/IO/CallPeakUnit.pyx":1773
  *             tarray_pileup = np.array( tlist_pileup, dtype="float32")
  *             tarray_control = np.array( tlist_control, dtype="float32")
  *             tarray_pscore = self.__cal_pscore( tarray_pileup, tarray_control )             # <<<<<<<<<<<<<<
  *             tarray_qscore = self.__cal_qscore( tarray_pileup, tarray_control )
  *             tarray_fc     = self.__cal_FE    ( tarray_pileup, tarray_control )
  */
-    __Pyx_TraceLine(1771,0,__PYX_ERR(0, 1771, __pyx_L1_error))
-    __pyx_t_10 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_tarray_pileup), ((PyArrayObject *)__pyx_v_tarray_control))); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1771, __pyx_L1_error)
+    __Pyx_TraceLine(1773,0,__PYX_ERR(0, 1773, __pyx_L1_error))
+    __pyx_t_10 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_pscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_tarray_pileup), ((PyArrayObject *)__pyx_v_tarray_control))); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1773, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
     __pyx_v_tarray_pscore = ((PyArrayObject *)__pyx_t_10);
     __pyx_t_10 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1772
+    /* "MACS2/IO/CallPeakUnit.pyx":1774
  *             tarray_control = np.array( tlist_control, dtype="float32")
  *             tarray_pscore = self.__cal_pscore( tarray_pileup, tarray_control )
  *             tarray_qscore = self.__cal_qscore( tarray_pileup, tarray_control )             # <<<<<<<<<<<<<<
  *             tarray_fc     = self.__cal_FE    ( tarray_pileup, tarray_control )
  * 
  */
-    __Pyx_TraceLine(1772,0,__PYX_ERR(0, 1772, __pyx_L1_error))
-    __pyx_t_10 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_qscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_tarray_pileup), ((PyArrayObject *)__pyx_v_tarray_control))); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1772, __pyx_L1_error)
+    __Pyx_TraceLine(1774,0,__PYX_ERR(0, 1774, __pyx_L1_error))
+    __pyx_t_10 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_qscore(__pyx_v_self, ((PyArrayObject *)__pyx_v_tarray_pileup), ((PyArrayObject *)__pyx_v_tarray_control))); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1774, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
     __pyx_v_tarray_qscore = ((PyArrayObject *)__pyx_t_10);
     __pyx_t_10 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1773
+    /* "MACS2/IO/CallPeakUnit.pyx":1775
  *             tarray_pscore = self.__cal_pscore( tarray_pileup, tarray_control )
  *             tarray_qscore = self.__cal_qscore( tarray_pileup, tarray_control )
  *             tarray_fc     = self.__cal_FE    ( tarray_pileup, tarray_control )             # <<<<<<<<<<<<<<
  * 
  *             peaks.add( chrom,           # chromosome
  */
-    __Pyx_TraceLine(1773,0,__PYX_ERR(0, 1773, __pyx_L1_error))
-    __pyx_t_10 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_FE(__pyx_v_self, ((PyArrayObject *)__pyx_v_tarray_pileup), ((PyArrayObject *)__pyx_v_tarray_control))); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1773, __pyx_L1_error)
+    __Pyx_TraceLine(1775,0,__PYX_ERR(0, 1775, __pyx_L1_error))
+    __pyx_t_10 = ((PyObject *)((struct __pyx_vtabstruct_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments *)__pyx_v_self->__pyx_vtab)->__pyx___cal_FE(__pyx_v_self, ((PyArrayObject *)__pyx_v_tarray_pileup), ((PyArrayObject *)__pyx_v_tarray_control))); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1775, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
     __pyx_v_tarray_fc = ((PyArrayObject *)__pyx_t_10);
     __pyx_t_10 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1775
+    /* "MACS2/IO/CallPeakUnit.pyx":1777
  *             tarray_fc     = self.__cal_FE    ( tarray_pileup, tarray_control )
  * 
  *             peaks.add( chrom,           # chromosome             # <<<<<<<<<<<<<<
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  */
-    __Pyx_TraceLine(1775,0,__PYX_ERR(0, 1775, __pyx_L1_error))
-    __pyx_t_10 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_add); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1775, __pyx_L1_error)
+    __Pyx_TraceLine(1777,0,__PYX_ERR(0, 1777, __pyx_L1_error))
+    __pyx_t_10 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_add); if (unlikely(!__pyx_t_10)) __PYX_ERR(0, 1777, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_10);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1776
+    /* "MACS2/IO/CallPeakUnit.pyx":1778
  * 
  *             peaks.add( chrom,           # chromosome
  *                        peak_content[0][0], # start             # <<<<<<<<<<<<<<
  *                        peak_content[-1][1], # end
  *                        summit = 0,
  */
-    __Pyx_TraceLine(1776,0,__PYX_ERR(0, 1776, __pyx_L1_error))
+    __Pyx_TraceLine(1778,0,__PYX_ERR(0, 1778, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1776, __pyx_L1_error)
+      __PYX_ERR(0, 1778, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1776, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1778, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_8 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1776, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_GetItemInt(__pyx_t_3, 0, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1778, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1777
+    /* "MACS2/IO/CallPeakUnit.pyx":1779
  *             peaks.add( chrom,           # chromosome
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end             # <<<<<<<<<<<<<<
  *                        summit = 0,
  *                        peak_score  = mean_from_value_length( tarray_qscore, tlist_length ),
  */
-    __Pyx_TraceLine(1777,0,__PYX_ERR(0, 1777, __pyx_L1_error))
+    __Pyx_TraceLine(1779,0,__PYX_ERR(0, 1779, __pyx_L1_error))
     if (unlikely(__pyx_v_peak_content == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-      __PYX_ERR(0, 1777, __pyx_L1_error)
+      __PYX_ERR(0, 1779, __pyx_L1_error)
     }
-    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1777, __pyx_L1_error)
+    __pyx_t_3 = __Pyx_GetItemInt_List(__pyx_v_peak_content, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1779, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_9 = __Pyx_GetItemInt(__pyx_t_3, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1777, __pyx_L1_error)
+    __pyx_t_9 = __Pyx_GetItemInt(__pyx_t_3, 1, long, 1, __Pyx_PyInt_From_long, 0, 0, 1); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1779, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1775
+    /* "MACS2/IO/CallPeakUnit.pyx":1777
  *             tarray_fc     = self.__cal_FE    ( tarray_pileup, tarray_control )
  * 
  *             peaks.add( chrom,           # chromosome             # <<<<<<<<<<<<<<
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  */
-    __Pyx_TraceLine(1775,0,__PYX_ERR(0, 1775, __pyx_L1_error))
-    __pyx_t_3 = PyTuple_New(3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1775, __pyx_L1_error)
+    __Pyx_TraceLine(1777,0,__PYX_ERR(0, 1777, __pyx_L1_error))
+    __pyx_t_3 = PyTuple_New(3); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1777, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_3);
     __Pyx_INCREF(__pyx_v_chrom);
     __Pyx_GIVEREF(__pyx_v_chrom);
@@ -23907,112 +23939,112 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
     __pyx_t_8 = 0;
     __pyx_t_9 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1778
+    /* "MACS2/IO/CallPeakUnit.pyx":1780
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  *                        summit = 0,             # <<<<<<<<<<<<<<
  *                        peak_score  = mean_from_value_length( tarray_qscore, tlist_length ),
  *                        pileup      = mean_from_value_length( tarray_pileup, tlist_length ),
  */
-    __Pyx_TraceLine(1778,0,__PYX_ERR(0, 1778, __pyx_L1_error))
-    __pyx_t_9 = __Pyx_PyDict_NewPresized(6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1778, __pyx_L1_error)
+    __Pyx_TraceLine(1780,0,__PYX_ERR(0, 1780, __pyx_L1_error))
+    __pyx_t_9 = __Pyx_PyDict_NewPresized(6); if (unlikely(!__pyx_t_9)) __PYX_ERR(0, 1780, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_9);
-    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_summit, __pyx_int_0) < 0) __PYX_ERR(0, 1778, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_summit, __pyx_int_0) < 0) __PYX_ERR(0, 1780, __pyx_L1_error)
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1779
+    /* "MACS2/IO/CallPeakUnit.pyx":1781
  *                        peak_content[-1][1], # end
  *                        summit = 0,
  *                        peak_score  = mean_from_value_length( tarray_qscore, tlist_length ),             # <<<<<<<<<<<<<<
  *                        pileup      = mean_from_value_length( tarray_pileup, tlist_length ),
  *                        pscore      = mean_from_value_length( tarray_pscore, tlist_length ),
  */
-    __Pyx_TraceLine(1779,0,__PYX_ERR(0, 1779, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_qscore), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1779, __pyx_L1_error)
+    __Pyx_TraceLine(1781,0,__PYX_ERR(0, 1781, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_qscore), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1781, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_peak_score, __pyx_t_8) < 0) __PYX_ERR(0, 1778, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_peak_score, __pyx_t_8) < 0) __PYX_ERR(0, 1780, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1780
+    /* "MACS2/IO/CallPeakUnit.pyx":1782
  *                        summit = 0,
  *                        peak_score  = mean_from_value_length( tarray_qscore, tlist_length ),
  *                        pileup      = mean_from_value_length( tarray_pileup, tlist_length ),             # <<<<<<<<<<<<<<
  *                        pscore      = mean_from_value_length( tarray_pscore, tlist_length ),
  *                        fold_change = mean_from_value_length( tarray_fc, tlist_length ),
  */
-    __Pyx_TraceLine(1780,0,__PYX_ERR(0, 1780, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_pileup), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1780, __pyx_L1_error)
+    __Pyx_TraceLine(1782,0,__PYX_ERR(0, 1782, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_pileup), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1782, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_pileup, __pyx_t_8) < 0) __PYX_ERR(0, 1778, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_pileup, __pyx_t_8) < 0) __PYX_ERR(0, 1780, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1781
+    /* "MACS2/IO/CallPeakUnit.pyx":1783
  *                        peak_score  = mean_from_value_length( tarray_qscore, tlist_length ),
  *                        pileup      = mean_from_value_length( tarray_pileup, tlist_length ),
  *                        pscore      = mean_from_value_length( tarray_pscore, tlist_length ),             # <<<<<<<<<<<<<<
  *                        fold_change = mean_from_value_length( tarray_fc, tlist_length ),
  *                        qscore      = mean_from_value_length( tarray_qscore, tlist_length ),
  */
-    __Pyx_TraceLine(1781,0,__PYX_ERR(0, 1781, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_pscore), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1781, __pyx_L1_error)
+    __Pyx_TraceLine(1783,0,__PYX_ERR(0, 1783, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_pscore), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1783, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_pscore, __pyx_t_8) < 0) __PYX_ERR(0, 1778, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_pscore, __pyx_t_8) < 0) __PYX_ERR(0, 1780, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1782
+    /* "MACS2/IO/CallPeakUnit.pyx":1784
  *                        pileup      = mean_from_value_length( tarray_pileup, tlist_length ),
  *                        pscore      = mean_from_value_length( tarray_pscore, tlist_length ),
  *                        fold_change = mean_from_value_length( tarray_fc, tlist_length ),             # <<<<<<<<<<<<<<
  *                        qscore      = mean_from_value_length( tarray_qscore, tlist_length ),
  *                        )
  */
-    __Pyx_TraceLine(1782,0,__PYX_ERR(0, 1782, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_fc), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1782, __pyx_L1_error)
+    __Pyx_TraceLine(1784,0,__PYX_ERR(0, 1784, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_fc), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1784, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_fold_change, __pyx_t_8) < 0) __PYX_ERR(0, 1778, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_fold_change, __pyx_t_8) < 0) __PYX_ERR(0, 1780, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1783
+    /* "MACS2/IO/CallPeakUnit.pyx":1785
  *                        pscore      = mean_from_value_length( tarray_pscore, tlist_length ),
  *                        fold_change = mean_from_value_length( tarray_fc, tlist_length ),
  *                        qscore      = mean_from_value_length( tarray_qscore, tlist_length ),             # <<<<<<<<<<<<<<
  *                        )
  *             #if chrom == "chr1" and  peak_content[0][0] == 237643 and peak_content[-1][1] == 237935:
  */
-    __Pyx_TraceLine(1783,0,__PYX_ERR(0, 1783, __pyx_L1_error))
-    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_qscore), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1783, __pyx_L1_error)
+    __Pyx_TraceLine(1785,0,__PYX_ERR(0, 1785, __pyx_L1_error))
+    __pyx_t_8 = PyFloat_FromDouble(__pyx_f_5MACS2_2IO_12CallPeakUnit_mean_from_value_length(((PyArrayObject *)__pyx_v_tarray_qscore), __pyx_v_tlist_length)); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1785, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_qscore, __pyx_t_8) < 0) __PYX_ERR(0, 1778, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_9, __pyx_n_s_qscore, __pyx_t_8) < 0) __PYX_ERR(0, 1780, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1775
+    /* "MACS2/IO/CallPeakUnit.pyx":1777
  *             tarray_fc     = self.__cal_FE    ( tarray_pileup, tarray_control )
  * 
  *             peaks.add( chrom,           # chromosome             # <<<<<<<<<<<<<<
  *                        peak_content[0][0], # start
  *                        peak_content[-1][1], # end
  */
-    __Pyx_TraceLine(1775,0,__PYX_ERR(0, 1775, __pyx_L1_error))
-    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_10, __pyx_t_3, __pyx_t_9); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1775, __pyx_L1_error)
+    __Pyx_TraceLine(1777,0,__PYX_ERR(0, 1777, __pyx_L1_error))
+    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_10, __pyx_t_3, __pyx_t_9); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1777, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_10); __pyx_t_10 = 0;
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
     __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1788
+    /* "MACS2/IO/CallPeakUnit.pyx":1790
  *             #    print tarray_qscore, tlist_length
  *             # start a new peak
  *             return True             # <<<<<<<<<<<<<<
  * 
  *     cdef __add_broadpeak (self, bpeaks, bytes chrom, object lvl2peak, list lvl1peakset):
  */
-    __Pyx_TraceLine(1788,0,__PYX_ERR(0, 1788, __pyx_L1_error))
+    __Pyx_TraceLine(1790,0,__PYX_ERR(0, 1790, __pyx_L1_error))
     __Pyx_XDECREF(((PyObject *)__pyx_r));
     __Pyx_INCREF(Py_True);
     __pyx_r = ((PyBoolObject *)Py_True);
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1758
+    /* "MACS2/IO/CallPeakUnit.pyx":1760
  * 
  *         peak_length = peak_content[ -1 ][ 1 ] - peak_content[ 0 ][ 0 ]
  *         if peak_length >= min_length: # if the peak is too small, reject it             # <<<<<<<<<<<<<<
@@ -24021,7 +24053,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1740
+  /* "MACS2/IO/CallPeakUnit.pyx":1742
  *         return
  * 
  *     cdef bool __close_peak_for_broad_region (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
@@ -24058,7 +24090,7 @@ static PyBoolObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1790
+/* "MACS2/IO/CallPeakUnit.pyx":1792
  *             return True
  * 
  *     cdef __add_broadpeak (self, bpeaks, bytes chrom, object lvl2peak, list lvl1peakset):             # <<<<<<<<<<<<<<
@@ -24090,63 +24122,63 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
   PyObject *__pyx_t_8 = NULL;
   Py_ssize_t __pyx_t_9;
   __Pyx_RefNannySetupContext("__add_broadpeak", 0);
-  __Pyx_TraceCall("__add_broadpeak", __pyx_f[0], 1790, 0, __PYX_ERR(0, 1790, __pyx_L1_error));
+  __Pyx_TraceCall("__add_broadpeak", __pyx_f[0], 1792, 0, __PYX_ERR(0, 1792, __pyx_L1_error));
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1800
+  /* "MACS2/IO/CallPeakUnit.pyx":1802
  *             bytes blockSizes, blockStarts, thickStart, thickEnd,
  * 
  *         start      = lvl2peak["start"]             # <<<<<<<<<<<<<<
  *         end        = lvl2peak["end"]
  * 
  */
-  __Pyx_TraceLine(1800,0,__PYX_ERR(0, 1800, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1800, __pyx_L1_error)
+  __Pyx_TraceLine(1802,0,__PYX_ERR(0, 1802, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1802, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_2 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1800, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_2 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1802, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_start = __pyx_t_2;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1801
+  /* "MACS2/IO/CallPeakUnit.pyx":1803
  * 
  *         start      = lvl2peak["start"]
  *         end        = lvl2peak["end"]             # <<<<<<<<<<<<<<
  * 
  *         if not lvl1peakset:
  */
-  __Pyx_TraceLine(1801,0,__PYX_ERR(0, 1801, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_end); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1801, __pyx_L1_error)
+  __Pyx_TraceLine(1803,0,__PYX_ERR(0, 1803, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_end); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1803, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_2 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_2 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1801, __pyx_L1_error)
+  __pyx_t_2 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_2 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1803, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_v_end = __pyx_t_2;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1803
+  /* "MACS2/IO/CallPeakUnit.pyx":1805
  *         end        = lvl2peak["end"]
  * 
  *         if not lvl1peakset:             # <<<<<<<<<<<<<<
  *             # will complement by adding 1bps start and end to this region
  *             # may change in the future if gappedPeak format was improved.
  */
-  __Pyx_TraceLine(1803,0,__PYX_ERR(0, 1803, __pyx_L1_error))
+  __Pyx_TraceLine(1805,0,__PYX_ERR(0, 1805, __pyx_L1_error))
   __pyx_t_3 = (__pyx_v_lvl1peakset != Py_None)&&(PyList_GET_SIZE(__pyx_v_lvl1peakset) != 0);
   __pyx_t_4 = ((!__pyx_t_3) != 0);
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1806
+    /* "MACS2/IO/CallPeakUnit.pyx":1808
  *             # will complement by adding 1bps start and end to this region
  *             # may change in the future if gappedPeak format was improved.
  *             bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=(b"%d" % start), thickEnd=(b"%d" % end),             # <<<<<<<<<<<<<<
  *                        blockNum = 2, blockSizes = b"1,1", blockStarts = (b"0,%d" % (end-start-1)), pileup = lvl2peak["pileup"],
  *                        pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  */
-    __Pyx_TraceLine(1806,0,__PYX_ERR(0, 1806, __pyx_L1_error))
-    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_bpeaks, __pyx_n_s_add); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __Pyx_TraceLine(1808,0,__PYX_ERR(0, 1808, __pyx_L1_error))
+    __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_bpeaks, __pyx_n_s_add); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_7 = PyTuple_New(3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_7 = PyTuple_New(3); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_INCREF(__pyx_v_chrom);
     __Pyx_GIVEREF(__pyx_v_chrom);
@@ -24157,108 +24189,108 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
     PyTuple_SET_ITEM(__pyx_t_7, 2, __pyx_t_6);
     __pyx_t_5 = 0;
     __pyx_t_6 = 0;
-    __pyx_t_6 = __Pyx_PyDict_NewPresized(10); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyDict_NewPresized(10); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_5 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_score); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_score); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_score, __pyx_t_5) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_score, __pyx_t_5) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_thickStart, __pyx_t_8) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_thickStart, __pyx_t_8) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    __pyx_t_5 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_8); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __pyx_t_5 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_8); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_thickEnd, __pyx_t_5) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_thickEnd, __pyx_t_5) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_blockNum, __pyx_int_2) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_blockSizes, __pyx_kp_b_1_1) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_blockNum, __pyx_int_2) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_blockSizes, __pyx_kp_b_1_1) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1807
+    /* "MACS2/IO/CallPeakUnit.pyx":1809
  *             # may change in the future if gappedPeak format was improved.
  *             bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=(b"%d" % start), thickEnd=(b"%d" % end),
  *                        blockNum = 2, blockSizes = b"1,1", blockStarts = (b"0,%d" % (end-start-1)), pileup = lvl2peak["pileup"],             # <<<<<<<<<<<<<<
  *                        pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  *                        qscore = lvl2peak["qscore"] )
  */
-    __Pyx_TraceLine(1807,0,__PYX_ERR(0, 1807, __pyx_L1_error))
-    __pyx_t_5 = __Pyx_PyInt_From_long(((__pyx_v_end - __pyx_v_start) - 1)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1807, __pyx_L1_error)
+    __Pyx_TraceLine(1809,0,__PYX_ERR(0, 1809, __pyx_L1_error))
+    __pyx_t_5 = __Pyx_PyInt_From_long(((__pyx_v_end - __pyx_v_start) - 1)); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1809, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_0_d, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1807, __pyx_L1_error)
+    __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_0_d, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1809, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_blockStarts, __pyx_t_8) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_blockStarts, __pyx_t_8) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pileup); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1807, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pileup); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1809, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_pileup, __pyx_t_8) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_pileup, __pyx_t_8) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1808
+    /* "MACS2/IO/CallPeakUnit.pyx":1810
  *             bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=(b"%d" % start), thickEnd=(b"%d" % end),
  *                        blockNum = 2, blockSizes = b"1,1", blockStarts = (b"0,%d" % (end-start-1)), pileup = lvl2peak["pileup"],
  *                        pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],             # <<<<<<<<<<<<<<
  *                        qscore = lvl2peak["qscore"] )
  *             return bpeaks
  */
-    __Pyx_TraceLine(1808,0,__PYX_ERR(0, 1808, __pyx_L1_error))
-    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pscore); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1808, __pyx_L1_error)
+    __Pyx_TraceLine(1810,0,__PYX_ERR(0, 1810, __pyx_L1_error))
+    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pscore); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1810, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_pscore, __pyx_t_8) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_pscore, __pyx_t_8) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_fc); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1808, __pyx_L1_error)
+    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_fc); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1810, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_fold_change, __pyx_t_8) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_fold_change, __pyx_t_8) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1809
+    /* "MACS2/IO/CallPeakUnit.pyx":1811
  *                        blockNum = 2, blockSizes = b"1,1", blockStarts = (b"0,%d" % (end-start-1)), pileup = lvl2peak["pileup"],
  *                        pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  *                        qscore = lvl2peak["qscore"] )             # <<<<<<<<<<<<<<
  *             return bpeaks
  * 
  */
-    __Pyx_TraceLine(1809,0,__PYX_ERR(0, 1809, __pyx_L1_error))
-    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_qscore); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1809, __pyx_L1_error)
+    __Pyx_TraceLine(1811,0,__PYX_ERR(0, 1811, __pyx_L1_error))
+    __pyx_t_8 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_qscore); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1811, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_qscore, __pyx_t_8) < 0) __PYX_ERR(0, 1806, __pyx_L1_error)
+    if (PyDict_SetItem(__pyx_t_6, __pyx_n_s_qscore, __pyx_t_8) < 0) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1806
+    /* "MACS2/IO/CallPeakUnit.pyx":1808
  *             # will complement by adding 1bps start and end to this region
  *             # may change in the future if gappedPeak format was improved.
  *             bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=(b"%d" % start), thickEnd=(b"%d" % end),             # <<<<<<<<<<<<<<
  *                        blockNum = 2, blockSizes = b"1,1", blockStarts = (b"0,%d" % (end-start-1)), pileup = lvl2peak["pileup"],
  *                        pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  */
-    __Pyx_TraceLine(1806,0,__PYX_ERR(0, 1806, __pyx_L1_error))
-    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_7, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1806, __pyx_L1_error)
+    __Pyx_TraceLine(1808,0,__PYX_ERR(0, 1808, __pyx_L1_error))
+    __pyx_t_8 = __Pyx_PyObject_Call(__pyx_t_1, __pyx_t_7, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1808, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1810
+    /* "MACS2/IO/CallPeakUnit.pyx":1812
  *                        pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  *                        qscore = lvl2peak["qscore"] )
  *             return bpeaks             # <<<<<<<<<<<<<<
  * 
  *         thickStart = b"%d" % (lvl1peakset[0]["start"])
  */
-    __Pyx_TraceLine(1810,0,__PYX_ERR(0, 1810, __pyx_L1_error))
+    __Pyx_TraceLine(1812,0,__PYX_ERR(0, 1812, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
     __Pyx_INCREF(__pyx_v_bpeaks);
     __pyx_r = __pyx_v_bpeaks;
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1803
+    /* "MACS2/IO/CallPeakUnit.pyx":1805
  *         end        = lvl2peak["end"]
  * 
  *         if not lvl1peakset:             # <<<<<<<<<<<<<<
@@ -24267,99 +24299,99 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1812
+  /* "MACS2/IO/CallPeakUnit.pyx":1814
  *             return bpeaks
  * 
  *         thickStart = b"%d" % (lvl1peakset[0]["start"])             # <<<<<<<<<<<<<<
  *         thickEnd   = b"%d" % (lvl1peakset[-1]["end"])
  *         blockNum   = len(lvl1peakset)
  */
-  __Pyx_TraceLine(1812,0,__PYX_ERR(0, 1812, __pyx_L1_error))
+  __Pyx_TraceLine(1814,0,__PYX_ERR(0, 1814, __pyx_L1_error))
   if (unlikely(__pyx_v_lvl1peakset == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1812, __pyx_L1_error)
+    __PYX_ERR(0, 1814, __pyx_L1_error)
   }
-  __pyx_t_8 = __Pyx_GetItemInt_List(__pyx_v_lvl1peakset, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1812, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_GetItemInt_List(__pyx_v_lvl1peakset, 0, long, 1, __Pyx_PyInt_From_long, 1, 0, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1814, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
-  __pyx_t_6 = __Pyx_PyObject_Dict_GetItem(__pyx_t_8, __pyx_n_u_start); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1812, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_Dict_GetItem(__pyx_t_8, __pyx_n_u_start); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1814, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-  __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1812, __pyx_L1_error)
+  __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1814, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_v_thickStart = ((PyObject*)__pyx_t_8);
   __pyx_t_8 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1813
+  /* "MACS2/IO/CallPeakUnit.pyx":1815
  * 
  *         thickStart = b"%d" % (lvl1peakset[0]["start"])
  *         thickEnd   = b"%d" % (lvl1peakset[-1]["end"])             # <<<<<<<<<<<<<<
  *         blockNum   = len(lvl1peakset)
  *         blockSizes = b",".join([b"%d" % y for y in [x["length"] for x in lvl1peakset]])
  */
-  __Pyx_TraceLine(1813,0,__PYX_ERR(0, 1813, __pyx_L1_error))
+  __Pyx_TraceLine(1815,0,__PYX_ERR(0, 1815, __pyx_L1_error))
   if (unlikely(__pyx_v_lvl1peakset == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-    __PYX_ERR(0, 1813, __pyx_L1_error)
+    __PYX_ERR(0, 1815, __pyx_L1_error)
   }
-  __pyx_t_8 = __Pyx_GetItemInt_List(__pyx_v_lvl1peakset, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1813, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_GetItemInt_List(__pyx_v_lvl1peakset, -1L, long, 1, __Pyx_PyInt_From_long, 1, 1, 1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1815, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
-  __pyx_t_6 = __Pyx_PyObject_Dict_GetItem(__pyx_t_8, __pyx_n_u_end); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1813, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyObject_Dict_GetItem(__pyx_t_8, __pyx_n_u_end); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1815, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-  __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1813, __pyx_L1_error)
+  __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1815, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_v_thickEnd = ((PyObject*)__pyx_t_8);
   __pyx_t_8 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1814
+  /* "MACS2/IO/CallPeakUnit.pyx":1816
  *         thickStart = b"%d" % (lvl1peakset[0]["start"])
  *         thickEnd   = b"%d" % (lvl1peakset[-1]["end"])
  *         blockNum   = len(lvl1peakset)             # <<<<<<<<<<<<<<
  *         blockSizes = b",".join([b"%d" % y for y in [x["length"] for x in lvl1peakset]])
  *         blockStarts = b",".join([b"%d" % x for x in getitem_then_subtract(lvl1peakset, start)])
  */
-  __Pyx_TraceLine(1814,0,__PYX_ERR(0, 1814, __pyx_L1_error))
+  __Pyx_TraceLine(1816,0,__PYX_ERR(0, 1816, __pyx_L1_error))
   if (unlikely(__pyx_v_lvl1peakset == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 1814, __pyx_L1_error)
+    __PYX_ERR(0, 1816, __pyx_L1_error)
   }
-  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_lvl1peakset); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1814, __pyx_L1_error)
+  __pyx_t_9 = PyList_GET_SIZE(__pyx_v_lvl1peakset); if (unlikely(__pyx_t_9 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1816, __pyx_L1_error)
   __pyx_v_blockNum = __pyx_t_9;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1815
+  /* "MACS2/IO/CallPeakUnit.pyx":1817
  *         thickEnd   = b"%d" % (lvl1peakset[-1]["end"])
  *         blockNum   = len(lvl1peakset)
  *         blockSizes = b",".join([b"%d" % y for y in [x["length"] for x in lvl1peakset]])             # <<<<<<<<<<<<<<
  *         blockStarts = b",".join([b"%d" % x for x in getitem_then_subtract(lvl1peakset, start)])
  * 
  */
-  __Pyx_TraceLine(1815,0,__PYX_ERR(0, 1815, __pyx_L1_error))
+  __Pyx_TraceLine(1817,0,__PYX_ERR(0, 1817, __pyx_L1_error))
   { /* enter inner scope */
-    __pyx_t_8 = PyList_New(0); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1815, __pyx_L6_error)
+    __pyx_t_8 = PyList_New(0); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1817, __pyx_L6_error)
     __Pyx_GOTREF(__pyx_t_8);
     { /* enter inner scope */
-      __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1815, __pyx_L11_error)
+      __pyx_t_6 = PyList_New(0); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1817, __pyx_L11_error)
       __Pyx_GOTREF(__pyx_t_6);
       if (unlikely(__pyx_v_lvl1peakset == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-        __PYX_ERR(0, 1815, __pyx_L11_error)
+        __PYX_ERR(0, 1817, __pyx_L11_error)
       }
       __pyx_t_7 = __pyx_v_lvl1peakset; __Pyx_INCREF(__pyx_t_7); __pyx_t_9 = 0;
       for (;;) {
         if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_7)) break;
         #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-        __pyx_t_1 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 1815, __pyx_L11_error)
+        __pyx_t_1 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_9); __Pyx_INCREF(__pyx_t_1); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 1817, __pyx_L11_error)
         #else
-        __pyx_t_1 = PySequence_ITEM(__pyx_t_7, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1815, __pyx_L11_error)
+        __pyx_t_1 = PySequence_ITEM(__pyx_t_7, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1817, __pyx_L11_error)
         __Pyx_GOTREF(__pyx_t_1);
         #endif
         __Pyx_XDECREF_SET(__pyx_8genexpr5__pyx_v_x, __pyx_t_1);
         __pyx_t_1 = 0;
-        __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_8genexpr5__pyx_v_x, __pyx_n_u_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1815, __pyx_L11_error)
+        __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_8genexpr5__pyx_v_x, __pyx_n_u_length); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1817, __pyx_L11_error)
         __Pyx_GOTREF(__pyx_t_1);
-        if (unlikely(__Pyx_ListComp_Append(__pyx_t_6, (PyObject*)__pyx_t_1))) __PYX_ERR(0, 1815, __pyx_L11_error)
+        if (unlikely(__Pyx_ListComp_Append(__pyx_t_6, (PyObject*)__pyx_t_1))) __PYX_ERR(0, 1817, __pyx_L11_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       }
       __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
@@ -24375,16 +24407,16 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
     for (;;) {
       if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_7)) break;
       #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-      __pyx_t_6 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_9); __Pyx_INCREF(__pyx_t_6); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 1815, __pyx_L6_error)
+      __pyx_t_6 = PyList_GET_ITEM(__pyx_t_7, __pyx_t_9); __Pyx_INCREF(__pyx_t_6); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 1817, __pyx_L6_error)
       #else
-      __pyx_t_6 = PySequence_ITEM(__pyx_t_7, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1815, __pyx_L6_error)
+      __pyx_t_6 = PySequence_ITEM(__pyx_t_7, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1817, __pyx_L6_error)
       __Pyx_GOTREF(__pyx_t_6);
       #endif
       __Pyx_XDECREF_SET(__pyx_8genexpr4__pyx_v_y, __pyx_t_6);
       __pyx_t_6 = 0;
-      __pyx_t_6 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_8genexpr4__pyx_v_y); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1815, __pyx_L6_error)
+      __pyx_t_6 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_8genexpr4__pyx_v_y); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1817, __pyx_L6_error)
       __Pyx_GOTREF(__pyx_t_6);
-      if (unlikely(__Pyx_ListComp_Append(__pyx_t_8, (PyObject*)__pyx_t_6))) __PYX_ERR(0, 1815, __pyx_L6_error)
+      if (unlikely(__Pyx_ListComp_Append(__pyx_t_8, (PyObject*)__pyx_t_6))) __PYX_ERR(0, 1817, __pyx_L6_error)
       __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     }
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
@@ -24395,45 +24427,45 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
     goto __pyx_L1_error;
     __pyx_L15_exit_scope:;
   } /* exit inner scope */
-  __pyx_t_7 = __Pyx_PyBytes_Join(__pyx_kp_b__13, __pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1815, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyBytes_Join(__pyx_kp_b__13, __pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1817, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-  if (!(likely(PyBytes_CheckExact(__pyx_t_7))||((__pyx_t_7) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_7)->tp_name), 0))) __PYX_ERR(0, 1815, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_7))||((__pyx_t_7) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_7)->tp_name), 0))) __PYX_ERR(0, 1817, __pyx_L1_error)
   __pyx_v_blockSizes = ((PyObject*)__pyx_t_7);
   __pyx_t_7 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1816
+  /* "MACS2/IO/CallPeakUnit.pyx":1818
  *         blockNum   = len(lvl1peakset)
  *         blockSizes = b",".join([b"%d" % y for y in [x["length"] for x in lvl1peakset]])
  *         blockStarts = b",".join([b"%d" % x for x in getitem_then_subtract(lvl1peakset, start)])             # <<<<<<<<<<<<<<
  * 
  *         # add 1bp left and/or right block if necessary
  */
-  __Pyx_TraceLine(1816,0,__PYX_ERR(0, 1816, __pyx_L1_error))
+  __Pyx_TraceLine(1818,0,__PYX_ERR(0, 1818, __pyx_L1_error))
   { /* enter inner scope */
-    __pyx_t_7 = PyList_New(0); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1816, __pyx_L18_error)
+    __pyx_t_7 = PyList_New(0); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1818, __pyx_L18_error)
     __Pyx_GOTREF(__pyx_t_7);
-    __pyx_t_8 = __pyx_f_5MACS2_2IO_12CallPeakUnit_getitem_then_subtract(__pyx_v_lvl1peakset, __pyx_v_start); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1816, __pyx_L18_error)
+    __pyx_t_8 = __pyx_f_5MACS2_2IO_12CallPeakUnit_getitem_then_subtract(__pyx_v_lvl1peakset, __pyx_v_start); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1818, __pyx_L18_error)
     __Pyx_GOTREF(__pyx_t_8);
     if (unlikely(__pyx_t_8 == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-      __PYX_ERR(0, 1816, __pyx_L18_error)
+      __PYX_ERR(0, 1818, __pyx_L18_error)
     }
     __pyx_t_6 = __pyx_t_8; __Pyx_INCREF(__pyx_t_6); __pyx_t_9 = 0;
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     for (;;) {
       if (__pyx_t_9 >= PyList_GET_SIZE(__pyx_t_6)) break;
       #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
-      __pyx_t_8 = PyList_GET_ITEM(__pyx_t_6, __pyx_t_9); __Pyx_INCREF(__pyx_t_8); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 1816, __pyx_L18_error)
+      __pyx_t_8 = PyList_GET_ITEM(__pyx_t_6, __pyx_t_9); __Pyx_INCREF(__pyx_t_8); __pyx_t_9++; if (unlikely(0 < 0)) __PYX_ERR(0, 1818, __pyx_L18_error)
       #else
-      __pyx_t_8 = PySequence_ITEM(__pyx_t_6, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1816, __pyx_L18_error)
+      __pyx_t_8 = PySequence_ITEM(__pyx_t_6, __pyx_t_9); __pyx_t_9++; if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1818, __pyx_L18_error)
       __Pyx_GOTREF(__pyx_t_8);
       #endif
       __Pyx_XDECREF_SET(__pyx_8genexpr6__pyx_v_x, __pyx_t_8);
       __pyx_t_8 = 0;
-      __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_8genexpr6__pyx_v_x); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1816, __pyx_L18_error)
+      __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_8genexpr6__pyx_v_x); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1818, __pyx_L18_error)
       __Pyx_GOTREF(__pyx_t_8);
-      if (unlikely(__Pyx_ListComp_Append(__pyx_t_7, (PyObject*)__pyx_t_8))) __PYX_ERR(0, 1816, __pyx_L18_error)
+      if (unlikely(__Pyx_ListComp_Append(__pyx_t_7, (PyObject*)__pyx_t_8))) __PYX_ERR(0, 1818, __pyx_L18_error)
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     }
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
@@ -24444,85 +24476,85 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
     goto __pyx_L1_error;
     __pyx_L21_exit_scope:;
   } /* exit inner scope */
-  __pyx_t_6 = __Pyx_PyBytes_Join(__pyx_kp_b__13, __pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1816, __pyx_L1_error)
+  __pyx_t_6 = __Pyx_PyBytes_Join(__pyx_kp_b__13, __pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1818, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  if (!(likely(PyBytes_CheckExact(__pyx_t_6))||((__pyx_t_6) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_6)->tp_name), 0))) __PYX_ERR(0, 1816, __pyx_L1_error)
+  if (!(likely(PyBytes_CheckExact(__pyx_t_6))||((__pyx_t_6) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_6)->tp_name), 0))) __PYX_ERR(0, 1818, __pyx_L1_error)
   __pyx_v_blockStarts = ((PyObject*)__pyx_t_6);
   __pyx_t_6 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1819
+  /* "MACS2/IO/CallPeakUnit.pyx":1821
  * 
  *         # add 1bp left and/or right block if necessary
  *         if int(thickStart) != start:             # <<<<<<<<<<<<<<
  *             # add 1bp left block
  *             thickStart = b"%d" % start
  */
-  __Pyx_TraceLine(1819,0,__PYX_ERR(0, 1819, __pyx_L1_error))
-  __pyx_t_6 = __Pyx_PyNumber_Int(__pyx_v_thickStart); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1819, __pyx_L1_error)
+  __Pyx_TraceLine(1821,0,__PYX_ERR(0, 1821, __pyx_L1_error))
+  __pyx_t_6 = __Pyx_PyNumber_Int(__pyx_v_thickStart); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1821, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_7 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1819, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1821, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_8 = PyObject_RichCompare(__pyx_t_6, __pyx_t_7, Py_NE); __Pyx_XGOTREF(__pyx_t_8); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1819, __pyx_L1_error)
+  __pyx_t_8 = PyObject_RichCompare(__pyx_t_6, __pyx_t_7, Py_NE); __Pyx_XGOTREF(__pyx_t_8); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1821, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_8); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1819, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_8); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1821, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1821
+    /* "MACS2/IO/CallPeakUnit.pyx":1823
  *         if int(thickStart) != start:
  *             # add 1bp left block
  *             thickStart = b"%d" % start             # <<<<<<<<<<<<<<
  *             blockNum += 1
  *             blockSizes = b"1,"+blockSizes
  */
-    __Pyx_TraceLine(1821,0,__PYX_ERR(0, 1821, __pyx_L1_error))
-    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1821, __pyx_L1_error)
+    __Pyx_TraceLine(1823,0,__PYX_ERR(0, 1823, __pyx_L1_error))
+    __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1823, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    __pyx_t_7 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1821, __pyx_L1_error)
+    __pyx_t_7 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1823, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     __Pyx_DECREF_SET(__pyx_v_thickStart, ((PyObject*)__pyx_t_7));
     __pyx_t_7 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1822
+    /* "MACS2/IO/CallPeakUnit.pyx":1824
  *             # add 1bp left block
  *             thickStart = b"%d" % start
  *             blockNum += 1             # <<<<<<<<<<<<<<
  *             blockSizes = b"1,"+blockSizes
  *             blockStarts = b"0,"+blockStarts
  */
-    __Pyx_TraceLine(1822,0,__PYX_ERR(0, 1822, __pyx_L1_error))
+    __Pyx_TraceLine(1824,0,__PYX_ERR(0, 1824, __pyx_L1_error))
     __pyx_v_blockNum = (__pyx_v_blockNum + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1823
+    /* "MACS2/IO/CallPeakUnit.pyx":1825
  *             thickStart = b"%d" % start
  *             blockNum += 1
  *             blockSizes = b"1,"+blockSizes             # <<<<<<<<<<<<<<
  *             blockStarts = b"0,"+blockStarts
  *         if int(thickEnd) != end:
  */
-    __Pyx_TraceLine(1823,0,__PYX_ERR(0, 1823, __pyx_L1_error))
-    __pyx_t_7 = PyNumber_Add(__pyx_kp_b_1, __pyx_v_blockSizes); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1823, __pyx_L1_error)
+    __Pyx_TraceLine(1825,0,__PYX_ERR(0, 1825, __pyx_L1_error))
+    __pyx_t_7 = PyNumber_Add(__pyx_kp_b_1, __pyx_v_blockSizes); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1825, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_DECREF_SET(__pyx_v_blockSizes, ((PyObject*)__pyx_t_7));
     __pyx_t_7 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1824
+    /* "MACS2/IO/CallPeakUnit.pyx":1826
  *             blockNum += 1
  *             blockSizes = b"1,"+blockSizes
  *             blockStarts = b"0,"+blockStarts             # <<<<<<<<<<<<<<
  *         if int(thickEnd) != end:
  *             # add 1bp right block
  */
-    __Pyx_TraceLine(1824,0,__PYX_ERR(0, 1824, __pyx_L1_error))
-    __pyx_t_7 = PyNumber_Add(__pyx_kp_b_0, __pyx_v_blockStarts); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1824, __pyx_L1_error)
+    __Pyx_TraceLine(1826,0,__PYX_ERR(0, 1826, __pyx_L1_error))
+    __pyx_t_7 = PyNumber_Add(__pyx_kp_b_0, __pyx_v_blockStarts); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1826, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_DECREF_SET(__pyx_v_blockStarts, ((PyObject*)__pyx_t_7));
     __pyx_t_7 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1819
+    /* "MACS2/IO/CallPeakUnit.pyx":1821
  * 
  *         # add 1bp left and/or right block if necessary
  *         if int(thickStart) != start:             # <<<<<<<<<<<<<<
@@ -24531,87 +24563,87 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1825
+  /* "MACS2/IO/CallPeakUnit.pyx":1827
  *             blockSizes = b"1,"+blockSizes
  *             blockStarts = b"0,"+blockStarts
  *         if int(thickEnd) != end:             # <<<<<<<<<<<<<<
  *             # add 1bp right block
  *             thickEnd = b"%d" % end
  */
-  __Pyx_TraceLine(1825,0,__PYX_ERR(0, 1825, __pyx_L1_error))
-  __pyx_t_7 = __Pyx_PyNumber_Int(__pyx_v_thickEnd); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1825, __pyx_L1_error)
+  __Pyx_TraceLine(1827,0,__PYX_ERR(0, 1827, __pyx_L1_error))
+  __pyx_t_7 = __Pyx_PyNumber_Int(__pyx_v_thickEnd); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1827, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1825, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1827, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
-  __pyx_t_6 = PyObject_RichCompare(__pyx_t_7, __pyx_t_8, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1825, __pyx_L1_error)
+  __pyx_t_6 = PyObject_RichCompare(__pyx_t_7, __pyx_t_8, Py_NE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1827, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1825, __pyx_L1_error)
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_4 < 0)) __PYX_ERR(0, 1827, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   if (__pyx_t_4) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1827
+    /* "MACS2/IO/CallPeakUnit.pyx":1829
  *         if int(thickEnd) != end:
  *             # add 1bp right block
  *             thickEnd = b"%d" % end             # <<<<<<<<<<<<<<
  *             blockNum += 1
  *             blockSizes = blockSizes + b",1"
  */
-    __Pyx_TraceLine(1827,0,__PYX_ERR(0, 1827, __pyx_L1_error))
-    __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1827, __pyx_L1_error)
+    __Pyx_TraceLine(1829,0,__PYX_ERR(0, 1829, __pyx_L1_error))
+    __pyx_t_6 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1829, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1827, __pyx_L1_error)
+    __pyx_t_8 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1829, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __Pyx_DECREF_SET(__pyx_v_thickEnd, ((PyObject*)__pyx_t_8));
     __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1828
+    /* "MACS2/IO/CallPeakUnit.pyx":1830
  *             # add 1bp right block
  *             thickEnd = b"%d" % end
  *             blockNum += 1             # <<<<<<<<<<<<<<
  *             blockSizes = blockSizes + b",1"
  *             blockStarts = blockStarts + b"," + (b"%d" % (end-start-1))
  */
-    __Pyx_TraceLine(1828,0,__PYX_ERR(0, 1828, __pyx_L1_error))
+    __Pyx_TraceLine(1830,0,__PYX_ERR(0, 1830, __pyx_L1_error))
     __pyx_v_blockNum = (__pyx_v_blockNum + 1);
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1829
+    /* "MACS2/IO/CallPeakUnit.pyx":1831
  *             thickEnd = b"%d" % end
  *             blockNum += 1
  *             blockSizes = blockSizes + b",1"             # <<<<<<<<<<<<<<
  *             blockStarts = blockStarts + b"," + (b"%d" % (end-start-1))
  * 
  */
-    __Pyx_TraceLine(1829,0,__PYX_ERR(0, 1829, __pyx_L1_error))
-    __pyx_t_8 = PyNumber_Add(__pyx_v_blockSizes, __pyx_kp_b_1_2); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1829, __pyx_L1_error)
+    __Pyx_TraceLine(1831,0,__PYX_ERR(0, 1831, __pyx_L1_error))
+    __pyx_t_8 = PyNumber_Add(__pyx_v_blockSizes, __pyx_kp_b_1_2); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1831, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
     __Pyx_DECREF_SET(__pyx_v_blockSizes, ((PyObject*)__pyx_t_8));
     __pyx_t_8 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1830
+    /* "MACS2/IO/CallPeakUnit.pyx":1832
  *             blockNum += 1
  *             blockSizes = blockSizes + b",1"
  *             blockStarts = blockStarts + b"," + (b"%d" % (end-start-1))             # <<<<<<<<<<<<<<
  * 
  *         bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=thickStart, thickEnd=thickEnd,
  */
-    __Pyx_TraceLine(1830,0,__PYX_ERR(0, 1830, __pyx_L1_error))
-    __pyx_t_8 = PyNumber_Add(__pyx_v_blockStarts, __pyx_kp_b__13); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1830, __pyx_L1_error)
+    __Pyx_TraceLine(1832,0,__PYX_ERR(0, 1832, __pyx_L1_error))
+    __pyx_t_8 = PyNumber_Add(__pyx_v_blockStarts, __pyx_kp_b__13); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1832, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_8);
-    __pyx_t_6 = __Pyx_PyInt_From_long(((__pyx_v_end - __pyx_v_start) - 1)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1830, __pyx_L1_error)
+    __pyx_t_6 = __Pyx_PyInt_From_long(((__pyx_v_end - __pyx_v_start) - 1)); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1832, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
-    __pyx_t_7 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1830, __pyx_L1_error)
+    __pyx_t_7 = PyNumber_Remainder(__pyx_kp_b_d_2, __pyx_t_6); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1832, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_7);
     __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-    __pyx_t_6 = PyNumber_Add(__pyx_t_8, __pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1830, __pyx_L1_error)
+    __pyx_t_6 = PyNumber_Add(__pyx_t_8, __pyx_t_7); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1832, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
     __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
     __Pyx_DECREF_SET(__pyx_v_blockStarts, ((PyObject*)__pyx_t_6));
     __pyx_t_6 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1825
+    /* "MACS2/IO/CallPeakUnit.pyx":1827
  *             blockSizes = b"1,"+blockSizes
  *             blockStarts = b"0,"+blockStarts
  *         if int(thickEnd) != end:             # <<<<<<<<<<<<<<
@@ -24620,21 +24652,21 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1832
+  /* "MACS2/IO/CallPeakUnit.pyx":1834
  *             blockStarts = blockStarts + b"," + (b"%d" % (end-start-1))
  * 
  *         bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=thickStart, thickEnd=thickEnd,             # <<<<<<<<<<<<<<
  *                    blockNum = blockNum, blockSizes = blockSizes, blockStarts = blockStarts, pileup = lvl2peak["pileup"],
  *                    pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  */
-  __Pyx_TraceLine(1832,0,__PYX_ERR(0, 1832, __pyx_L1_error))
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_bpeaks, __pyx_n_s_add); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1832, __pyx_L1_error)
+  __Pyx_TraceLine(1834,0,__PYX_ERR(0, 1834, __pyx_L1_error))
+  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_bpeaks, __pyx_n_s_add); if (unlikely(!__pyx_t_6)) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_7 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1832, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyInt_From_npy_int32(__pyx_v_start); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1832, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_PyInt_From_npy_int32(__pyx_v_end); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
-  __pyx_t_1 = PyTuple_New(3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1832, __pyx_L1_error)
+  __pyx_t_1 = PyTuple_New(3); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_INCREF(__pyx_v_chrom);
   __Pyx_GIVEREF(__pyx_v_chrom);
@@ -24645,93 +24677,93 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
   PyTuple_SET_ITEM(__pyx_t_1, 2, __pyx_t_8);
   __pyx_t_7 = 0;
   __pyx_t_8 = 0;
-  __pyx_t_8 = __Pyx_PyDict_NewPresized(10); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1832, __pyx_L1_error)
+  __pyx_t_8 = __Pyx_PyDict_NewPresized(10); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_8);
-  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_score); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1832, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_score); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_score, __pyx_t_7) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_score, __pyx_t_7) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_thickStart, __pyx_v_thickStart) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_thickEnd, __pyx_v_thickEnd) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_thickStart, __pyx_v_thickStart) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_thickEnd, __pyx_v_thickEnd) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1833
+  /* "MACS2/IO/CallPeakUnit.pyx":1835
  * 
  *         bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=thickStart, thickEnd=thickEnd,
  *                    blockNum = blockNum, blockSizes = blockSizes, blockStarts = blockStarts, pileup = lvl2peak["pileup"],             # <<<<<<<<<<<<<<
  *                    pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  *                    qscore = lvl2peak["qscore"] )
  */
-  __Pyx_TraceLine(1833,0,__PYX_ERR(0, 1833, __pyx_L1_error))
-  __pyx_t_7 = __Pyx_PyInt_From_npy_int32(__pyx_v_blockNum); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1833, __pyx_L1_error)
+  __Pyx_TraceLine(1835,0,__PYX_ERR(0, 1835, __pyx_L1_error))
+  __pyx_t_7 = __Pyx_PyInt_From_npy_int32(__pyx_v_blockNum); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1835, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_blockNum, __pyx_t_7) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_blockNum, __pyx_t_7) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_blockSizes, __pyx_v_blockSizes) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_blockStarts, __pyx_v_blockStarts) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
-  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pileup); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1833, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_blockSizes, __pyx_v_blockSizes) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_blockStarts, __pyx_v_blockStarts) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pileup); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1835, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_pileup, __pyx_t_7) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_pileup, __pyx_t_7) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1834
+  /* "MACS2/IO/CallPeakUnit.pyx":1836
  *         bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=thickStart, thickEnd=thickEnd,
  *                    blockNum = blockNum, blockSizes = blockSizes, blockStarts = blockStarts, pileup = lvl2peak["pileup"],
  *                    pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],             # <<<<<<<<<<<<<<
  *                    qscore = lvl2peak["qscore"] )
  *         return bpeaks
  */
-  __Pyx_TraceLine(1834,0,__PYX_ERR(0, 1834, __pyx_L1_error))
-  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pscore); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1834, __pyx_L1_error)
+  __Pyx_TraceLine(1836,0,__PYX_ERR(0, 1836, __pyx_L1_error))
+  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_pscore); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1836, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_pscore, __pyx_t_7) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_pscore, __pyx_t_7) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
-  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_fc); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1834, __pyx_L1_error)
+  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_fc); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1836, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_fold_change, __pyx_t_7) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_fold_change, __pyx_t_7) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1835
+  /* "MACS2/IO/CallPeakUnit.pyx":1837
  *                    blockNum = blockNum, blockSizes = blockSizes, blockStarts = blockStarts, pileup = lvl2peak["pileup"],
  *                    pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  *                    qscore = lvl2peak["qscore"] )             # <<<<<<<<<<<<<<
  *         return bpeaks
  * 
  */
-  __Pyx_TraceLine(1835,0,__PYX_ERR(0, 1835, __pyx_L1_error))
-  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_qscore); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1835, __pyx_L1_error)
+  __Pyx_TraceLine(1837,0,__PYX_ERR(0, 1837, __pyx_L1_error))
+  __pyx_t_7 = __Pyx_PyObject_Dict_GetItem(__pyx_v_lvl2peak, __pyx_n_u_qscore); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1837, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
-  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_qscore, __pyx_t_7) < 0) __PYX_ERR(0, 1832, __pyx_L1_error)
+  if (PyDict_SetItem(__pyx_t_8, __pyx_n_s_qscore, __pyx_t_7) < 0) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1832
+  /* "MACS2/IO/CallPeakUnit.pyx":1834
  *             blockStarts = blockStarts + b"," + (b"%d" % (end-start-1))
  * 
  *         bpeaks.add(chrom, start, end, score=lvl2peak["score"], thickStart=thickStart, thickEnd=thickEnd,             # <<<<<<<<<<<<<<
  *                    blockNum = blockNum, blockSizes = blockSizes, blockStarts = blockStarts, pileup = lvl2peak["pileup"],
  *                    pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  */
-  __Pyx_TraceLine(1832,0,__PYX_ERR(0, 1832, __pyx_L1_error))
-  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_1, __pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1832, __pyx_L1_error)
+  __Pyx_TraceLine(1834,0,__PYX_ERR(0, 1834, __pyx_L1_error))
+  __pyx_t_7 = __Pyx_PyObject_Call(__pyx_t_6, __pyx_t_1, __pyx_t_8); if (unlikely(!__pyx_t_7)) __PYX_ERR(0, 1834, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_7);
   __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
   __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1836
+  /* "MACS2/IO/CallPeakUnit.pyx":1838
  *                    pscore = lvl2peak["pscore"], fold_change = lvl2peak["fc"],
  *                    qscore = lvl2peak["qscore"] )
  *         return bpeaks             # <<<<<<<<<<<<<<
  * 
  *     cpdef refine_peak_from_tags_distribution ( self, peaks, int32_t window_size = 100, float32_t cutoff = 5 ):
  */
-  __Pyx_TraceLine(1836,0,__PYX_ERR(0, 1836, __pyx_L1_error))
+  __Pyx_TraceLine(1838,0,__PYX_ERR(0, 1838, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(__pyx_v_bpeaks);
   __pyx_r = __pyx_v_bpeaks;
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1790
+  /* "MACS2/IO/CallPeakUnit.pyx":1792
  *             return True
  * 
  *     cdef __add_broadpeak (self, bpeaks, bytes chrom, object lvl2peak, list lvl1peakset):             # <<<<<<<<<<<<<<
@@ -24762,7 +24794,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments___add_
   return __pyx_r;
 }
 
-/* "MACS2/IO/CallPeakUnit.pyx":1838
+/* "MACS2/IO/CallPeakUnit.pyx":1840
  *         return bpeaks
  * 
  *     cpdef refine_peak_from_tags_distribution ( self, peaks, int32_t window_size = 100, float32_t cutoff = 5 ):             # <<<<<<<<<<<<<<
@@ -24828,7 +24860,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
   Py_ssize_t __pyx_t_23;
   Py_ssize_t __pyx_t_24;
   __Pyx_RefNannySetupContext("refine_peak_from_tags_distribution", 0);
-  __Pyx_TraceCall("refine_peak_from_tags_distribution", __pyx_f[0], 1838, 0, __PYX_ERR(0, 1838, __pyx_L1_error));
+  __Pyx_TraceCall("refine_peak_from_tags_distribution", __pyx_f[0], 1840, 0, __PYX_ERR(0, 1840, __pyx_L1_error));
   if (__pyx_optional_args) {
     if (__pyx_optional_args->__pyx_n > 0) {
       __pyx_v_window_size = __pyx_optional_args->window_size;
@@ -24846,13 +24878,13 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
     if (unlikely(!__Pyx_object_dict_version_matches(((PyObject *)__pyx_v_self), __pyx_tp_dict_version, __pyx_obj_dict_version))) {
       PY_UINT64_T __pyx_type_dict_guard = __Pyx_get_tp_dict_version(((PyObject *)__pyx_v_self));
       #endif
-      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_refine_peak_from_tags_distributi); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1838, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_PyObject_GetAttrStr(((PyObject *)__pyx_v_self), __pyx_n_s_refine_peak_from_tags_distributi); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1840, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       if (!PyCFunction_Check(__pyx_t_1) || (PyCFunction_GET_FUNCTION(__pyx_t_1) != (PyCFunction)(void*)__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_13refine_peak_from_tags_distribution)) {
         __Pyx_XDECREF(__pyx_r);
-        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1838, __pyx_L1_error)
+        __pyx_t_3 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 1840, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_3);
-        __pyx_t_4 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1838, __pyx_L1_error)
+        __pyx_t_4 = PyFloat_FromDouble(__pyx_v_cutoff); if (unlikely(!__pyx_t_4)) __PYX_ERR(0, 1840, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_4);
         __Pyx_INCREF(__pyx_t_1);
         __pyx_t_5 = __pyx_t_1; __pyx_t_6 = NULL;
@@ -24870,7 +24902,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         #if CYTHON_FAST_PYCALL
         if (PyFunction_Check(__pyx_t_5)) {
           PyObject *__pyx_temp[4] = {__pyx_t_6, __pyx_v_peaks, __pyx_t_3, __pyx_t_4};
-          __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 3+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1838, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 3+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1840, __pyx_L1_error)
           __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -24880,7 +24912,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         #if CYTHON_FAST_PYCCALL
         if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
           PyObject *__pyx_temp[4] = {__pyx_t_6, __pyx_v_peaks, __pyx_t_3, __pyx_t_4};
-          __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 3+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1838, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 3+__pyx_t_7); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1840, __pyx_L1_error)
           __Pyx_XDECREF(__pyx_t_6); __pyx_t_6 = 0;
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
@@ -24888,7 +24920,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         } else
         #endif
         {
-          __pyx_t_8 = PyTuple_New(3+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1838, __pyx_L1_error)
+          __pyx_t_8 = PyTuple_New(3+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1840, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_8);
           if (__pyx_t_6) {
             __Pyx_GIVEREF(__pyx_t_6); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __pyx_t_6 = NULL;
@@ -24902,7 +24934,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
           PyTuple_SET_ITEM(__pyx_t_8, 2+__pyx_t_7, __pyx_t_4);
           __pyx_t_3 = 0;
           __pyx_t_4 = 0;
-          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1838, __pyx_L1_error)
+          __pyx_t_2 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1840, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_2);
           __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
         }
@@ -24925,30 +24957,30 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
     #endif
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1861
+  /* "MACS2/IO/CallPeakUnit.pyx":1863
  *             np.ndarray adjusted_summits, passflags
  * 
  *         if self.PE_mode:             # <<<<<<<<<<<<<<
  *             return None
  * 
  */
-  __Pyx_TraceLine(1861,0,__PYX_ERR(0, 1861, __pyx_L1_error))
-  __pyx_t_9 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->PE_mode)); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1861, __pyx_L1_error)
+  __Pyx_TraceLine(1863,0,__PYX_ERR(0, 1863, __pyx_L1_error))
+  __pyx_t_9 = __Pyx_PyObject_IsTrue(((PyObject *)__pyx_v_self->PE_mode)); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1863, __pyx_L1_error)
   if (__pyx_t_9) {
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1862
+    /* "MACS2/IO/CallPeakUnit.pyx":1864
  * 
  *         if self.PE_mode:
  *             return None             # <<<<<<<<<<<<<<
  * 
  *         pchrnames = sorted(peaks.get_chr_names())
  */
-    __Pyx_TraceLine(1862,0,__PYX_ERR(0, 1862, __pyx_L1_error))
+    __Pyx_TraceLine(1864,0,__PYX_ERR(0, 1864, __pyx_L1_error))
     __Pyx_XDECREF(__pyx_r);
     __pyx_r = Py_None; __Pyx_INCREF(Py_None);
     goto __pyx_L0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1861
+    /* "MACS2/IO/CallPeakUnit.pyx":1863
  *             np.ndarray adjusted_summits, passflags
  * 
  *         if self.PE_mode:             # <<<<<<<<<<<<<<
@@ -24957,15 +24989,15 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
  */
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1864
+  /* "MACS2/IO/CallPeakUnit.pyx":1866
  *             return None
  * 
  *         pchrnames = sorted(peaks.get_chr_names())             # <<<<<<<<<<<<<<
  *         retval = []
  * 
  */
-  __Pyx_TraceLine(1864,0,__PYX_ERR(0, 1864, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_get_chr_names); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1864, __pyx_L1_error)
+  __Pyx_TraceLine(1866,0,__PYX_ERR(0, 1866, __pyx_L1_error))
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_get_chr_names); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1866, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_8 = NULL;
   if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_5))) {
@@ -24979,47 +25011,47 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
   }
   __pyx_t_2 = (__pyx_t_8) ? __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_8) : __Pyx_PyObject_CallNoArg(__pyx_t_5);
   __Pyx_XDECREF(__pyx_t_8); __pyx_t_8 = 0;
-  if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1864, __pyx_L1_error)
+  if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1866, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_t_5 = PySequence_List(__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1864, __pyx_L1_error)
+  __pyx_t_5 = PySequence_List(__pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1866, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
   __pyx_t_1 = ((PyObject*)__pyx_t_5);
   __pyx_t_5 = 0;
-  __pyx_t_10 = PyList_Sort(__pyx_t_1); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1864, __pyx_L1_error)
-  if (!(likely(PySet_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "set", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1864, __pyx_L1_error)
+  __pyx_t_10 = PyList_Sort(__pyx_t_1); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1866, __pyx_L1_error)
+  if (!(likely(PySet_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "set", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1866, __pyx_L1_error)
   __pyx_v_pchrnames = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1865
+  /* "MACS2/IO/CallPeakUnit.pyx":1867
  * 
  *         pchrnames = sorted(peaks.get_chr_names())
  *         retval = []             # <<<<<<<<<<<<<<
  * 
  *         # this object should be sorted
  */
-  __Pyx_TraceLine(1865,0,__PYX_ERR(0, 1865, __pyx_L1_error))
-  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1865, __pyx_L1_error)
+  __Pyx_TraceLine(1867,0,__PYX_ERR(0, 1867, __pyx_L1_error))
+  __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1867, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_v_retval = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1868
+  /* "MACS2/IO/CallPeakUnit.pyx":1870
  * 
  *         # this object should be sorted
  *         if not self.treat.__sorted: self.treat.sort()             # <<<<<<<<<<<<<<
  *         # PeakIO object should be sorted
  *         peaks.sort()
  */
-  __Pyx_TraceLine(1868,0,__PYX_ERR(0, 1868, __pyx_L1_error))
-  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_sorted_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1868, __pyx_L1_error)
+  __Pyx_TraceLine(1870,0,__PYX_ERR(0, 1870, __pyx_L1_error))
+  __pyx_t_1 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_sorted_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1870, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
-  __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1868, __pyx_L1_error)
+  __pyx_t_9 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_9 < 0)) __PYX_ERR(0, 1870, __pyx_L1_error)
   __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   __pyx_t_11 = ((!__pyx_t_9) != 0);
   if (__pyx_t_11) {
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_sort); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1868, __pyx_L1_error)
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_sort); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1870, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
     __pyx_t_2 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_5))) {
@@ -25033,48 +25065,21 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
     }
     __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_2) : __Pyx_PyObject_CallNoArg(__pyx_t_5);
     __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1868, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1870, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1870
+  /* "MACS2/IO/CallPeakUnit.pyx":1872
  *         if not self.treat.__sorted: self.treat.sort()
  *         # PeakIO object should be sorted
  *         peaks.sort()             # <<<<<<<<<<<<<<
  * 
  *         chrnames = self.treat.get_chr_names()
  */
-  __Pyx_TraceLine(1870,0,__PYX_ERR(0, 1870, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_sort); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1870, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_5);
-  __pyx_t_2 = NULL;
-  if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_5))) {
-    __pyx_t_2 = PyMethod_GET_SELF(__pyx_t_5);
-    if (likely(__pyx_t_2)) {
-      PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_5);
-      __Pyx_INCREF(__pyx_t_2);
-      __Pyx_INCREF(function);
-      __Pyx_DECREF_SET(__pyx_t_5, function);
-    }
-  }
-  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_2) : __Pyx_PyObject_CallNoArg(__pyx_t_5);
-  __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1870, __pyx_L1_error)
-  __Pyx_GOTREF(__pyx_t_1);
-  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
-
-  /* "MACS2/IO/CallPeakUnit.pyx":1872
- *         peaks.sort()
- * 
- *         chrnames = self.treat.get_chr_names()             # <<<<<<<<<<<<<<
- * 
- *         ret_peaks = PeakIO()
- */
   __Pyx_TraceLine(1872,0,__PYX_ERR(0, 1872, __pyx_L1_error))
-  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_get_chr_names); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1872, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_sort); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1872, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_2 = NULL;
   if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_5))) {
@@ -25091,22 +25096,20 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
   if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1872, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  if (!(likely(PySet_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "set", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1872, __pyx_L1_error)
-  __pyx_v_chrnames = ((PyObject*)__pyx_t_1);
-  __pyx_t_1 = 0;
+  __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
   /* "MACS2/IO/CallPeakUnit.pyx":1874
- *         chrnames = self.treat.get_chr_names()
+ *         peaks.sort()
  * 
- *         ret_peaks = PeakIO()             # <<<<<<<<<<<<<<
+ *         chrnames = self.treat.get_chr_names()             # <<<<<<<<<<<<<<
  * 
- *         for c in range(len(pchrnames)):
+ *         ret_peaks = PeakIO()
  */
   __Pyx_TraceLine(1874,0,__PYX_ERR(0, 1874, __pyx_L1_error))
-  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1874, __pyx_L1_error)
+  __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_get_chr_names); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1874, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_5);
   __pyx_t_2 = NULL;
-  if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
+  if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_5))) {
     __pyx_t_2 = PyMethod_GET_SELF(__pyx_t_5);
     if (likely(__pyx_t_2)) {
       PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_5);
@@ -25120,83 +25123,112 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
   if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1874, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-  __pyx_v_ret_peaks = __pyx_t_1;
+  if (!(likely(PySet_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "set", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1874, __pyx_L1_error)
+  __pyx_v_chrnames = ((PyObject*)__pyx_t_1);
   __pyx_t_1 = 0;
 
   /* "MACS2/IO/CallPeakUnit.pyx":1876
+ *         chrnames = self.treat.get_chr_names()
+ * 
+ *         ret_peaks = PeakIO()             # <<<<<<<<<<<<<<
+ * 
+ *         for c in range(len(pchrnames)):
+ */
+  __Pyx_TraceLine(1876,0,__PYX_ERR(0, 1876, __pyx_L1_error))
+  __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_PeakIO); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1876, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_5);
+  __pyx_t_2 = NULL;
+  if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
+    __pyx_t_2 = PyMethod_GET_SELF(__pyx_t_5);
+    if (likely(__pyx_t_2)) {
+      PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_5);
+      __Pyx_INCREF(__pyx_t_2);
+      __Pyx_INCREF(function);
+      __Pyx_DECREF_SET(__pyx_t_5, function);
+    }
+  }
+  __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_t_2) : __Pyx_PyObject_CallNoArg(__pyx_t_5);
+  __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
+  if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1876, __pyx_L1_error)
+  __Pyx_GOTREF(__pyx_t_1);
+  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  __pyx_v_ret_peaks = __pyx_t_1;
+  __pyx_t_1 = 0;
+
+  /* "MACS2/IO/CallPeakUnit.pyx":1878
  *         ret_peaks = PeakIO()
  * 
  *         for c in range(len(pchrnames)):             # <<<<<<<<<<<<<<
  *             chrom = pchrnames[c]
  *             assert chrom in chrnames, "chromosome %s can't be found in the FWTrack object." % (chrom.decode())
  */
-  __Pyx_TraceLine(1876,0,__PYX_ERR(0, 1876, __pyx_L1_error))
+  __Pyx_TraceLine(1878,0,__PYX_ERR(0, 1878, __pyx_L1_error))
   if (unlikely(__pyx_v_pchrnames == Py_None)) {
     PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-    __PYX_ERR(0, 1876, __pyx_L1_error)
+    __PYX_ERR(0, 1878, __pyx_L1_error)
   }
-  __pyx_t_12 = PySet_GET_SIZE(__pyx_v_pchrnames); if (unlikely(__pyx_t_12 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1876, __pyx_L1_error)
+  __pyx_t_12 = PySet_GET_SIZE(__pyx_v_pchrnames); if (unlikely(__pyx_t_12 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1878, __pyx_L1_error)
   __pyx_t_13 = __pyx_t_12;
   for (__pyx_t_14 = 0; __pyx_t_14 < __pyx_t_13; __pyx_t_14+=1) {
     __pyx_v_c = __pyx_t_14;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1877
+    /* "MACS2/IO/CallPeakUnit.pyx":1879
  * 
  *         for c in range(len(pchrnames)):
  *             chrom = pchrnames[c]             # <<<<<<<<<<<<<<
  *             assert chrom in chrnames, "chromosome %s can't be found in the FWTrack object." % (chrom.decode())
  *             (plus, minus) = self.treat.__locations[chrom]
  */
-    __Pyx_TraceLine(1877,0,__PYX_ERR(0, 1877, __pyx_L1_error))
-    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_pchrnames, __pyx_v_c, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1877, __pyx_L1_error)
+    __Pyx_TraceLine(1879,0,__PYX_ERR(0, 1879, __pyx_L1_error))
+    __pyx_t_1 = __Pyx_GetItemInt(__pyx_v_pchrnames, __pyx_v_c, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1879, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
-    if (!(likely(PyBytes_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1877, __pyx_L1_error)
+    if (!(likely(PyBytes_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "bytes", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1879, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_chrom, ((PyObject*)__pyx_t_1));
     __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1878
+    /* "MACS2/IO/CallPeakUnit.pyx":1880
  *         for c in range(len(pchrnames)):
  *             chrom = pchrnames[c]
  *             assert chrom in chrnames, "chromosome %s can't be found in the FWTrack object." % (chrom.decode())             # <<<<<<<<<<<<<<
  *             (plus, minus) = self.treat.__locations[chrom]
  *             cpeaks = peaks.get_data_from_chrom(chrom)
  */
-    __Pyx_TraceLine(1878,0,__PYX_ERR(0, 1878, __pyx_L1_error))
+    __Pyx_TraceLine(1880,0,__PYX_ERR(0, 1880, __pyx_L1_error))
     #ifndef CYTHON_WITHOUT_ASSERTIONS
     if (unlikely(!Py_OptimizeFlag)) {
       if (unlikely(__pyx_v_chrnames == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not iterable");
-        __PYX_ERR(0, 1878, __pyx_L1_error)
+        __PYX_ERR(0, 1880, __pyx_L1_error)
       }
-      __pyx_t_11 = (__Pyx_PySet_ContainsTF(__pyx_v_chrom, __pyx_v_chrnames, Py_EQ)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1878, __pyx_L1_error)
+      __pyx_t_11 = (__Pyx_PySet_ContainsTF(__pyx_v_chrom, __pyx_v_chrnames, Py_EQ)); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1880, __pyx_L1_error)
       if (unlikely(!(__pyx_t_11 != 0))) {
         if (unlikely(__pyx_v_chrom == Py_None)) {
           PyErr_Format(PyExc_AttributeError, "'NoneType' object has no attribute '%.30s'", "decode");
-          __PYX_ERR(0, 1878, __pyx_L1_error)
+          __PYX_ERR(0, 1880, __pyx_L1_error)
         }
-        __pyx_t_1 = __Pyx_decode_bytes(__pyx_v_chrom, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1878, __pyx_L1_error)
+        __pyx_t_1 = __Pyx_decode_bytes(__pyx_v_chrom, 0, PY_SSIZE_T_MAX, NULL, NULL, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1880, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_5 = PyUnicode_Format(__pyx_kp_u_chromosome_s_can_t_be_found_in_t, __pyx_t_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1878, __pyx_L1_error)
+        __pyx_t_5 = PyUnicode_Format(__pyx_kp_u_chromosome_s_can_t_be_found_in_t, __pyx_t_1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1880, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         PyErr_SetObject(PyExc_AssertionError, __pyx_t_5);
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-        __PYX_ERR(0, 1878, __pyx_L1_error)
+        __PYX_ERR(0, 1880, __pyx_L1_error)
       }
     }
     #endif
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1879
+    /* "MACS2/IO/CallPeakUnit.pyx":1881
  *             chrom = pchrnames[c]
  *             assert chrom in chrnames, "chromosome %s can't be found in the FWTrack object." % (chrom.decode())
  *             (plus, minus) = self.treat.__locations[chrom]             # <<<<<<<<<<<<<<
  *             cpeaks = peaks.get_data_from_chrom(chrom)
  * 
  */
-    __Pyx_TraceLine(1879,0,__PYX_ERR(0, 1879, __pyx_L1_error))
-    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_locations); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1879, __pyx_L1_error)
+    __Pyx_TraceLine(1881,0,__PYX_ERR(0, 1881, __pyx_L1_error))
+    __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_self->treat, __pyx_n_s_locations); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1881, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_1 = __Pyx_PyObject_GetItem(__pyx_t_5, __pyx_v_chrom); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1879, __pyx_L1_error)
+    __pyx_t_1 = __Pyx_PyObject_GetItem(__pyx_t_5, __pyx_v_chrom); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1881, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
     if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
@@ -25205,7 +25237,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       if (unlikely(size != 2)) {
         if (size > 2) __Pyx_RaiseTooManyValuesError(2);
         else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-        __PYX_ERR(0, 1879, __pyx_L1_error)
+        __PYX_ERR(0, 1881, __pyx_L1_error)
       }
       #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
       if (likely(PyTuple_CheckExact(sequence))) {
@@ -25218,15 +25250,15 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       __Pyx_INCREF(__pyx_t_5);
       __Pyx_INCREF(__pyx_t_2);
       #else
-      __pyx_t_5 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1879, __pyx_L1_error)
+      __pyx_t_5 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1881, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_2 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1879, __pyx_L1_error)
+      __pyx_t_2 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1881, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       #endif
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
     } else {
       Py_ssize_t index = -1;
-      __pyx_t_8 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1879, __pyx_L1_error)
+      __pyx_t_8 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1881, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_8);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_t_15 = Py_TYPE(__pyx_t_8)->tp_iternext;
@@ -25234,7 +25266,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       __Pyx_GOTREF(__pyx_t_5);
       index = 1; __pyx_t_2 = __pyx_t_15(__pyx_t_8); if (unlikely(!__pyx_t_2)) goto __pyx_L7_unpacking_failed;
       __Pyx_GOTREF(__pyx_t_2);
-      if (__Pyx_IternextUnpackEndCheck(__pyx_t_15(__pyx_t_8), 2) < 0) __PYX_ERR(0, 1879, __pyx_L1_error)
+      if (__Pyx_IternextUnpackEndCheck(__pyx_t_15(__pyx_t_8), 2) < 0) __PYX_ERR(0, 1881, __pyx_L1_error)
       __pyx_t_15 = NULL;
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
       goto __pyx_L8_unpacking_done;
@@ -25242,25 +25274,25 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
       __pyx_t_15 = NULL;
       if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-      __PYX_ERR(0, 1879, __pyx_L1_error)
+      __PYX_ERR(0, 1881, __pyx_L1_error)
       __pyx_L8_unpacking_done:;
     }
-    if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1879, __pyx_L1_error)
-    if (!(likely(((__pyx_t_2) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_2, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1879, __pyx_L1_error)
+    if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1881, __pyx_L1_error)
+    if (!(likely(((__pyx_t_2) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_2, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1881, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_plus, ((PyArrayObject *)__pyx_t_5));
     __pyx_t_5 = 0;
     __Pyx_XDECREF_SET(__pyx_v_minus, ((PyArrayObject *)__pyx_t_2));
     __pyx_t_2 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1880
+    /* "MACS2/IO/CallPeakUnit.pyx":1882
  *             assert chrom in chrnames, "chromosome %s can't be found in the FWTrack object." % (chrom.decode())
  *             (plus, minus) = self.treat.__locations[chrom]
  *             cpeaks = peaks.get_data_from_chrom(chrom)             # <<<<<<<<<<<<<<
  * 
  *             prev_i = 0
  */
-    __Pyx_TraceLine(1880,0,__PYX_ERR(0, 1880, __pyx_L1_error))
-    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_get_data_from_chrom); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1880, __pyx_L1_error)
+    __Pyx_TraceLine(1882,0,__PYX_ERR(0, 1882, __pyx_L1_error))
+    __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_v_peaks, __pyx_n_s_get_data_from_chrom); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1882, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_2);
     __pyx_t_5 = NULL;
     if (CYTHON_UNPACK_METHODS && likely(PyMethod_Check(__pyx_t_2))) {
@@ -25274,169 +25306,169 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
     }
     __pyx_t_1 = (__pyx_t_5) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_5, __pyx_v_chrom) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_v_chrom);
     __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
-    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1880, __pyx_L1_error)
+    if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1882, __pyx_L1_error)
     __Pyx_GOTREF(__pyx_t_1);
     __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-    if (!(likely(PyList_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1880, __pyx_L1_error)
+    if (!(likely(PyList_CheckExact(__pyx_t_1))||((__pyx_t_1) == Py_None)||(PyErr_Format(PyExc_TypeError, "Expected %.16s, got %.200s", "list", Py_TYPE(__pyx_t_1)->tp_name), 0))) __PYX_ERR(0, 1882, __pyx_L1_error)
     __Pyx_XDECREF_SET(__pyx_v_cpeaks, ((PyObject*)__pyx_t_1));
     __pyx_t_1 = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1882
+    /* "MACS2/IO/CallPeakUnit.pyx":1884
  *             cpeaks = peaks.get_data_from_chrom(chrom)
  * 
  *             prev_i = 0             # <<<<<<<<<<<<<<
  *             prev_j = 0
  *             for m in range(len(cpeaks)):
  */
-    __Pyx_TraceLine(1882,0,__PYX_ERR(0, 1882, __pyx_L1_error))
+    __Pyx_TraceLine(1884,0,__PYX_ERR(0, 1884, __pyx_L1_error))
     __pyx_v_prev_i = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1883
+    /* "MACS2/IO/CallPeakUnit.pyx":1885
  * 
  *             prev_i = 0
  *             prev_j = 0             # <<<<<<<<<<<<<<
  *             for m in range(len(cpeaks)):
  *                 thispeak = cpeaks[m]
  */
-    __Pyx_TraceLine(1883,0,__PYX_ERR(0, 1883, __pyx_L1_error))
+    __Pyx_TraceLine(1885,0,__PYX_ERR(0, 1885, __pyx_L1_error))
     __pyx_v_prev_j = 0;
 
-    /* "MACS2/IO/CallPeakUnit.pyx":1884
+    /* "MACS2/IO/CallPeakUnit.pyx":1886
  *             prev_i = 0
  *             prev_j = 0
  *             for m in range(len(cpeaks)):             # <<<<<<<<<<<<<<
  *                 thispeak = cpeaks[m]
  *                 startpos = thispeak["start"] - window_size
  */
-    __Pyx_TraceLine(1884,0,__PYX_ERR(0, 1884, __pyx_L1_error))
+    __Pyx_TraceLine(1886,0,__PYX_ERR(0, 1886, __pyx_L1_error))
     if (unlikely(__pyx_v_cpeaks == Py_None)) {
       PyErr_SetString(PyExc_TypeError, "object of type 'NoneType' has no len()");
-      __PYX_ERR(0, 1884, __pyx_L1_error)
+      __PYX_ERR(0, 1886, __pyx_L1_error)
     }
-    __pyx_t_16 = PyList_GET_SIZE(__pyx_v_cpeaks); if (unlikely(__pyx_t_16 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1884, __pyx_L1_error)
+    __pyx_t_16 = PyList_GET_SIZE(__pyx_v_cpeaks); if (unlikely(__pyx_t_16 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1886, __pyx_L1_error)
     __pyx_t_17 = __pyx_t_16;
     for (__pyx_t_18 = 0; __pyx_t_18 < __pyx_t_17; __pyx_t_18+=1) {
       __pyx_v_m = __pyx_t_18;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1885
+      /* "MACS2/IO/CallPeakUnit.pyx":1887
  *             prev_j = 0
  *             for m in range(len(cpeaks)):
  *                 thispeak = cpeaks[m]             # <<<<<<<<<<<<<<
  *                 startpos = thispeak["start"] - window_size
  *                 endpos   = thispeak["end"] + window_size
  */
-      __Pyx_TraceLine(1885,0,__PYX_ERR(0, 1885, __pyx_L1_error))
+      __Pyx_TraceLine(1887,0,__PYX_ERR(0, 1887, __pyx_L1_error))
       if (unlikely(__pyx_v_cpeaks == Py_None)) {
         PyErr_SetString(PyExc_TypeError, "'NoneType' object is not subscriptable");
-        __PYX_ERR(0, 1885, __pyx_L1_error)
+        __PYX_ERR(0, 1887, __pyx_L1_error)
       }
-      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_cpeaks, __pyx_v_m, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1885, __pyx_L1_error)
+      __pyx_t_1 = __Pyx_GetItemInt_List(__pyx_v_cpeaks, __pyx_v_m, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 1, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1887, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_XDECREF_SET(__pyx_v_thispeak, __pyx_t_1);
       __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1886
+      /* "MACS2/IO/CallPeakUnit.pyx":1888
  *             for m in range(len(cpeaks)):
  *                 thispeak = cpeaks[m]
  *                 startpos = thispeak["start"] - window_size             # <<<<<<<<<<<<<<
  *                 endpos   = thispeak["end"] + window_size
  *                 temp = []
  */
-      __Pyx_TraceLine(1886,0,__PYX_ERR(0, 1886, __pyx_L1_error))
-      __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_v_thispeak, __pyx_n_u_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1886, __pyx_L1_error)
+      __Pyx_TraceLine(1888,0,__PYX_ERR(0, 1888, __pyx_L1_error))
+      __pyx_t_1 = __Pyx_PyObject_Dict_GetItem(__pyx_v_thispeak, __pyx_n_u_start); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1888, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
-      __pyx_t_2 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1886, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1888, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_5 = PyNumber_Subtract(__pyx_t_1, __pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1886, __pyx_L1_error)
+      __pyx_t_5 = PyNumber_Subtract(__pyx_t_1, __pyx_t_2); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1888, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      __pyx_t_19 = __Pyx_PyInt_As_npy_int32(__pyx_t_5); if (unlikely((__pyx_t_19 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1886, __pyx_L1_error)
+      __pyx_t_19 = __Pyx_PyInt_As_npy_int32(__pyx_t_5); if (unlikely((__pyx_t_19 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1888, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __pyx_v_startpos = __pyx_t_19;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1887
+      /* "MACS2/IO/CallPeakUnit.pyx":1889
  *                 thispeak = cpeaks[m]
  *                 startpos = thispeak["start"] - window_size
  *                 endpos   = thispeak["end"] + window_size             # <<<<<<<<<<<<<<
  *                 temp = []
  *                 for i in range(prev_i,plus.shape[0]):
  */
-      __Pyx_TraceLine(1887,0,__PYX_ERR(0, 1887, __pyx_L1_error))
-      __pyx_t_5 = __Pyx_PyObject_Dict_GetItem(__pyx_v_thispeak, __pyx_n_u_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1887, __pyx_L1_error)
+      __Pyx_TraceLine(1889,0,__PYX_ERR(0, 1889, __pyx_L1_error))
+      __pyx_t_5 = __Pyx_PyObject_Dict_GetItem(__pyx_v_thispeak, __pyx_n_u_end); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1889, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_2 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1887, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1889, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_1 = PyNumber_Add(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1887, __pyx_L1_error)
+      __pyx_t_1 = PyNumber_Add(__pyx_t_5, __pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1889, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      __pyx_t_19 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_19 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1887, __pyx_L1_error)
+      __pyx_t_19 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_19 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1889, __pyx_L1_error)
       __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       __pyx_v_endpos = __pyx_t_19;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1888
+      /* "MACS2/IO/CallPeakUnit.pyx":1890
  *                 startpos = thispeak["start"] - window_size
  *                 endpos   = thispeak["end"] + window_size
  *                 temp = []             # <<<<<<<<<<<<<<
  *                 for i in range(prev_i,plus.shape[0]):
  *                     pos = plus[i]
  */
-      __Pyx_TraceLine(1888,0,__PYX_ERR(0, 1888, __pyx_L1_error))
-      __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1888, __pyx_L1_error)
+      __Pyx_TraceLine(1890,0,__PYX_ERR(0, 1890, __pyx_L1_error))
+      __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1890, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_XDECREF_SET(__pyx_v_temp, ((PyObject*)__pyx_t_1));
       __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1889
+      /* "MACS2/IO/CallPeakUnit.pyx":1891
  *                 endpos   = thispeak["end"] + window_size
  *                 temp = []
  *                 for i in range(prev_i,plus.shape[0]):             # <<<<<<<<<<<<<<
  *                     pos = plus[i]
  *                     if pos < startpos:
  */
-      __Pyx_TraceLine(1889,0,__PYX_ERR(0, 1889, __pyx_L1_error))
+      __Pyx_TraceLine(1891,0,__PYX_ERR(0, 1891, __pyx_L1_error))
       __pyx_t_20 = (__pyx_v_plus->dimensions[0]);
       __pyx_t_21 = __pyx_t_20;
       for (__pyx_t_19 = __pyx_v_prev_i; __pyx_t_19 < __pyx_t_21; __pyx_t_19+=1) {
         __pyx_v_i = __pyx_t_19;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1890
+        /* "MACS2/IO/CallPeakUnit.pyx":1892
  *                 temp = []
  *                 for i in range(prev_i,plus.shape[0]):
  *                     pos = plus[i]             # <<<<<<<<<<<<<<
  *                     if pos < startpos:
  *                         continue
  */
-        __Pyx_TraceLine(1890,0,__PYX_ERR(0, 1890, __pyx_L1_error))
-        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_plus), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1890, __pyx_L1_error)
+        __Pyx_TraceLine(1892,0,__PYX_ERR(0, 1892, __pyx_L1_error))
+        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_plus), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1892, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_22 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1890, __pyx_L1_error)
+        __pyx_t_22 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1892, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_v_pos = __pyx_t_22;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1891
+        /* "MACS2/IO/CallPeakUnit.pyx":1893
  *                 for i in range(prev_i,plus.shape[0]):
  *                     pos = plus[i]
  *                     if pos < startpos:             # <<<<<<<<<<<<<<
  *                         continue
  *                     elif pos > endpos:
  */
-        __Pyx_TraceLine(1891,0,__PYX_ERR(0, 1891, __pyx_L1_error))
+        __Pyx_TraceLine(1893,0,__PYX_ERR(0, 1893, __pyx_L1_error))
         __pyx_t_11 = ((__pyx_v_pos < __pyx_v_startpos) != 0);
         if (__pyx_t_11) {
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1892
+          /* "MACS2/IO/CallPeakUnit.pyx":1894
  *                     pos = plus[i]
  *                     if pos < startpos:
  *                         continue             # <<<<<<<<<<<<<<
  *                     elif pos > endpos:
  *                         prev_i = i
  */
-          __Pyx_TraceLine(1892,0,__PYX_ERR(0, 1892, __pyx_L1_error))
+          __Pyx_TraceLine(1894,0,__PYX_ERR(0, 1894, __pyx_L1_error))
           goto __pyx_L11_continue;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1891
+          /* "MACS2/IO/CallPeakUnit.pyx":1893
  *                 for i in range(prev_i,plus.shape[0]):
  *                     pos = plus[i]
  *                     if pos < startpos:             # <<<<<<<<<<<<<<
@@ -25445,38 +25477,38 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
  */
         }
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1893
+        /* "MACS2/IO/CallPeakUnit.pyx":1895
  *                     if pos < startpos:
  *                         continue
  *                     elif pos > endpos:             # <<<<<<<<<<<<<<
  *                         prev_i = i
  *                         break
  */
-        __Pyx_TraceLine(1893,0,__PYX_ERR(0, 1893, __pyx_L1_error))
+        __Pyx_TraceLine(1895,0,__PYX_ERR(0, 1895, __pyx_L1_error))
         __pyx_t_11 = ((__pyx_v_pos > __pyx_v_endpos) != 0);
         if (__pyx_t_11) {
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1894
+          /* "MACS2/IO/CallPeakUnit.pyx":1896
  *                         continue
  *                     elif pos > endpos:
  *                         prev_i = i             # <<<<<<<<<<<<<<
  *                         break
  *                     else:
  */
-          __Pyx_TraceLine(1894,0,__PYX_ERR(0, 1894, __pyx_L1_error))
+          __Pyx_TraceLine(1896,0,__PYX_ERR(0, 1896, __pyx_L1_error))
           __pyx_v_prev_i = __pyx_v_i;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1895
+          /* "MACS2/IO/CallPeakUnit.pyx":1897
  *                     elif pos > endpos:
  *                         prev_i = i
  *                         break             # <<<<<<<<<<<<<<
  *                     else:
  *                         temp.append(pos)
  */
-          __Pyx_TraceLine(1895,0,__PYX_ERR(0, 1895, __pyx_L1_error))
+          __Pyx_TraceLine(1897,0,__PYX_ERR(0, 1897, __pyx_L1_error))
           goto __pyx_L12_break;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1893
+          /* "MACS2/IO/CallPeakUnit.pyx":1895
  *                     if pos < startpos:
  *                         continue
  *                     elif pos > endpos:             # <<<<<<<<<<<<<<
@@ -25485,35 +25517,35 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
  */
         }
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1897
+        /* "MACS2/IO/CallPeakUnit.pyx":1899
  *                         break
  *                     else:
  *                         temp.append(pos)             # <<<<<<<<<<<<<<
  *                 rt_plus = np.array(temp)
  * 
  */
-        __Pyx_TraceLine(1897,0,__PYX_ERR(0, 1897, __pyx_L1_error))
+        __Pyx_TraceLine(1899,0,__PYX_ERR(0, 1899, __pyx_L1_error))
         /*else*/ {
-          __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_pos); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1897, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_pos); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1899, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_temp, __pyx_t_1); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1897, __pyx_L1_error)
+          __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_temp, __pyx_t_1); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1899, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         }
         __pyx_L11_continue:;
       }
       __pyx_L12_break:;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1898
+      /* "MACS2/IO/CallPeakUnit.pyx":1900
  *                     else:
  *                         temp.append(pos)
  *                 rt_plus = np.array(temp)             # <<<<<<<<<<<<<<
  * 
  *                 temp = []
  */
-      __Pyx_TraceLine(1898,0,__PYX_ERR(0, 1898, __pyx_L1_error))
-      __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1898, __pyx_L1_error)
+      __Pyx_TraceLine(1900,0,__PYX_ERR(0, 1900, __pyx_L1_error))
+      __Pyx_GetModuleGlobalName(__pyx_t_2, __pyx_n_s_np); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1900, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
-      __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_array); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1898, __pyx_L1_error)
+      __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_t_2, __pyx_n_s_array); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1900, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
       __pyx_t_2 = NULL;
@@ -25528,75 +25560,75 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       }
       __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_2, __pyx_v_temp) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_temp);
       __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1898, __pyx_L1_error)
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1900, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-      if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1898, __pyx_L1_error)
+      if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1900, __pyx_L1_error)
       __Pyx_XDECREF_SET(__pyx_v_rt_plus, ((PyArrayObject *)__pyx_t_1));
       __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1900
+      /* "MACS2/IO/CallPeakUnit.pyx":1902
  *                 rt_plus = np.array(temp)
  * 
  *                 temp = []             # <<<<<<<<<<<<<<
  *                 for j in range(prev_j,minus.shape[0]):
  *                     pos = minus[j]
  */
-      __Pyx_TraceLine(1900,0,__PYX_ERR(0, 1900, __pyx_L1_error))
-      __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1900, __pyx_L1_error)
+      __Pyx_TraceLine(1902,0,__PYX_ERR(0, 1902, __pyx_L1_error))
+      __pyx_t_1 = PyList_New(0); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1902, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF_SET(__pyx_v_temp, ((PyObject*)__pyx_t_1));
       __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1901
+      /* "MACS2/IO/CallPeakUnit.pyx":1903
  * 
  *                 temp = []
  *                 for j in range(prev_j,minus.shape[0]):             # <<<<<<<<<<<<<<
  *                     pos = minus[j]
  *                     if pos < startpos:
  */
-      __Pyx_TraceLine(1901,0,__PYX_ERR(0, 1901, __pyx_L1_error))
+      __Pyx_TraceLine(1903,0,__PYX_ERR(0, 1903, __pyx_L1_error))
       __pyx_t_20 = (__pyx_v_minus->dimensions[0]);
       __pyx_t_21 = __pyx_t_20;
       for (__pyx_t_19 = __pyx_v_prev_j; __pyx_t_19 < __pyx_t_21; __pyx_t_19+=1) {
         __pyx_v_j = __pyx_t_19;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1902
+        /* "MACS2/IO/CallPeakUnit.pyx":1904
  *                 temp = []
  *                 for j in range(prev_j,minus.shape[0]):
  *                     pos = minus[j]             # <<<<<<<<<<<<<<
  *                     if pos < startpos:
  *                         continue
  */
-        __Pyx_TraceLine(1902,0,__PYX_ERR(0, 1902, __pyx_L1_error))
-        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_minus), __pyx_v_j, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1902, __pyx_L1_error)
+        __Pyx_TraceLine(1904,0,__PYX_ERR(0, 1904, __pyx_L1_error))
+        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_minus), __pyx_v_j, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1904, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_22 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1902, __pyx_L1_error)
+        __pyx_t_22 = __Pyx_PyInt_As_npy_int32(__pyx_t_1); if (unlikely((__pyx_t_22 == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1904, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_v_pos = __pyx_t_22;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1903
+        /* "MACS2/IO/CallPeakUnit.pyx":1905
  *                 for j in range(prev_j,minus.shape[0]):
  *                     pos = minus[j]
  *                     if pos < startpos:             # <<<<<<<<<<<<<<
  *                         continue
  *                     elif pos > endpos:
  */
-        __Pyx_TraceLine(1903,0,__PYX_ERR(0, 1903, __pyx_L1_error))
+        __Pyx_TraceLine(1905,0,__PYX_ERR(0, 1905, __pyx_L1_error))
         __pyx_t_11 = ((__pyx_v_pos < __pyx_v_startpos) != 0);
         if (__pyx_t_11) {
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1904
+          /* "MACS2/IO/CallPeakUnit.pyx":1906
  *                     pos = minus[j]
  *                     if pos < startpos:
  *                         continue             # <<<<<<<<<<<<<<
  *                     elif pos > endpos:
  *                         prev_j = j
  */
-          __Pyx_TraceLine(1904,0,__PYX_ERR(0, 1904, __pyx_L1_error))
+          __Pyx_TraceLine(1906,0,__PYX_ERR(0, 1906, __pyx_L1_error))
           goto __pyx_L14_continue;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1903
+          /* "MACS2/IO/CallPeakUnit.pyx":1905
  *                 for j in range(prev_j,minus.shape[0]):
  *                     pos = minus[j]
  *                     if pos < startpos:             # <<<<<<<<<<<<<<
@@ -25605,38 +25637,38 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
  */
         }
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1905
+        /* "MACS2/IO/CallPeakUnit.pyx":1907
  *                     if pos < startpos:
  *                         continue
  *                     elif pos > endpos:             # <<<<<<<<<<<<<<
  *                         prev_j = j
  *                         break
  */
-        __Pyx_TraceLine(1905,0,__PYX_ERR(0, 1905, __pyx_L1_error))
+        __Pyx_TraceLine(1907,0,__PYX_ERR(0, 1907, __pyx_L1_error))
         __pyx_t_11 = ((__pyx_v_pos > __pyx_v_endpos) != 0);
         if (__pyx_t_11) {
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1906
+          /* "MACS2/IO/CallPeakUnit.pyx":1908
  *                         continue
  *                     elif pos > endpos:
  *                         prev_j = j             # <<<<<<<<<<<<<<
  *                         break
  *                     else:
  */
-          __Pyx_TraceLine(1906,0,__PYX_ERR(0, 1906, __pyx_L1_error))
+          __Pyx_TraceLine(1908,0,__PYX_ERR(0, 1908, __pyx_L1_error))
           __pyx_v_prev_j = __pyx_v_j;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1907
+          /* "MACS2/IO/CallPeakUnit.pyx":1909
  *                     elif pos > endpos:
  *                         prev_j = j
  *                         break             # <<<<<<<<<<<<<<
  *                     else:
  *                         temp.append(pos)
  */
-          __Pyx_TraceLine(1907,0,__PYX_ERR(0, 1907, __pyx_L1_error))
+          __Pyx_TraceLine(1909,0,__PYX_ERR(0, 1909, __pyx_L1_error))
           goto __pyx_L15_break;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1905
+          /* "MACS2/IO/CallPeakUnit.pyx":1907
  *                     if pos < startpos:
  *                         continue
  *                     elif pos > endpos:             # <<<<<<<<<<<<<<
@@ -25645,35 +25677,35 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
  */
         }
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1909
+        /* "MACS2/IO/CallPeakUnit.pyx":1911
  *                         break
  *                     else:
  *                         temp.append(pos)             # <<<<<<<<<<<<<<
  *                 rt_minus = np.array(temp)
  * 
  */
-        __Pyx_TraceLine(1909,0,__PYX_ERR(0, 1909, __pyx_L1_error))
+        __Pyx_TraceLine(1911,0,__PYX_ERR(0, 1911, __pyx_L1_error))
         /*else*/ {
-          __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_pos); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1909, __pyx_L1_error)
+          __pyx_t_1 = __Pyx_PyInt_From_npy_int32(__pyx_v_pos); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1911, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
-          __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_temp, __pyx_t_1); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1909, __pyx_L1_error)
+          __pyx_t_10 = __Pyx_PyList_Append(__pyx_v_temp, __pyx_t_1); if (unlikely(__pyx_t_10 == ((int)-1))) __PYX_ERR(0, 1911, __pyx_L1_error)
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         }
         __pyx_L14_continue:;
       }
       __pyx_L15_break:;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1910
+      /* "MACS2/IO/CallPeakUnit.pyx":1912
  *                     else:
  *                         temp.append(pos)
  *                 rt_minus = np.array(temp)             # <<<<<<<<<<<<<<
  * 
  *                 (adjusted_summits, passflags) = wtd_find_summit(chrom, rt_plus, rt_minus, startpos, endpos, window_size, cutoff)
  */
-      __Pyx_TraceLine(1910,0,__PYX_ERR(0, 1910, __pyx_L1_error))
-      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1910, __pyx_L1_error)
+      __Pyx_TraceLine(1912,0,__PYX_ERR(0, 1912, __pyx_L1_error))
+      __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_np); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1912, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_5);
-      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_array); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1910, __pyx_L1_error)
+      __pyx_t_2 = __Pyx_PyObject_GetAttrStr(__pyx_t_5, __pyx_n_s_array); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1912, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_2);
       __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
       __pyx_t_5 = NULL;
@@ -25688,22 +25720,22 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       }
       __pyx_t_1 = (__pyx_t_5) ? __Pyx_PyObject_Call2Args(__pyx_t_2, __pyx_t_5, __pyx_v_temp) : __Pyx_PyObject_CallOneArg(__pyx_t_2, __pyx_v_temp);
       __Pyx_XDECREF(__pyx_t_5); __pyx_t_5 = 0;
-      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1910, __pyx_L1_error)
+      if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1912, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       __Pyx_DECREF(__pyx_t_2); __pyx_t_2 = 0;
-      if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1910, __pyx_L1_error)
+      if (!(likely(((__pyx_t_1) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_1, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1912, __pyx_L1_error)
       __Pyx_XDECREF_SET(__pyx_v_rt_minus, ((PyArrayObject *)__pyx_t_1));
       __pyx_t_1 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1912
+      /* "MACS2/IO/CallPeakUnit.pyx":1914
  *                 rt_minus = np.array(temp)
  * 
  *                 (adjusted_summits, passflags) = wtd_find_summit(chrom, rt_plus, rt_minus, startpos, endpos, window_size, cutoff)             # <<<<<<<<<<<<<<
  *                 # those local maxima above cutoff will be defined as good summits
  *                 for i in range(len(adjusted_summits)):
  */
-      __Pyx_TraceLine(1912,0,__PYX_ERR(0, 1912, __pyx_L1_error))
-      __pyx_t_1 = __pyx_f_5MACS2_2IO_12CallPeakUnit_wtd_find_summit(__pyx_v_chrom, __pyx_v_rt_plus, __pyx_v_rt_minus, __pyx_v_startpos, __pyx_v_endpos, __pyx_v_window_size, __pyx_v_cutoff); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1912, __pyx_L1_error)
+      __Pyx_TraceLine(1914,0,__PYX_ERR(0, 1914, __pyx_L1_error))
+      __pyx_t_1 = __pyx_f_5MACS2_2IO_12CallPeakUnit_wtd_find_summit(__pyx_v_chrom, __pyx_v_rt_plus, __pyx_v_rt_minus, __pyx_v_startpos, __pyx_v_endpos, __pyx_v_window_size, __pyx_v_cutoff); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1914, __pyx_L1_error)
       __Pyx_GOTREF(__pyx_t_1);
       if ((likely(PyTuple_CheckExact(__pyx_t_1))) || (PyList_CheckExact(__pyx_t_1))) {
         PyObject* sequence = __pyx_t_1;
@@ -25711,7 +25743,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         if (unlikely(size != 2)) {
           if (size > 2) __Pyx_RaiseTooManyValuesError(2);
           else if (size >= 0) __Pyx_RaiseNeedMoreValuesError(size);
-          __PYX_ERR(0, 1912, __pyx_L1_error)
+          __PYX_ERR(0, 1914, __pyx_L1_error)
         }
         #if CYTHON_ASSUME_SAFE_MACROS && !CYTHON_AVOID_BORROWED_REFS
         if (likely(PyTuple_CheckExact(sequence))) {
@@ -25724,15 +25756,15 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         __Pyx_INCREF(__pyx_t_2);
         __Pyx_INCREF(__pyx_t_5);
         #else
-        __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1912, __pyx_L1_error)
+        __pyx_t_2 = PySequence_ITEM(sequence, 0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1914, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_2);
-        __pyx_t_5 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1912, __pyx_L1_error)
+        __pyx_t_5 = PySequence_ITEM(sequence, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1914, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
         #endif
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
       } else {
         Py_ssize_t index = -1;
-        __pyx_t_8 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1912, __pyx_L1_error)
+        __pyx_t_8 = PyObject_GetIter(__pyx_t_1); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1914, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_8);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __pyx_t_15 = Py_TYPE(__pyx_t_8)->tp_iternext;
@@ -25740,7 +25772,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         __Pyx_GOTREF(__pyx_t_2);
         index = 1; __pyx_t_5 = __pyx_t_15(__pyx_t_8); if (unlikely(!__pyx_t_5)) goto __pyx_L17_unpacking_failed;
         __Pyx_GOTREF(__pyx_t_5);
-        if (__Pyx_IternextUnpackEndCheck(__pyx_t_15(__pyx_t_8), 2) < 0) __PYX_ERR(0, 1912, __pyx_L1_error)
+        if (__Pyx_IternextUnpackEndCheck(__pyx_t_15(__pyx_t_8), 2) < 0) __PYX_ERR(0, 1914, __pyx_L1_error)
         __pyx_t_15 = NULL;
         __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
         goto __pyx_L18_unpacking_done;
@@ -25748,75 +25780,75 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
         __pyx_t_15 = NULL;
         if (__Pyx_IterFinish() == 0) __Pyx_RaiseNeedMoreValuesError(index);
-        __PYX_ERR(0, 1912, __pyx_L1_error)
+        __PYX_ERR(0, 1914, __pyx_L1_error)
         __pyx_L18_unpacking_done:;
       }
-      if (!(likely(((__pyx_t_2) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_2, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1912, __pyx_L1_error)
-      if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1912, __pyx_L1_error)
+      if (!(likely(((__pyx_t_2) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_2, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1914, __pyx_L1_error)
+      if (!(likely(((__pyx_t_5) == Py_None) || likely(__Pyx_TypeTest(__pyx_t_5, __pyx_ptype_5numpy_ndarray))))) __PYX_ERR(0, 1914, __pyx_L1_error)
       __Pyx_XDECREF_SET(__pyx_v_adjusted_summits, ((PyArrayObject *)__pyx_t_2));
       __pyx_t_2 = 0;
       __Pyx_XDECREF_SET(__pyx_v_passflags, ((PyArrayObject *)__pyx_t_5));
       __pyx_t_5 = 0;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1914
+      /* "MACS2/IO/CallPeakUnit.pyx":1916
  *                 (adjusted_summits, passflags) = wtd_find_summit(chrom, rt_plus, rt_minus, startpos, endpos, window_size, cutoff)
  *                 # those local maxima above cutoff will be defined as good summits
  *                 for i in range(len(adjusted_summits)):             # <<<<<<<<<<<<<<
  *                     adjusted_summit = adjusted_summits[i]
  *                     passflag = passflags[i]
  */
-      __Pyx_TraceLine(1914,0,__PYX_ERR(0, 1914, __pyx_L1_error))
-      __pyx_t_23 = PyObject_Length(((PyObject *)__pyx_v_adjusted_summits)); if (unlikely(__pyx_t_23 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1914, __pyx_L1_error)
+      __Pyx_TraceLine(1916,0,__PYX_ERR(0, 1916, __pyx_L1_error))
+      __pyx_t_23 = PyObject_Length(((PyObject *)__pyx_v_adjusted_summits)); if (unlikely(__pyx_t_23 == ((Py_ssize_t)-1))) __PYX_ERR(0, 1916, __pyx_L1_error)
       __pyx_t_24 = __pyx_t_23;
       for (__pyx_t_19 = 0; __pyx_t_19 < __pyx_t_24; __pyx_t_19+=1) {
         __pyx_v_i = __pyx_t_19;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1915
+        /* "MACS2/IO/CallPeakUnit.pyx":1917
  *                 # those local maxima above cutoff will be defined as good summits
  *                 for i in range(len(adjusted_summits)):
  *                     adjusted_summit = adjusted_summits[i]             # <<<<<<<<<<<<<<
  *                     passflag = passflags[i]
  *                     if passflag:
  */
-        __Pyx_TraceLine(1915,0,__PYX_ERR(0, 1915, __pyx_L1_error))
-        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_adjusted_summits), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1915, __pyx_L1_error)
+        __Pyx_TraceLine(1917,0,__PYX_ERR(0, 1917, __pyx_L1_error))
+        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_adjusted_summits), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1917, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_XDECREF_SET(__pyx_v_adjusted_summit, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1916
+        /* "MACS2/IO/CallPeakUnit.pyx":1918
  *                 for i in range(len(adjusted_summits)):
  *                     adjusted_summit = adjusted_summits[i]
  *                     passflag = passflags[i]             # <<<<<<<<<<<<<<
  *                     if passflag:
  *                         tmppeak = copy(thispeak)
  */
-        __Pyx_TraceLine(1916,0,__PYX_ERR(0, 1916, __pyx_L1_error))
-        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_passflags), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1916, __pyx_L1_error)
+        __Pyx_TraceLine(1918,0,__PYX_ERR(0, 1918, __pyx_L1_error))
+        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_passflags), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1918, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
         __Pyx_XDECREF_SET(__pyx_v_passflag, __pyx_t_1);
         __pyx_t_1 = 0;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1917
+        /* "MACS2/IO/CallPeakUnit.pyx":1919
  *                     adjusted_summit = adjusted_summits[i]
  *                     passflag = passflags[i]
  *                     if passflag:             # <<<<<<<<<<<<<<
  *                         tmppeak = copy(thispeak)
  *                         tmppeak["summit"] = adjusted_summit
  */
-        __Pyx_TraceLine(1917,0,__PYX_ERR(0, 1917, __pyx_L1_error))
-        __pyx_t_11 = __Pyx_PyObject_IsTrue(__pyx_v_passflag); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1917, __pyx_L1_error)
+        __Pyx_TraceLine(1919,0,__PYX_ERR(0, 1919, __pyx_L1_error))
+        __pyx_t_11 = __Pyx_PyObject_IsTrue(__pyx_v_passflag); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1919, __pyx_L1_error)
         if (__pyx_t_11) {
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1918
+          /* "MACS2/IO/CallPeakUnit.pyx":1920
  *                     passflag = passflags[i]
  *                     if passflag:
  *                         tmppeak = copy(thispeak)             # <<<<<<<<<<<<<<
  *                         tmppeak["summit"] = adjusted_summit
  *                         ret_peaks.add_PeakContent(chrom, tmppeak)
  */
-          __Pyx_TraceLine(1918,0,__PYX_ERR(0, 1918, __pyx_L1_error))
-          __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_copy); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1918, __pyx_L1_error)
+          __Pyx_TraceLine(1920,0,__PYX_ERR(0, 1920, __pyx_L1_error))
+          __Pyx_GetModuleGlobalName(__pyx_t_5, __pyx_n_s_copy); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1920, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_5);
           __pyx_t_2 = NULL;
           if (CYTHON_UNPACK_METHODS && unlikely(PyMethod_Check(__pyx_t_5))) {
@@ -25830,31 +25862,31 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
           }
           __pyx_t_1 = (__pyx_t_2) ? __Pyx_PyObject_Call2Args(__pyx_t_5, __pyx_t_2, __pyx_v_thispeak) : __Pyx_PyObject_CallOneArg(__pyx_t_5, __pyx_v_thispeak);
           __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
-          if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1918, __pyx_L1_error)
+          if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1920, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_1);
           __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
           __Pyx_XDECREF_SET(__pyx_v_tmppeak, __pyx_t_1);
           __pyx_t_1 = 0;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1919
+          /* "MACS2/IO/CallPeakUnit.pyx":1921
  *                     if passflag:
  *                         tmppeak = copy(thispeak)
  *                         tmppeak["summit"] = adjusted_summit             # <<<<<<<<<<<<<<
  *                         ret_peaks.add_PeakContent(chrom, tmppeak)
  * 
  */
-          __Pyx_TraceLine(1919,0,__PYX_ERR(0, 1919, __pyx_L1_error))
-          if (unlikely(PyObject_SetItem(__pyx_v_tmppeak, __pyx_n_u_summit, __pyx_v_adjusted_summit) < 0)) __PYX_ERR(0, 1919, __pyx_L1_error)
+          __Pyx_TraceLine(1921,0,__PYX_ERR(0, 1921, __pyx_L1_error))
+          if (unlikely(PyObject_SetItem(__pyx_v_tmppeak, __pyx_n_u_summit, __pyx_v_adjusted_summit) < 0)) __PYX_ERR(0, 1921, __pyx_L1_error)
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1920
+          /* "MACS2/IO/CallPeakUnit.pyx":1922
  *                         tmppeak = copy(thispeak)
  *                         tmppeak["summit"] = adjusted_summit
  *                         ret_peaks.add_PeakContent(chrom, tmppeak)             # <<<<<<<<<<<<<<
  * 
  *                 # rewind window_size
  */
-          __Pyx_TraceLine(1920,0,__PYX_ERR(0, 1920, __pyx_L1_error))
-          __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_ret_peaks, __pyx_n_s_add_PeakContent); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1920, __pyx_L1_error)
+          __Pyx_TraceLine(1922,0,__PYX_ERR(0, 1922, __pyx_L1_error))
+          __pyx_t_5 = __Pyx_PyObject_GetAttrStr(__pyx_v_ret_peaks, __pyx_n_s_add_PeakContent); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1922, __pyx_L1_error)
           __Pyx_GOTREF(__pyx_t_5);
           __pyx_t_2 = NULL;
           __pyx_t_7 = 0;
@@ -25871,7 +25903,7 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
           #if CYTHON_FAST_PYCALL
           if (PyFunction_Check(__pyx_t_5)) {
             PyObject *__pyx_temp[3] = {__pyx_t_2, __pyx_v_chrom, __pyx_v_tmppeak};
-            __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 2+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1920, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_PyFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 2+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1922, __pyx_L1_error)
             __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
             __Pyx_GOTREF(__pyx_t_1);
           } else
@@ -25879,13 +25911,13 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
           #if CYTHON_FAST_PYCCALL
           if (__Pyx_PyFastCFunction_Check(__pyx_t_5)) {
             PyObject *__pyx_temp[3] = {__pyx_t_2, __pyx_v_chrom, __pyx_v_tmppeak};
-            __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 2+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1920, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_PyCFunction_FastCall(__pyx_t_5, __pyx_temp+1-__pyx_t_7, 2+__pyx_t_7); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1922, __pyx_L1_error)
             __Pyx_XDECREF(__pyx_t_2); __pyx_t_2 = 0;
             __Pyx_GOTREF(__pyx_t_1);
           } else
           #endif
           {
-            __pyx_t_8 = PyTuple_New(2+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1920, __pyx_L1_error)
+            __pyx_t_8 = PyTuple_New(2+__pyx_t_7); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1922, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_8);
             if (__pyx_t_2) {
               __Pyx_GIVEREF(__pyx_t_2); PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_2); __pyx_t_2 = NULL;
@@ -25896,14 +25928,14 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
             __Pyx_INCREF(__pyx_v_tmppeak);
             __Pyx_GIVEREF(__pyx_v_tmppeak);
             PyTuple_SET_ITEM(__pyx_t_8, 1+__pyx_t_7, __pyx_v_tmppeak);
-            __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1920, __pyx_L1_error)
+            __pyx_t_1 = __Pyx_PyObject_Call(__pyx_t_5, __pyx_t_8, NULL); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1922, __pyx_L1_error)
             __Pyx_GOTREF(__pyx_t_1);
             __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
           }
           __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
           __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1917
+          /* "MACS2/IO/CallPeakUnit.pyx":1919
  *                     adjusted_summit = adjusted_summits[i]
  *                     passflag = passflags[i]
  *                     if passflag:             # <<<<<<<<<<<<<<
@@ -25913,53 +25945,53 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
         }
       }
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1923
+      /* "MACS2/IO/CallPeakUnit.pyx":1925
  * 
  *                 # rewind window_size
  *                 for i in range(prev_i, 0, -1):             # <<<<<<<<<<<<<<
  *                     if plus[prev_i] - plus[i] >= window_size:
  *                         break
  */
-      __Pyx_TraceLine(1923,0,__PYX_ERR(0, 1923, __pyx_L1_error))
+      __Pyx_TraceLine(1925,0,__PYX_ERR(0, 1925, __pyx_L1_error))
       for (__pyx_t_19 = __pyx_v_prev_i; __pyx_t_19 > 0; __pyx_t_19-=1) {
         __pyx_v_i = __pyx_t_19;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1924
+        /* "MACS2/IO/CallPeakUnit.pyx":1926
  *                 # rewind window_size
  *                 for i in range(prev_i, 0, -1):
  *                     if plus[prev_i] - plus[i] >= window_size:             # <<<<<<<<<<<<<<
  *                         break
  *                 prev_i = i
  */
-        __Pyx_TraceLine(1924,0,__PYX_ERR(0, 1924, __pyx_L1_error))
-        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_plus), __pyx_v_prev_i, long, 1, __Pyx_PyInt_From_long, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1924, __pyx_L1_error)
+        __Pyx_TraceLine(1926,0,__PYX_ERR(0, 1926, __pyx_L1_error))
+        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_plus), __pyx_v_prev_i, long, 1, __Pyx_PyInt_From_long, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1926, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_plus), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1924, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_plus), __pyx_v_i, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1926, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
-        __pyx_t_8 = PyNumber_Subtract(__pyx_t_1, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1924, __pyx_L1_error)
+        __pyx_t_8 = PyNumber_Subtract(__pyx_t_1, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1926, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_8);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-        __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1924, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1926, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_8, __pyx_t_5, Py_GE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1924, __pyx_L1_error)
+        __pyx_t_1 = PyObject_RichCompare(__pyx_t_8, __pyx_t_5, Py_GE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1926, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-        __pyx_t_11 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1924, __pyx_L1_error)
+        __pyx_t_11 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1926, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         if (__pyx_t_11) {
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1925
+          /* "MACS2/IO/CallPeakUnit.pyx":1927
  *                 for i in range(prev_i, 0, -1):
  *                     if plus[prev_i] - plus[i] >= window_size:
  *                         break             # <<<<<<<<<<<<<<
  *                 prev_i = i
  * 
  */
-          __Pyx_TraceLine(1925,0,__PYX_ERR(0, 1925, __pyx_L1_error))
+          __Pyx_TraceLine(1927,0,__PYX_ERR(0, 1927, __pyx_L1_error))
           goto __pyx_L23_break;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1924
+          /* "MACS2/IO/CallPeakUnit.pyx":1926
  *                 # rewind window_size
  *                 for i in range(prev_i, 0, -1):
  *                     if plus[prev_i] - plus[i] >= window_size:             # <<<<<<<<<<<<<<
@@ -25970,63 +26002,63 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       }
       __pyx_L23_break:;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1926
+      /* "MACS2/IO/CallPeakUnit.pyx":1928
  *                     if plus[prev_i] - plus[i] >= window_size:
  *                         break
  *                 prev_i = i             # <<<<<<<<<<<<<<
  * 
  *                 for j in range(prev_j, 0, -1):
  */
-      __Pyx_TraceLine(1926,0,__PYX_ERR(0, 1926, __pyx_L1_error))
+      __Pyx_TraceLine(1928,0,__PYX_ERR(0, 1928, __pyx_L1_error))
       __pyx_v_prev_i = __pyx_v_i;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1928
+      /* "MACS2/IO/CallPeakUnit.pyx":1930
  *                 prev_i = i
  * 
  *                 for j in range(prev_j, 0, -1):             # <<<<<<<<<<<<<<
  *                     if minus[prev_j] - minus[j] >= window_size:
  *                         break
  */
-      __Pyx_TraceLine(1928,0,__PYX_ERR(0, 1928, __pyx_L1_error))
+      __Pyx_TraceLine(1930,0,__PYX_ERR(0, 1930, __pyx_L1_error))
       for (__pyx_t_19 = __pyx_v_prev_j; __pyx_t_19 > 0; __pyx_t_19-=1) {
         __pyx_v_j = __pyx_t_19;
 
-        /* "MACS2/IO/CallPeakUnit.pyx":1929
+        /* "MACS2/IO/CallPeakUnit.pyx":1931
  * 
  *                 for j in range(prev_j, 0, -1):
  *                     if minus[prev_j] - minus[j] >= window_size:             # <<<<<<<<<<<<<<
  *                         break
  *                 prev_j = j
  */
-        __Pyx_TraceLine(1929,0,__PYX_ERR(0, 1929, __pyx_L1_error))
-        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_minus), __pyx_v_prev_j, long, 1, __Pyx_PyInt_From_long, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1929, __pyx_L1_error)
+        __Pyx_TraceLine(1931,0,__PYX_ERR(0, 1931, __pyx_L1_error))
+        __pyx_t_1 = __Pyx_GetItemInt(((PyObject *)__pyx_v_minus), __pyx_v_prev_j, long, 1, __Pyx_PyInt_From_long, 0, 1, 1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1931, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_1);
-        __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_minus), __pyx_v_j, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1929, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_GetItemInt(((PyObject *)__pyx_v_minus), __pyx_v_j, __pyx_t_5numpy_int32_t, 1, __Pyx_PyInt_From_npy_int32, 0, 1, 1); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1931, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
-        __pyx_t_8 = PyNumber_Subtract(__pyx_t_1, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1929, __pyx_L1_error)
+        __pyx_t_8 = PyNumber_Subtract(__pyx_t_1, __pyx_t_5); if (unlikely(!__pyx_t_8)) __PYX_ERR(0, 1931, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_8);
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-        __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1929, __pyx_L1_error)
+        __pyx_t_5 = __Pyx_PyInt_From_npy_int32(__pyx_v_window_size); if (unlikely(!__pyx_t_5)) __PYX_ERR(0, 1931, __pyx_L1_error)
         __Pyx_GOTREF(__pyx_t_5);
-        __pyx_t_1 = PyObject_RichCompare(__pyx_t_8, __pyx_t_5, Py_GE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1929, __pyx_L1_error)
+        __pyx_t_1 = PyObject_RichCompare(__pyx_t_8, __pyx_t_5, Py_GE); __Pyx_XGOTREF(__pyx_t_1); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1931, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
         __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
-        __pyx_t_11 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1929, __pyx_L1_error)
+        __pyx_t_11 = __Pyx_PyObject_IsTrue(__pyx_t_1); if (unlikely(__pyx_t_11 < 0)) __PYX_ERR(0, 1931, __pyx_L1_error)
         __Pyx_DECREF(__pyx_t_1); __pyx_t_1 = 0;
         if (__pyx_t_11) {
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1930
+          /* "MACS2/IO/CallPeakUnit.pyx":1932
  *                 for j in range(prev_j, 0, -1):
  *                     if minus[prev_j] - minus[j] >= window_size:
  *                         break             # <<<<<<<<<<<<<<
  *                 prev_j = j
  *                 # end of a loop
  */
-          __Pyx_TraceLine(1930,0,__PYX_ERR(0, 1930, __pyx_L1_error))
+          __Pyx_TraceLine(1932,0,__PYX_ERR(0, 1932, __pyx_L1_error))
           goto __pyx_L26_break;
 
-          /* "MACS2/IO/CallPeakUnit.pyx":1929
+          /* "MACS2/IO/CallPeakUnit.pyx":1931
  * 
  *                 for j in range(prev_j, 0, -1):
  *                     if minus[prev_j] - minus[j] >= window_size:             # <<<<<<<<<<<<<<
@@ -26037,31 +26069,31 @@ static PyObject *__pyx_f_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine
       }
       __pyx_L26_break:;
 
-      /* "MACS2/IO/CallPeakUnit.pyx":1931
+      /* "MACS2/IO/CallPeakUnit.pyx":1933
  *                     if minus[prev_j] - minus[j] >= window_size:
  *                         break
  *                 prev_j = j             # <<<<<<<<<<<<<<
  *                 # end of a loop
  *         return ret_peaks
  */
-      __Pyx_TraceLine(1931,0,__PYX_ERR(0, 1931, __pyx_L1_error))
+      __Pyx_TraceLine(1933,0,__PYX_ERR(0, 1933, __pyx_L1_error))
       __pyx_v_prev_j = __pyx_v_j;
     }
   }
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1933
+  /* "MACS2/IO/CallPeakUnit.pyx":1935
  *                 prev_j = j
  *                 # end of a loop
  *         return ret_peaks             # <<<<<<<<<<<<<<
  * 
  */
-  __Pyx_TraceLine(1933,0,__PYX_ERR(0, 1933, __pyx_L1_error))
+  __Pyx_TraceLine(1935,0,__PYX_ERR(0, 1935, __pyx_L1_error))
   __Pyx_XDECREF(__pyx_r);
   __Pyx_INCREF(__pyx_v_ret_peaks);
   __pyx_r = __pyx_v_ret_peaks;
   goto __pyx_L0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1838
+  /* "MACS2/IO/CallPeakUnit.pyx":1840
  *         return bpeaks
  * 
  *     cpdef refine_peak_from_tags_distribution ( self, peaks, int32_t window_size = 100, float32_t cutoff = 5 ):             # <<<<<<<<<<<<<<
@@ -26149,7 +26181,7 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_13ref
         }
       }
       if (unlikely(kw_args > 0)) {
-        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "refine_peak_from_tags_distribution") < 0)) __PYX_ERR(0, 1838, __pyx_L3_error)
+        if (unlikely(__Pyx_ParseOptionalKeywords(__pyx_kwds, __pyx_pyargnames, 0, values, pos_args, "refine_peak_from_tags_distribution") < 0)) __PYX_ERR(0, 1840, __pyx_L3_error)
       }
     } else {
       switch (PyTuple_GET_SIZE(__pyx_args)) {
@@ -26164,19 +26196,19 @@ static PyObject *__pyx_pw_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_13ref
     }
     __pyx_v_peaks = values[0];
     if (values[1]) {
-      __pyx_v_window_size = __Pyx_PyInt_As_npy_int32(values[1]); if (unlikely((__pyx_v_window_size == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1838, __pyx_L3_error)
+      __pyx_v_window_size = __Pyx_PyInt_As_npy_int32(values[1]); if (unlikely((__pyx_v_window_size == ((npy_int32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1840, __pyx_L3_error)
     } else {
       __pyx_v_window_size = ((__pyx_t_5numpy_int32_t)0x64);
     }
     if (values[2]) {
-      __pyx_v_cutoff = __pyx_PyFloat_AsFloat(values[2]); if (unlikely((__pyx_v_cutoff == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1838, __pyx_L3_error)
+      __pyx_v_cutoff = __pyx_PyFloat_AsFloat(values[2]); if (unlikely((__pyx_v_cutoff == ((npy_float32)-1)) && PyErr_Occurred())) __PYX_ERR(0, 1840, __pyx_L3_error)
     } else {
       __pyx_v_cutoff = ((__pyx_t_5numpy_float32_t)5.0);
     }
   }
   goto __pyx_L4_argument_unpacking_done;
   __pyx_L5_argtuple_error:;
-  __Pyx_RaiseArgtupleInvalid("refine_peak_from_tags_distribution", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 1838, __pyx_L3_error)
+  __Pyx_RaiseArgtupleInvalid("refine_peak_from_tags_distribution", 0, 1, 3, PyTuple_GET_SIZE(__pyx_args)); __PYX_ERR(0, 1840, __pyx_L3_error)
   __pyx_L3_error:;
   __Pyx_AddTraceback("MACS2.IO.CallPeakUnit.CallerFromAlignments.refine_peak_from_tags_distribution", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __Pyx_RefNannyFinishContext();
@@ -26196,12 +26228,12 @@ static PyObject *__pyx_pf_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_12ref
   PyObject *__pyx_t_1 = NULL;
   struct __pyx_opt_args_5MACS2_2IO_12CallPeakUnit_20CallerFromAlignments_refine_peak_from_tags_distribution __pyx_t_2;
   __Pyx_RefNannySetupContext("refine_peak_from_tags_distribution", 0);
-  __Pyx_TraceCall("refine_peak_from_tags_distribution (wrapper)", __pyx_f[0], 1838, 0, __PYX_ERR(0, 1838, __pyx_L1_error));
+  __Pyx_TraceCall("refine_peak_from_tags_distribution (wrapper)", __pyx_f[0], 1840, 0, __PYX_ERR(0, 1840, __pyx_L1_error));
   __Pyx_XDECREF(__pyx_r);
   __pyx_t_2.__pyx_n = 2;
   __pyx_t_2.window_size = __pyx_v_window_size;
   __pyx_t_2.cutoff = __pyx_v_cutoff;
-  __pyx_t_1 = __pyx_vtabptr_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments->refine_peak_from_tags_distribution(__pyx_v_self, __pyx_v_peaks, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1838, __pyx_L1_error)
+  __pyx_t_1 = __pyx_vtabptr_5MACS2_2IO_12CallPeakUnit_CallerFromAlignments->refine_peak_from_tags_distribution(__pyx_v_self, __pyx_v_peaks, 1, &__pyx_t_2); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 1840, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_1);
   __pyx_r = __pyx_t_1;
   __pyx_t_1 = 0;
@@ -29467,7 +29499,7 @@ static CYTHON_SMALL_CODE int __Pyx_InitCachedBuiltins(void) {
   __pyx_builtin_open = __Pyx_GetBuiltinName(__pyx_n_s_open); if (!__pyx_builtin_open) __PYX_ERR(0, 491, __pyx_L1_error)
   __pyx_builtin_sorted = __Pyx_GetBuiltinName(__pyx_n_s_sorted); if (!__pyx_builtin_sorted) __PYX_ERR(0, 719, __pyx_L1_error)
   __pyx_builtin_round = __Pyx_GetBuiltinName(__pyx_n_s_round); if (!__pyx_builtin_round) __PYX_ERR(0, 769, __pyx_L1_error)
-  __pyx_builtin_StopIteration = __Pyx_GetBuiltinName(__pyx_n_s_StopIteration); if (!__pyx_builtin_StopIteration) __PYX_ERR(0, 1554, __pyx_L1_error)
+  __pyx_builtin_StopIteration = __Pyx_GetBuiltinName(__pyx_n_s_StopIteration); if (!__pyx_builtin_StopIteration) __PYX_ERR(0, 1556, __pyx_L1_error)
   __pyx_builtin_TypeError = __Pyx_GetBuiltinName(__pyx_n_s_TypeError); if (!__pyx_builtin_TypeError) __PYX_ERR(1, 2, __pyx_L1_error)
   __pyx_builtin_ValueError = __Pyx_GetBuiltinName(__pyx_n_s_ValueError); if (!__pyx_builtin_ValueError) __PYX_ERR(2, 272, __pyx_L1_error)
   __pyx_builtin_RuntimeError = __Pyx_GetBuiltinName(__pyx_n_s_RuntimeError); if (!__pyx_builtin_RuntimeError) __PYX_ERR(2, 856, __pyx_L1_error)
@@ -30722,206 +30754,206 @@ if (!__Pyx_RefNanny) {
   __Pyx_TraceLine(736,0,__PYX_ERR(0, 736, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":896
+  /* "MACS2/IO/CallPeakUnit.pyx":898
  *         return
  * 
  *     cpdef call_peaks ( self, list scoring_function_symbols, list score_cutoff_s, int32_t min_length = 200,             # <<<<<<<<<<<<<<
  *                        int32_t max_gap = 50, bool call_summits = False, bool cutoff_analysis = False ):
  *         """Call peaks for all chromosomes. Return a PeakIO object.
  */
-  __Pyx_TraceLine(896,0,__PYX_ERR(0, 896, __pyx_L1_error))
+  __Pyx_TraceLine(898,0,__PYX_ERR(0, 898, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":962
+  /* "MACS2/IO/CallPeakUnit.pyx":964
  *         return peaks
  * 
  *     cdef void __chrom_call_peak_using_certain_criteria ( self, peaks, bytes chrom, list scoring_function_s, list score_cutoff_s, int32_t min_length,             # <<<<<<<<<<<<<<
  *                                                    int32_t max_gap, bool call_summits, bool save_bedGraph ):
  *         """ Call peaks for a chromosome.
  */
-  __Pyx_TraceLine(962,0,__PYX_ERR(0, 962, __pyx_L1_error))
+  __Pyx_TraceLine(964,0,__PYX_ERR(0, 964, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1100
+  /* "MACS2/IO/CallPeakUnit.pyx":1102
  *         return
  * 
  *     cdef bool __close_peak_wo_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
  *                                           bytes chrom, int32_t smoothlen, list score_array_s, list score_cutoff_s=[]):
  *         """Close the peak region, output peak boundaries, peak summit
  */
-  __Pyx_TraceLine(1100,0,__PYX_ERR(0, 1100, __pyx_L1_error))
+  __Pyx_TraceLine(1102,0,__PYX_ERR(0, 1102, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1101
+  /* "MACS2/IO/CallPeakUnit.pyx":1103
  * 
  *     cdef bool __close_peak_wo_subpeaks (self, list peak_content, peaks, int32_t min_length,
  *                                           bytes chrom, int32_t smoothlen, list score_array_s, list score_cutoff_s=[]):             # <<<<<<<<<<<<<<
  *         """Close the peak region, output peak boundaries, peak summit
  *         and scores, then add the peak to peakIO object.
  */
-  __Pyx_TraceLine(1101,0,__PYX_ERR(0, 1101, __pyx_L1_error))
-  __pyx_t_2 = PyList_New(0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1101, __pyx_L1_error)
+  __Pyx_TraceLine(1103,0,__PYX_ERR(0, 1103, __pyx_L1_error))
+  __pyx_t_2 = PyList_New(0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1103, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_k__11 = ((PyObject*)__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1161
+  /* "MACS2/IO/CallPeakUnit.pyx":1163
  *             return True
  * 
  *     cdef bool __close_peak_with_subpeaks (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
  *                                          bytes chrom, int32_t smoothlen, list score_array_s, list score_cutoff_s=[],
  *                                          float32_t min_valley = 0.9 ):
  */
-  __Pyx_TraceLine(1161,0,__PYX_ERR(0, 1161, __pyx_L1_error))
+  __Pyx_TraceLine(1163,0,__PYX_ERR(0, 1163, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1162
+  /* "MACS2/IO/CallPeakUnit.pyx":1164
  * 
  *     cdef bool __close_peak_with_subpeaks (self, list peak_content, peaks, int32_t min_length,
  *                                          bytes chrom, int32_t smoothlen, list score_array_s, list score_cutoff_s=[],             # <<<<<<<<<<<<<<
  *                                          float32_t min_valley = 0.9 ):
  *         """Algorithm implemented by Ben, to profile the pileup signals
  */
-  __Pyx_TraceLine(1162,0,__PYX_ERR(0, 1162, __pyx_L1_error))
-  __pyx_t_2 = PyList_New(0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1162, __pyx_L1_error)
+  __Pyx_TraceLine(1164,0,__PYX_ERR(0, 1164, __pyx_L1_error))
+  __pyx_t_2 = PyList_New(0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1164, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_k__12 = ((PyObject*)__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1248
+  /* "MACS2/IO/CallPeakUnit.pyx":1250
  *         return True
  * 
  *     cdef np.ndarray __cal_pscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
  *         cdef:
  *             int64_t i, array1_size
  */
-  __Pyx_TraceLine(1248,0,__PYX_ERR(0, 1248, __pyx_L1_error))
+  __Pyx_TraceLine(1250,0,__PYX_ERR(0, 1250, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1273
+  /* "MACS2/IO/CallPeakUnit.pyx":1275
  *         return s
  * 
  *     cdef np.ndarray __cal_qscore ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
  *         cdef:
  *             int64_t i, array1_size
  */
-  __Pyx_TraceLine(1273,0,__PYX_ERR(0, 1273, __pyx_L1_error))
+  __Pyx_TraceLine(1275,0,__PYX_ERR(0, 1275, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1296
+  /* "MACS2/IO/CallPeakUnit.pyx":1298
  *         return s
  * 
  *     cdef np.ndarray __cal_logLR ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
  *         cdef:
  *             int64_t i, array1_size
  */
-  __Pyx_TraceLine(1296,0,__PYX_ERR(0, 1296, __pyx_L1_error))
+  __Pyx_TraceLine(1298,0,__PYX_ERR(0, 1298, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1318
+  /* "MACS2/IO/CallPeakUnit.pyx":1320
  *         return s
  * 
  *     cdef np.ndarray __cal_logFE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
  *         cdef:
  *             int64_t i, array1_size
  */
-  __Pyx_TraceLine(1318,0,__PYX_ERR(0, 1318, __pyx_L1_error))
+  __Pyx_TraceLine(1320,0,__PYX_ERR(0, 1320, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1340
+  /* "MACS2/IO/CallPeakUnit.pyx":1342
  *         return s
  * 
  *     cdef np.ndarray __cal_FE ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
  *         cdef:
  *             int64_t i, array1_size
  */
-  __Pyx_TraceLine(1340,0,__PYX_ERR(0, 1340, __pyx_L1_error))
+  __Pyx_TraceLine(1342,0,__PYX_ERR(0, 1342, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1362
+  /* "MACS2/IO/CallPeakUnit.pyx":1364
  *         return s
  * 
  *     cdef np.ndarray __cal_subtraction ( self, np.ndarray[np.float32_t, ndim=1] array1, np.ndarray[np.float32_t, ndim=1] array2 ):             # <<<<<<<<<<<<<<
  *         cdef:
  *             int64_t i, array1_size
  */
-  __Pyx_TraceLine(1362,0,__PYX_ERR(0, 1362, __pyx_L1_error))
+  __Pyx_TraceLine(1364,0,__PYX_ERR(0, 1364, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1385
+  /* "MACS2/IO/CallPeakUnit.pyx":1387
  * 
  * 
  *     cdef bool __write_bedGraph_for_a_chromosome ( self, bytes chrom ):             # <<<<<<<<<<<<<<
  *         """Write treat/control values for a certain chromosome into a
  *         specified file handler.
  */
-  __Pyx_TraceLine(1385,0,__PYX_ERR(0, 1385, __pyx_L1_error))
+  __Pyx_TraceLine(1387,0,__PYX_ERR(0, 1387, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1461
+  /* "MACS2/IO/CallPeakUnit.pyx":1463
  *         return True
  * 
  *     cpdef call_broadpeaks (self, list scoring_function_symbols, list lvl1_cutoff_s, list lvl2_cutoff_s, int32_t min_length=200, int32_t lvl1_max_gap=50, int32_t lvl2_max_gap=400, bool cutoff_analysis = False):             # <<<<<<<<<<<<<<
  *         """This function try to find enriched regions within which,
  *         scores are continuously higher than a given cutoff for level
  */
-  __Pyx_TraceLine(1461,0,__PYX_ERR(0, 1461, __pyx_L1_error))
+  __Pyx_TraceLine(1463,0,__PYX_ERR(0, 1463, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1564
+  /* "MACS2/IO/CallPeakUnit.pyx":1566
  *         return broadpeaks
  * 
  *     cdef void  __chrom_call_broadpeak_using_certain_criteria ( self, lvl1peaks, lvl2peaks, bytes chrom, list scoring_function_s, list lvl1_cutoff_s, list lvl2_cutoff_s,             # <<<<<<<<<<<<<<
  *                                                          int32_t min_length, int32_t lvl1_max_gap, int32_t lvl2_max_gap, bool save_bedGraph):
  *         """ Call peaks for a chromosome.
  */
-  __Pyx_TraceLine(1564,0,__PYX_ERR(0, 1564, __pyx_L1_error))
+  __Pyx_TraceLine(1566,0,__PYX_ERR(0, 1566, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1740
+  /* "MACS2/IO/CallPeakUnit.pyx":1742
  *         return
  * 
  *     cdef bool __close_peak_for_broad_region (self, list peak_content, peaks, int32_t min_length,             # <<<<<<<<<<<<<<
  *                                              bytes chrom, int32_t smoothlen, list score_array_s, list score_cutoff_s=[]):
  *         """Close the broad peak region, output peak boundaries, peak summit
  */
-  __Pyx_TraceLine(1740,0,__PYX_ERR(0, 1740, __pyx_L1_error))
+  __Pyx_TraceLine(1742,0,__PYX_ERR(0, 1742, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1741
+  /* "MACS2/IO/CallPeakUnit.pyx":1743
  * 
  *     cdef bool __close_peak_for_broad_region (self, list peak_content, peaks, int32_t min_length,
  *                                              bytes chrom, int32_t smoothlen, list score_array_s, list score_cutoff_s=[]):             # <<<<<<<<<<<<<<
  *         """Close the broad peak region, output peak boundaries, peak summit
  *         and scores, then add the peak to peakIO object.
  */
-  __Pyx_TraceLine(1741,0,__PYX_ERR(0, 1741, __pyx_L1_error))
-  __pyx_t_2 = PyList_New(0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1741, __pyx_L1_error)
+  __Pyx_TraceLine(1743,0,__PYX_ERR(0, 1743, __pyx_L1_error))
+  __pyx_t_2 = PyList_New(0); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 1743, __pyx_L1_error)
   __Pyx_GOTREF(__pyx_t_2);
   __pyx_k__23 = ((PyObject*)__pyx_t_2);
   __Pyx_GIVEREF(__pyx_t_2);
   __pyx_t_2 = 0;
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1790
+  /* "MACS2/IO/CallPeakUnit.pyx":1792
  *             return True
  * 
  *     cdef __add_broadpeak (self, bpeaks, bytes chrom, object lvl2peak, list lvl1peakset):             # <<<<<<<<<<<<<<
  *         """Internal function to create broad peak.
  * 
  */
-  __Pyx_TraceLine(1790,0,__PYX_ERR(0, 1790, __pyx_L1_error))
+  __Pyx_TraceLine(1792,0,__PYX_ERR(0, 1792, __pyx_L1_error))
 
 
-  /* "MACS2/IO/CallPeakUnit.pyx":1838
+  /* "MACS2/IO/CallPeakUnit.pyx":1840
  *         return bpeaks
  * 
  *     cpdef refine_peak_from_tags_distribution ( self, peaks, int32_t window_size = 100, float32_t cutoff = 5 ):             # <<<<<<<<<<<<<<
  *         """Extract tags in peak, then apply func on extracted tags.
  * 
  */
-  __Pyx_TraceLine(1838,0,__PYX_ERR(0, 1838, __pyx_L1_error))
+  __Pyx_TraceLine(1840,0,__PYX_ERR(0, 1840, __pyx_L1_error))
 
 
   /* "MACS2/IO/CallPeakUnit.pyx":1

--- a/MACS2/IO/CallPeakUnit.pyx
+++ b/MACS2/IO/CallPeakUnit.pyx
@@ -875,14 +875,16 @@ cdef class CallerFromAlignments:
         logging.debug( "access pq hash for %d times" % nhcal )
 
         # write pvalue and total length of predicted peaks
+        # this is the output from cutoff-analysis
         fhd = open( self.cutoff_analysis_filename, "w" )
         fhd.write( "pscore\tqscore\tnpeaks\tlpeaks\tavelpeak\n" )
         x = []
         y = []
         for cutoff in tmplist:
-            fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
-            x.append( cutoff )
-            y.append( self.pvalue_length[ cutoff ] )
+            if self.pvalue_npeaks[ cutoff ] > 0:
+                fhd.write( "%.2f\t%.2f\t%d\t%d\t%.2f\n" % ( cutoff, self.pqtable[ cutoff ], self.pvalue_npeaks[ cutoff ], self.pvalue_length[ cutoff ], self.pvalue_length[ cutoff ]/self.pvalue_npeaks[ cutoff ] ) )
+                x.append( cutoff )
+                y.append( self.pvalue_length[ cutoff ] )
         fhd.close()
         logging.info( "#3 Analysis of cutoff vs num of peaks or total length has been saved in %s" % self.cutoff_analysis_filename )
         #logging.info( "#3 Suggest a cutoff..." )


### PR DESCRIPTION
…all, to skip cutoff without peaks

Basically, check 'npeak' first.